### PR TITLE
Enable verbose error message for credential issues

### DIFF
--- a/internal/pkg/aws/session/session.go
+++ b/internal/pkg/aws/session/session.go
@@ -15,6 +15,9 @@ import (
 // Default returns a session configured against the "default" AWS profile.
 func Default() (*session.Session, error) {
 	return session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			CredentialsChainVerboseErrors: aws.Bool(true),
+		},
 		SharedConfigState: session.SharedConfigEnable,
 	})
 }
@@ -22,6 +25,9 @@ func Default() (*session.Session, error) {
 // FromProfile returns a session configured against the input profile name.
 func FromProfile(name string) (*session.Session, error) {
 	return session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{
+			CredentialsChainVerboseErrors: aws.Bool(true),
+		},
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           name,
 	})
@@ -37,7 +43,8 @@ func FromRole(roleARN string, region string) (*session.Session, error) {
 
 	creds := stscreds.NewCredentials(defaultSession, roleARN)
 	return session.NewSession(&aws.Config{
-		Credentials: creds,
-		Region:      &region,
+		CredentialsChainVerboseErrors: aws.Bool(true),
+		Credentials:                   creds,
+		Region:                        &region,
 	})
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Before the change:
```
$ env -i AWS_DEFAULT_REGION=us-west-1 ./bin/local/archer project ls
Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

After the change:
```
env -i AWS_DEFAULT_REGION=us-west-1 ./bin/local/archer project ls
Error: NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
SharedCredsLoad: failed to load profile, .
EC2RoleRequestError: no EC2 instance role found
caused by: RequestError: send request failed
caused by: Get http://169.254.169.254/latest/meta-data/iam/security-credentials/: dial tcp 169.254.169.254:80: connect: host is down
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #163.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
