### PR TITLE
Fix workspace idempotency issue

### DIFF
--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -134,15 +134,11 @@ func (ws *Service) summaryPath() (string, error) {
 
 func (ws *Service) createManifestDirectory() error {
 	// First check to see if a manifest directory already exists
-	dirExists, err := ws.fsUtils.DirExists(filepath.Join(ws.workingDir, manifestDirectoryName))
-	if err != nil {
-		return err
+	existingWorkspace, _ := ws.manifestDirectoryPath()
+	if existingWorkspace != "" {
+		return nil
 	}
-	// If a manifest directory doesn't exist, create it - otherwise fast succeed
-	if !dirExists {
-		return ws.fsUtils.Mkdir(manifestDirectoryName, 0755)
-	}
-	return nil
+	return ws.fsUtils.Mkdir(manifestDirectoryName, 0755)
 }
 
 func (ws *Service) manifestDirectoryPath() (string, error) {


### PR DESCRIPTION
Currently, we'll only check to see if an existing manifest dir
was created in the current directory.

This leads to a bug where if someone runs init in a subdirectory
of a workspace, the manifest directory is re-created.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
