### PR TITLE
Add ECR to Env CloudFormation Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,11 @@ ${COVERAGE}: test
 integ-test: packr-build run-integ-test packr-clean
 
 run-integ-test:
-	go test -v -run Integration -tags integration ${PACKAGES}
+	# These tests have a long timeout as they create and teardown CloudFormation stacks.
+	# Also adding count=1 so the test results aren't cached.
+	# This command also targets files with the build integration tag
+	# and runs tests which end in Integration.
+	go test -v -count=1 -timeout 15m -run Integration -tags integration ${PACKAGES}
 
 .PHONY: e2e-test
 e2e-test: build

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -23,6 +23,8 @@ import (
 const (
 	environmentTemplate         = "environment/cf.yml"
 	includeLoadBalancerParamKey = "IncludePublicLoadBalancer"
+	projectNameParamKey         = "ProjectName"
+	environmentNameParamKey     = "EnvironmentName"
 )
 
 // CloudFormation wraps the CloudFormationAPI interface
@@ -55,6 +57,14 @@ func (cf CloudFormation) DeployEnvironment(env *archer.Environment) error {
 		{
 			ParameterKey:   aws.String(includeLoadBalancerParamKey),
 			ParameterValue: aws.String(strconv.FormatBool(env.PublicLoadBalancer)),
+		},
+		{
+			ParameterKey:   aws.String(projectNameParamKey),
+			ParameterValue: aws.String(env.Project),
+		},
+		{
+			ParameterKey:   aws.String(environmentNameParamKey),
+			ParameterValue: aws.String(env.Name),
 		},
 	}))
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -1,0 +1,176 @@
+// +build integration
+
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation_test
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	awsCF "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// This test can take quite long as it spins up a CloudFormation stack
+// and then waits for it to be deleted. If you find your CF stack
+// is failing to be spun up because you've reached some limits, try
+// switching your default region by running aws configure.
+func Test_Environment_Deployment_Integration(t *testing.T) {
+	sess, err := testSession()
+	require.NoError(t, err)
+	deployer := cloudformation.New(sess)
+	cfClient := awsCF.New(sess)
+
+	environmentToDeploy := archer.Environment{Name: randStringBytes(10), Project: randStringBytes(10), PublicLoadBalancer: true}
+	envStackName := fmt.Sprintf("%s-%s", environmentToDeploy.Project, environmentToDeploy.Name)
+
+	t.Run("Deploys an Environment to CloudFormation", func(t *testing.T) {
+		// Given our stack doesn't exist
+		output, err := cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: aws.String(envStackName),
+		})
+		require.True(t, len(output.Stacks) == 0, "Stack %s should not exist.", envStackName)
+
+		// Make sure we delete the stack after the test is done
+		defer func() {
+			cfClient.DeleteStack(&awsCF.DeleteStackInput{
+				StackName: aws.String(envStackName),
+			})
+			cfClient.WaitUntilStackDeleteComplete(&awsCF.DescribeStacksInput{
+				StackName: aws.String(envStackName),
+			})
+		}()
+
+		// Deploy the environment and wait for it to be complete
+		require.NoError(t, deployer.DeployEnvironment(&environmentToDeploy))
+		require.NoError(t, deployer.WaitForEnvironmentCreation(&environmentToDeploy))
+
+		// Ensure that the new stack exists
+		output, err = cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: aws.String(envStackName),
+		})
+		require.NoError(t, err)
+		require.True(t, len(output.Stacks) == 1, "Stack %s should have been deployed.", envStackName)
+
+		deployedStack := output.Stacks[0]
+		expectedResultsForKey := map[string]func(*awsCF.Output){
+			"ECRRepositoryArn": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-ECRArn", envStackName),
+					*output.ExportName,
+					"Should export ECR Arn as stackname-Arn")
+
+				require.True(t,
+					strings.HasSuffix(*output.OutputValue,
+						fmt.Sprintf("repository/%s/%s", environmentToDeploy.Project, environmentToDeploy.Name)),
+					"ECR Repo Should be named repository/project_name/env_name")
+			},
+			"ClusterId": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-ClusterId", envStackName),
+					*output.ExportName,
+					"Should export Cluster as stackname-ClusterId")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"Cluster value should not be nil")
+			},
+			"PrivateSubnets": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-PrivateSubnets", envStackName),
+					*output.ExportName,
+					"Should PrivateSubnets as stackname-PrivateSubnets")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"Private Subnet values should not be nil")
+			},
+			"VpcId": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-VpcId", envStackName),
+					*output.ExportName,
+					"Should export VpcId as stackname-VpcId")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"VpcId value should not be nil")
+			},
+			"PublicLoadBalancerSecurityGroupId": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-PublicLoadBalancerSecurityGroupId", envStackName),
+					*output.ExportName,
+					"Should export PublicLoadBalancerSecurityGroupId as stackname-PublicLoadBalancerSecurityGroupId")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"PublicLoadBalancerSecurityGroupId value should not be nil")
+			},
+			"PublicSubnets": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-PublicSubnets", envStackName),
+					*output.ExportName,
+					"Should export PublicSubnets as stackname-PublicSubnets")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"PublicSubnets value should not be nil")
+			},
+			"PublicLoadBalancerArn": func(output *awsCF.Output) {
+				require.Equal(t,
+					fmt.Sprintf("%s-PublicLoadBalancerArn", envStackName),
+					*output.ExportName,
+					"Should export PublicLoadBalancerArn as stackname-PublicLoadBalancerArn")
+
+				require.NotNil(t,
+					output.OutputValue,
+					"PublicLoadBalancerArn value should not be nil")
+			},
+			"PublicLoadBalancerDNSName": func(output *awsCF.Output) {
+				require.NotNil(t,
+					output.OutputValue,
+					"PublicLoadBalancerDNSName value should not be nil")
+			},
+		}
+		require.True(t, len(deployedStack.Outputs) == len(expectedResultsForKey),
+			"There should have been %d output values - instead there were %d. The value of the CF stack was %s",
+			len(expectedResultsForKey),
+			len(deployedStack.Outputs),
+			deployedStack.GoString(),
+		)
+		for _, output := range deployedStack.Outputs {
+			key := *output.OutputKey
+			validationFunction := expectedResultsForKey[key]
+			require.NotNil(t, validationFunction, "Unexpected output key %s in stack.", key)
+			validationFunction(output)
+		}
+	})
+}
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
+
+func testSession() (*session.Session, error) {
+	return session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+}
+
+func randStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -70,7 +70,7 @@ func TestDeployEnvironment(t *testing.T) {
 				},
 				box: emptyBox(),
 			},
-			want: errors.New(fmt.Sprintf("failed to find template %s for the environment: %s", environmentTemplate, "file does not exist")),
+			want: fmt.Errorf("failed to find template %s for the environment: %s", environmentTemplate, "file does not exist"),
 		},
 		"should wrap error returned from CreateChangeSet call": {
 			env: &archer.Environment{
@@ -86,7 +86,7 @@ func TestDeployEnvironment(t *testing.T) {
 				},
 				box: boxWithTemplateFile(),
 			},
-			want: errors.New(fmt.Sprintf("failed to create changeSet for stack %s: %s", mockProjectName+"-"+mockEnvironmentName, "some AWS error")),
+			want: fmt.Errorf("failed to create changeSet for stack %s: %s", mockProjectName+"-"+mockEnvironmentName, "some AWS error"),
 		},
 		"should return a ErrStackAlreadyExists if the stack already exists": {
 			cf: CloudFormation{
@@ -128,7 +128,7 @@ func TestDeployEnvironment(t *testing.T) {
 				},
 				box: boxWithTemplateFile(),
 			},
-			want: errors.New(fmt.Sprintf("failed to wait for changeSet creation %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error")),
+			want: fmt.Errorf("failed to wait for changeSet creation %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error"),
 		},
 		"should wrap error return from DescribeChangeSet call": {
 			env: &archer.Environment{
@@ -153,7 +153,7 @@ func TestDeployEnvironment(t *testing.T) {
 				},
 				box: boxWithTemplateFile(),
 			},
-			want: errors.New(fmt.Sprintf("failed to describe changeSet %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error")),
+			want: fmt.Errorf("failed to describe changeSet %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error"),
 		},
 		"should not execute Change Set with no changes": {
 			env: &archer.Environment{
@@ -274,7 +274,7 @@ func TestDeployEnvironment(t *testing.T) {
 				},
 				box: boxWithTemplateFile(),
 			},
-			want: errors.New(fmt.Sprintf("failed to execute changeSet %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error")),
+			want: fmt.Errorf("failed to execute changeSet %s: %s", fmt.Sprintf("name=%s, stackID=%s", mockChangeSetID, mockStackID), "some AWS error"),
 		},
 		"should deploy an environment": {
 			cf: CloudFormation{

--- a/internal/pkg/store/ssm/ssm_integration_test.go
+++ b/internal/pkg/store/ssm/ssm_integration_test.go
@@ -20,7 +20,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func Test_Project_Integration(t *testing.T) {
+func Test_SSM_Project_Integration(t *testing.T) {
 	s, _ := ssm.NewStore()
 	projectToCreate := archer.Project{Name: randStringBytes(10), Version: "1.0"}
 	t.Run("Create, Get and List Projects", func(t *testing.T) {
@@ -44,7 +44,7 @@ func Test_Project_Integration(t *testing.T) {
 	})
 }
 
-func Test_Environment_Integration(t *testing.T) {
+func Test_SSM_Environment_Integration(t *testing.T) {
 	s, _ := ssm.NewStore()
 	projectToCreate := archer.Project{Name: randStringBytes(10), Version: "1.0"}
 	testEnvironment := archer.Environment{Name: "test", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234"}

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -4,6 +4,12 @@
 # TODO: Resource tags
 
 Parameters:
+  ProjectName:
+    Type: String
+
+  EnvironmentName:
+    Type: String
+
   VpcCIDR:
     Type: String
     Default: 10.0.0.0/16
@@ -194,6 +200,11 @@ Resources:
       Subnets: [ !Ref PublicSubnet1, !Ref PublicSubnet2 ]
       Type: application
 
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+        RepositoryName: !Join [ '/', [ !Ref ProjectName, !Ref EnvironmentName ] ]
+
 Outputs:
   VpcId:
     Value: !Ref VPC
@@ -232,3 +243,9 @@ Outputs:
     Value: !Ref Cluster
     Export:
       Name: !Sub ${AWS::StackName}-ClusterId
+
+  ECRRepositoryArn:
+    Value: !GetAtt ECRRepository.Arn
+    Description: ECR Repository used by this environment.
+    Export:
+      Name: !Sub ${AWS::StackName}-ECRArn


### PR DESCRIPTION
* Add integration test for spinning up environments
* These ECR repos will fail to spin up if your project/env name
  have upper/lower case. This will be solved once we make our
  env/project names case sensitive (if we choose not to go that route
  we can store the ECR name in the env param and let CF generate it -
  though then we'd miss out on the nice namespacing feature of ECR).
* Update the integration test target / ssm test names to be more clear.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Fixes #189 