### PR TITLE
Rename "env add" cmd to "env init"

### DIFF
--- a/internal/pkg/cli/env.go
+++ b/internal/pkg/cli/env.go
@@ -52,7 +52,7 @@ An environment represents a deployment stage.`,
 	cmd.PersistentFlags().String(EnvProjectFlag, "", "Name of the project (required unless you're in a workspace).")
 	viper.BindPFlag(EnvProjectFlag, cmd.PersistentFlags().Lookup(EnvProjectFlag))
 
-	cmd.AddCommand(BuildEnvAddCmd())
+	cmd.AddCommand(BuildEnvInitCmd())
 	cmd.AddCommand(BuildEnvListCmd())
 	cmd.SetUsageTemplate(template.Usage)
 	cmd.Annotations = map[string]string{

--- a/internal/pkg/cli/env_add.go
+++ b/internal/pkg/cli/env_add.go
@@ -104,8 +104,8 @@ func (opts *AddEnvOpts) Execute() error {
 	return nil
 }
 
-// BuildEnvAddCmd builds the command for adding an environment.
-func BuildEnvAddCmd() *cobra.Command {
+// BuildEnvInitCmd builds the command for adding an environment.
+func BuildEnvInitCmd() *cobra.Command {
 	opts := AddEnvOpts{
 		EnvProfile: "default",
 		prog:       spinner.New(),
@@ -113,8 +113,8 @@ func BuildEnvAddCmd() *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "add [name]",
-		Short: "Deploy a new environment to your project",
+		Use:   "init [name]",
+		Short: "Create a new environment in your project.",
 		Example: `
   Create a test environment in your "default" AWS profile
   $ archer env add test


### PR DESCRIPTION
Rename the `env add` command to `env init` to be consistent with our [style guide's grammar](https://github.com/aws/amazon-ecs-cli-v2/blob/master/STYLE_GUIDE.md#command-grammar).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
