### PR TITLE
Separate Environment deploy details from main CF file

### DIFF
--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -8,12 +8,20 @@ package archer
 // the location of the Environment (account and region), the name of the environment, as well as the project
 // the environment belongs to.
 type Environment struct {
-	Project            string `json:"project"`            // Name of the project this environment belongs to.
-	Name               string `json:"name"`               // Name of the environment, must be unique within a project.
-	Region             string `json:"region"`             // Name of the region this environment is stored in.
-	AccountID          string `json:"accountID"`          // Account ID of the account this environment is stored in.
-	Prod               bool   `json:"prod"`               // Whether or not this environment is a production environment.
-	PublicLoadBalancer bool   `json:"publicLoadBalancer"` // Whether or not this environment contains a shared public load balancer between applications.
+	Project     string `json:"project"`     // Name of the project this environment belongs to.
+	Name        string `json:"name"`        // Name of the environment, must be unique within a project.
+	Region      string `json:"region"`      // Name of the region this environment is stored in.
+	AccountID   string `json:"accountID"`   // Account ID of the account this environment is stored in.
+	Prod        bool   `json:"prod"`        // Whether or not this environment is a production environment.
+	RegistryURL string `json:"registryURL"` // URL For ECR Registry for this environment.
+}
+
+// DeployEnvironmentInput represents the fields required to setup and deploy an environment
+type DeployEnvironmentInput struct {
+	Project            string // Name of the project this environment belongs to.
+	Name               string // Name of the environment, must be unique within a project.
+	Prod               bool   // Whether or not this environment is a production environment.
+	PublicLoadBalancer bool   // Whether or not this environment should contain a shared public load balancer between applications.
 }
 
 // EnvironmentStore can List, Create and Get environments in an underlying project management store
@@ -40,6 +48,6 @@ type EnvironmentCreator interface {
 
 // EnvironmentDeployer can deploy an environment
 type EnvironmentDeployer interface {
-	DeployEnvironment(env *Environment) error
-	WaitForEnvironmentCreation(env *Environment) error
+	DeployEnvironment(env *DeployEnvironmentInput) error
+	WaitForEnvironmentCreation(env *DeployEnvironmentInput) (*Environment, error)
 }

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -69,17 +69,15 @@ func (opts *AddEnvOpts) Execute() error {
 		return err
 	}
 
-	env := &archer.Environment{
+	deployEnvInput := &archer.DeployEnvironmentInput{
 		Name:               opts.EnvName,
 		Project:            opts.ProjectName,
-		AccountID:          "1234", // FIXME
-		Region:             "1234",
 		Prod:               opts.Production,
 		PublicLoadBalancer: true, // TODO: configure this based on user input or application Type needs?
 	}
 
 	opts.prog.Start("Preparing deployment...")
-	if err := opts.deployer.DeployEnvironment(env); err != nil {
+	if err := opts.deployer.DeployEnvironment(deployEnvInput); err != nil {
 		var existsErr *cloudformation.ErrStackAlreadyExists
 		if errors.As(err, &existsErr) {
 			// Do nothing if the stack already exists.
@@ -92,7 +90,8 @@ func (opts *AddEnvOpts) Execute() error {
 	}
 	opts.prog.Stop("Done!")
 	opts.prog.Start("Deploying env...")
-	if err := opts.deployer.WaitForEnvironmentCreation(env); err != nil {
+	env, err := opts.deployer.WaitForEnvironmentCreation(deployEnvInput)
+	if err != nil {
 		opts.prog.Stop("Error!")
 		return err
 	}

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -107,13 +107,12 @@ func TestEnvAdd_Execute(t *testing.T) {
 				prog:          mockSpinner,
 			},
 			expectedEnv: archer.Environment{
-				Name:    "env",
-				Project: "project",
-				//TODO update these to real values
-				AccountID:          "1234",
-				Region:             "1234",
-				Prod:               true,
-				PublicLoadBalancer: true,
+				Name:        "env",
+				Project:     "project",
+				AccountID:   "1234",
+				Region:      "1234",
+				RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
+				Prod:        true,
 			},
 			mocking: func() {
 				gomock.InOrder(
@@ -126,7 +125,16 @@ func TestEnvAdd_Execute(t *testing.T) {
 					mockSpinner.EXPECT().Stop(gomock.Eq("Done!")),
 					mockSpinner.EXPECT().Start(gomock.Eq("Deploying env...")),
 					// TODO: Assert Wait is called with stack name returned by DeployEnvironment.
-					mockDeployer.EXPECT().WaitForEnvironmentCreation(gomock.Any()),
+					mockDeployer.EXPECT().
+						WaitForEnvironmentCreation(gomock.Any()).
+						Return(&archer.Environment{
+							Name:        "env",
+							Project:     "project",
+							AccountID:   "1234",
+							Region:      "1234",
+							RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
+							Prod:        true,
+						}, nil),
 					mockEnvStore.
 						EXPECT().
 						CreateEnvironment(gomock.Any()).
@@ -149,12 +157,12 @@ func TestEnvAdd_Execute(t *testing.T) {
 				prog:          mockSpinner,
 			},
 			expectedEnv: archer.Environment{
-				Name:    "env",
-				Project: "project",
-				//TODO update these to real values
-				AccountID: "1234",
-				Region:    "1234",
-				Prod:      true,
+				Name:        "env",
+				Project:     "project",
+				AccountID:   "1234",
+				Region:      "1234",
+				RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
+				Prod:        true,
 			},
 			mocking: func() {
 				mockProjStore.

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -51,7 +51,7 @@ type InitAppOpts struct {
 func (opts *InitAppOpts) Prepare() {
 	log.Warningln("It's best to run this command in the root of your workspace.")
 	log.Infoln(`Welcome the the ECS CLI! We're going to walk you through some questions to help you get set up
-with a project on ECS. A project is a collection of containerized applications (or micro-services) 
+with a project on ECS. A project is a collection of containerized applications (or micro-services)
 that operate together.` + "\n")
 
 	// If there's a local project, we'll use that and just skip the project question.
@@ -269,19 +269,19 @@ func (opts *InitAppOpts) deploy() error {
 
 func (opts *InitAppOpts) deployEnv() error {
 	// TODO https://github.com/aws/amazon-ecs-cli-v2/issues/56
-	env := &archer.Environment{
+	deployEnvInput := &archer.DeployEnvironmentInput{
 		Project:            opts.Project,
 		Name:               defaultEnvironmentName,
 		PublicLoadBalancer: true, // TODO: configure this value based on user input or Application type needs?
 	}
 
 	opts.prog.Start("Preparing deployment...")
-	if err := opts.envDeployer.DeployEnvironment(env); err != nil {
+	if err := opts.envDeployer.DeployEnvironment(deployEnvInput); err != nil {
 		var existsErr *cloudformation.ErrStackAlreadyExists
 		if errors.As(err, &existsErr) {
 			// Do nothing if the stack already exists.
 			opts.prog.Stop("")
-			log.Infof("The environment %s already exists under project %s.\n", env.Name, opts.Project)
+			log.Infof("The environment %s already exists under project %s.\n", deployEnvInput.Name, opts.Project)
 			return nil
 		}
 		opts.prog.Stop("Error!")
@@ -289,7 +289,8 @@ func (opts *InitAppOpts) deployEnv() error {
 	}
 	opts.prog.Stop("Done!")
 	opts.prog.Start("Deploying env...")
-	if err := opts.envDeployer.WaitForEnvironmentCreation(env); err != nil {
+	env, err := opts.envDeployer.WaitForEnvironmentCreation(deployEnvInput)
+	if err != nil {
 		opts.prog.Stop("Error!")
 		return err
 	}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -471,7 +471,7 @@ func TestInit_Execute(t *testing.T) {
 						Times(1),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						DeployEnvironment(gomock.Eq(&archer.Environment{
+						DeployEnvironment(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
@@ -511,7 +511,7 @@ func TestInit_Execute(t *testing.T) {
 						Times(1),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						DeployEnvironment(gomock.Eq(&archer.Environment{
+						DeployEnvironment(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
@@ -521,12 +521,12 @@ func TestInit_Execute(t *testing.T) {
 					mockProgress.EXPECT().Stop(gomock.Any()),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						WaitForEnvironmentCreation(gomock.Eq(&archer.Environment{
+						WaitForEnvironmentCreation(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
 						})).
-						Return(mockError).
+						Return(nil, mockError).
 						Times(1),
 					mockProgress.EXPECT().Stop(gomock.Any()),
 				)
@@ -561,7 +561,7 @@ func TestInit_Execute(t *testing.T) {
 						Times(1),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						DeployEnvironment(gomock.Eq(&archer.Environment{
+						DeployEnvironment(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
@@ -571,12 +571,17 @@ func TestInit_Execute(t *testing.T) {
 					mockProgress.EXPECT().Stop(gomock.Any()),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						WaitForEnvironmentCreation(gomock.Eq(&archer.Environment{
+						WaitForEnvironmentCreation(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
 						})).
-						Return(nil).
+						Return(&archer.Environment{
+							Project:   "project3",
+							Name:      defaultEnvironmentName,
+							AccountID: "2345",
+							Region:    "us-west-2",
+						}, nil).
 						Times(1),
 					mockEnvStore.
 						EXPECT().
@@ -616,7 +621,7 @@ func TestInit_Execute(t *testing.T) {
 						Times(1),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						DeployEnvironment(gomock.Eq(&archer.Environment{
+						DeployEnvironment(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
@@ -626,12 +631,17 @@ func TestInit_Execute(t *testing.T) {
 					mockProgress.EXPECT().Stop(gomock.Any()),
 					mockProgress.EXPECT().Start(gomock.Any()),
 					mockDeployer.EXPECT().
-						WaitForEnvironmentCreation(gomock.Eq(&archer.Environment{
+						WaitForEnvironmentCreation(gomock.Eq(&archer.DeployEnvironmentInput{
 							Project:            "project3",
 							Name:               defaultEnvironmentName,
 							PublicLoadBalancer: true,
 						})).
-						Return(nil).
+						Return(&archer.Environment{
+							Project:   "project3",
+							Name:      defaultEnvironmentName,
+							AccountID: "1234",
+							Region:    "us-west-2",
+						}, nil).
 						Times(1),
 					mockEnvStore.
 						EXPECT().

--- a/internal/pkg/deploy/cloudformation/changeset.go
+++ b/internal/pkg/deploy/cloudformation/changeset.go
@@ -6,7 +6,6 @@ package cloudformation
 import (
 	"fmt"
 
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -136,17 +135,8 @@ func withCreateChangeSetType() createChangeSetOpt {
 	}
 }
 
-func withEnvTags(env *archer.Environment) createChangeSetOpt {
+func withTags(tags []*cloudformation.Tag) createChangeSetOpt {
 	return func(in *cloudformation.CreateChangeSetInput) {
-		in.Tags = []*cloudformation.Tag{
-                        {
-			         Key:   aws.String("ecs-project"),
-			         Value: aws.String(env.Project),
-		        },
-		       {
-			         Key:   aws.String("ecs-env"),
-			         Value: aws.String(env.Name),
-		        },
-	       }
+		in.Tags = tags
 	}
 }

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -1,0 +1,121 @@
+package cloudformation
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+
+	"github.com/gobuffalo/packd"
+)
+
+// envStackConfig is for providing all the values to set up an
+// environment stack and to interpret the outputs from it.
+type envStackConfig struct {
+	*archer.DeployEnvironmentInput
+	box packd.Box
+}
+
+const (
+	// EnvParamIncludeLBKey is the CF Param Key Name for whether to include a LB
+	EnvParamIncludeLBKey = "IncludePublicLoadBalancer"
+	// EnvParamProjectNameKey is the CF Param Key Name for providing the project name
+	EnvParamProjectNameKey = "ProjectName"
+	// EnvParamEnvNameKey is the CF Param Key Name for providing the environment name
+	EnvParamEnvNameKey = "EnvironmentName"
+	// EnvOutputECRKey is the CF Output Key Name for the ECR Repo Name
+	EnvOutputECRKey = "ECRRepositoryName"
+
+	ecrURLFormatString = "%s.dkr.ecr.%s.amazonaws.com/%s"
+
+	envTemplatePath = "environment/cf.yml"
+)
+
+// newEnvStackConfig sets up a struct which can provide values to CloudFormation for
+// spinning up an environment.
+func newEnvStackConfig(input *archer.DeployEnvironmentInput, box packd.Box) *envStackConfig {
+	return &envStackConfig{
+		DeployEnvironmentInput: input,
+		box:                    box,
+	}
+}
+
+// Template returns the environment CloudFormation template.
+func (e *envStackConfig) Template() (string, error) {
+	template, err := e.box.FindString(envTemplatePath)
+	if err != nil {
+		return "", &ErrTemplateNotFound{templateLocation: envTemplatePath, parentErr: err}
+	}
+	return template, nil
+}
+
+// Parameters returns the parameters to be passed into a environment CloudFormation template.
+func (e *envStackConfig) Parameters() []*cloudformation.Parameter {
+	return []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(EnvParamIncludeLBKey),
+			ParameterValue: aws.String(strconv.FormatBool(e.PublicLoadBalancer)),
+		},
+		{
+			ParameterKey:   aws.String(EnvParamProjectNameKey),
+			ParameterValue: aws.String(e.Project),
+		},
+		{
+			ParameterKey:   aws.String(EnvParamEnvNameKey),
+			ParameterValue: aws.String(e.Name),
+		},
+	}
+}
+
+// Tags returns the tags that should be applied to the environment CloudFormation stack.
+func (e *envStackConfig) Tags() []*cloudformation.Tag {
+	return []*cloudformation.Tag{
+		{
+			Key:   aws.String(projectTagKey),
+			Value: aws.String(e.Project),
+		},
+		{
+			Key:   aws.String(envTagKey),
+			Value: aws.String(e.Name),
+		},
+	}
+}
+
+// StackName returns the name of the CloudFormation stack (based on the project and env names).
+func (e *envStackConfig) StackName() string {
+	return fmt.Sprintf("%s-%s", e.Project, e.Name)
+}
+
+// ToEnv inspects an environment cloudformation stack and constructs an environment
+// struct out of it (including resources like ECR Repo)
+func (e *envStackConfig) ToEnv(stack *cloudformation.Stack) (*archer.Environment, error) {
+	stackARN, err := arn.Parse(*stack.StackId)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't extract region and account from stack ID %s: %w", *stack.StackId, err)
+	}
+
+	stackOutputs := make(map[string]string)
+	for _, output := range stack.Outputs {
+		stackOutputs[*output.OutputKey] = *output.OutputValue
+	}
+
+	createdEnv := archer.Environment{
+		Name:      e.Name,
+		Project:   e.Project,
+		Prod:      e.Prod,
+		Region:    stackARN.Region,
+		AccountID: stackARN.AccountID,
+	}
+
+	if stackOutputs[EnvOutputECRKey] != "" {
+		createdEnv.RegistryURL = fmt.Sprintf(ecrURLFormatString,
+			createdEnv.AccountID,
+			createdEnv.Region,
+			stackOutputs[EnvOutputECRKey])
+	}
+
+	return &createdEnv, nil
+}

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -1,0 +1,159 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/gobuffalo/packd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvTemplate(t *testing.T) {
+	testCases := map[string]struct {
+		box            packd.Box
+		expectedOutput string
+		want           error
+	}{
+		"should return error given template not found": {
+			box:  emptyEnvBox(),
+			want: fmt.Errorf("failed to find the cloudformation template at %s", envTemplatePath),
+		},
+		"should return template body when present": {
+			box:            envBoxWithTemplateFile(),
+			expectedOutput: mockTemplate,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			envStack := newEnvStackConfig(mockDeployEnvironmentInput(), tc.box)
+			got, err := envStack.Template()
+
+			if tc.want != nil {
+				require.EqualError(t, tc.want, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestEnvParameters(t *testing.T) {
+	deploymentInput := mockDeployEnvironmentInput()
+	env := newEnvStackConfig(deploymentInput, emptyEnvBox())
+	expectedParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(EnvParamIncludeLBKey),
+			ParameterValue: aws.String(strconv.FormatBool(deploymentInput.PublicLoadBalancer)),
+		},
+		{
+			ParameterKey:   aws.String(EnvParamProjectNameKey),
+			ParameterValue: aws.String(deploymentInput.Project),
+		},
+		{
+			ParameterKey:   aws.String(EnvParamEnvNameKey),
+			ParameterValue: aws.String(deploymentInput.Name),
+		},
+	}
+	require.ElementsMatch(t, expectedParams, env.Parameters())
+}
+
+func TestEnvTags(t *testing.T) {
+	deploymentInput := mockDeployEnvironmentInput()
+	env := newEnvStackConfig(deploymentInput, emptyEnvBox())
+	expectedTags := []*cloudformation.Tag{
+		{
+			Key:   aws.String(projectTagKey),
+			Value: aws.String(deploymentInput.Project),
+		},
+		{
+			Key:   aws.String(envTagKey),
+			Value: aws.String(deploymentInput.Name),
+		},
+	}
+	require.ElementsMatch(t, expectedTags, env.Tags())
+}
+
+func TestStackName(t *testing.T) {
+	deploymentInput := mockDeployEnvironmentInput()
+	env := newEnvStackConfig(deploymentInput, emptyEnvBox())
+	require.Equal(t, fmt.Sprintf("%s-%s", deploymentInput.Project, deploymentInput.Name), env.StackName())
+}
+
+func TestToEnv(t *testing.T) {
+	mockDeployInput := mockDeployEnvironmentInput()
+	testCases := map[string]struct {
+		expectedEnv archer.Environment
+		mockStack   *cloudformation.Stack
+		want        error
+	}{
+		"should return error if Stack ID is invalid": {
+			want:      fmt.Errorf("couldn't extract region and account from stack ID : arn: invalid prefix"),
+			mockStack: mockEnvironmentStack("", ""),
+		},
+		"should return a well formed environment": {
+			mockStack: mockEnvironmentStack("arn:aws:cloudformation:eu-west-3:902697171733:stack/project-env", "project/env"),
+			expectedEnv: archer.Environment{
+				Name:        mockDeployInput.Name,
+				Project:     mockDeployInput.Project,
+				Prod:        mockDeployInput.Prod,
+				AccountID:   "902697171733",
+				Region:      "eu-west-3",
+				RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			envStack := newEnvStackConfig(mockDeployInput, emptyBox())
+			got, err := envStack.ToEnv(tc.mockStack)
+
+			if tc.want != nil {
+				require.EqualError(t, tc.want, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedEnv, *got)
+			}
+		})
+	}
+}
+func mockEnvironmentStack(stackArn, ecrOutput string) *cloudformation.Stack {
+	return &cloudformation.Stack{
+		StackId: aws.String(stackArn),
+		Outputs: []*cloudformation.Output{
+			&cloudformation.Output{
+				OutputKey:   aws.String(EnvOutputECRKey),
+				OutputValue: aws.String(ecrOutput),
+			},
+		},
+	}
+}
+
+func mockDeployEnvironmentInput() *archer.DeployEnvironmentInput {
+	return &archer.DeployEnvironmentInput{
+		Name:               "env",
+		Project:            "project",
+		Prod:               true,
+		PublicLoadBalancer: true,
+	}
+}
+func emptyEnvBox() packd.Box {
+	return packd.NewMemoryBox()
+}
+
+func envBoxWithTemplateFile() packd.Box {
+	box := packd.NewMemoryBox()
+
+	box.AddString(envTemplatePath, mockTemplate)
+
+	return box
+}

--- a/internal/pkg/deploy/cloudformation/errors.go
+++ b/internal/pkg/deploy/cloudformation/errors.go
@@ -28,3 +28,18 @@ type ErrNotExecutableChangeSet struct {
 func (err *ErrNotExecutableChangeSet) Error() string {
 	return fmt.Sprintf("cannot execute change set %s because status is %s with reason %s", err.set, err.set.executionStatus, err.set.statusReason)
 }
+
+// ErrTemplateNotFound occurs when we can't find a predefined template.
+type ErrTemplateNotFound struct {
+	templateLocation string
+	parentErr        error
+}
+
+func (err *ErrTemplateNotFound) Error() string {
+	return fmt.Sprintf("failed to find the cloudformation template at %s", err.templateLocation)
+}
+
+// Unwrap returns the original error.
+func (err *ErrTemplateNotFound) Unwrap() error {
+	return err.parentErr
+}

--- a/mocks/mock_env.go
+++ b/mocks/mock_env.go
@@ -214,7 +214,7 @@ func (m *MockEnvironmentDeployer) EXPECT() *MockEnvironmentDeployerMockRecorder 
 }
 
 // DeployEnvironment mocks base method
-func (m *MockEnvironmentDeployer) DeployEnvironment(env *archer.Environment) error {
+func (m *MockEnvironmentDeployer) DeployEnvironment(env *archer.DeployEnvironmentInput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployEnvironment", env)
 	ret0, _ := ret[0].(error)
@@ -228,11 +228,12 @@ func (mr *MockEnvironmentDeployerMockRecorder) DeployEnvironment(env interface{}
 }
 
 // WaitForEnvironmentCreation mocks base method
-func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *archer.Environment) error {
+func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *archer.DeployEnvironmentInput) (*archer.Environment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForEnvironmentCreation", env)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*archer.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // WaitForEnvironmentCreation indicates an expected call of WaitForEnvironmentCreation

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -249,3 +249,9 @@ Outputs:
     Description: ECR Repository used by this environment.
     Export:
       Name: !Sub ${AWS::StackName}-ECRArn
+
+  ECRRepositoryName:
+    Value: !Ref ECRRepository
+    Description: Name of ECR Repository used by this environment.
+    Export:
+      Name: !Sub ${AWS::StackName}-ECRName


### PR DESCRIPTION
This PR does a couple of things:
* Creates a DeployEnvironmentInput which contains the fields
  which are needed to create an environment.
* Separate the Tags/Parameter/Template/StackName generation
  into a separate env.go file so cloudformation.go can focus on
  deployment logic. I think this will make adding application/pipeline
  deployments much easier.
* Stores the ECR URL for the environment into the env struct.

<!-- Provide summary of changes -->

Fixes #191 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
