### PR TITLE
Rename manifest.Create() to CreateApp

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -216,7 +216,7 @@ func (opts *InitAppOpts) createProject() error {
 }
 
 func (opts *InitAppOpts) createManifest() error {
-	manifest, err := manifest.Create(opts.AppName, opts.AppType)
+	manifest, err := manifest.CreateApp(opts.AppName, opts.AppType)
 	if err != nil {
 		return fmt.Errorf("failed to generate a manifest %w", err)
 	}

--- a/internal/pkg/manifest/app_manifest.go
+++ b/internal/pkg/manifest/app_manifest.go
@@ -27,9 +27,9 @@ type AppStage struct {
 	DesiredCount int    `yaml:"desiredCount"`
 }
 
-// Create returns a manifest object based on the application's type.
+// CreateApp returns a manifest object based on the application's type.
 // If the application type is invalid, then returns an ErrInvalidManifestType.
-func Create(appName, appType string) (archer.Manifest, error) {
+func CreateApp(appName, appType string) (archer.Manifest, error) {
 	switch appType {
 	case LoadBalancedWebApplication:
 		return NewLoadBalancedFargateManifest(appName), nil

--- a/internal/pkg/manifest/app_manifest_test.go
+++ b/internal/pkg/manifest/app_manifest_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			m, err := Create(tc.inAppName, tc.inAppType)
+			m, err := CreateApp(tc.inAppName, tc.inAppType)
 
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())


### PR DESCRIPTION
<!-- Provide summary of changes -->
This is necessary because we need a namespace for the pipeline manifest.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #207.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
