### PR TITLE
Rename Opts structs to match file names

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// AppInitOpts holds the configuration needed to create a new application.
-type AppInitOpts struct {
+// InitAppOpts holds the configuration needed to create a new application.
+type InitAppOpts struct {
 	// Fields with matching flags.
 	AppType        string
 	AppName        string
@@ -41,7 +41,7 @@ type AppInitOpts struct {
 }
 
 // Ask prompts for fields that are required but not passed in.
-func (opts *AppInitOpts) Ask() error {
+func (opts *InitAppOpts) Ask() error {
 	if opts.AppType == "" {
 		if err := opts.askAppType(); err != nil {
 			return err
@@ -61,7 +61,7 @@ func (opts *AppInitOpts) Ask() error {
 }
 
 // Validate returns an error if the flag values passed by the user are invalid.
-func (opts *AppInitOpts) Validate() error {
+func (opts *InitAppOpts) Validate() error {
 	if opts.AppType != "" {
 		if err := validateApplicationType(opts.AppType); err != nil {
 			return err
@@ -84,7 +84,7 @@ func (opts *AppInitOpts) Validate() error {
 }
 
 // Execute writes the application's manifest file and stores the application in SSM.
-func (opts *AppInitOpts) Execute() error {
+func (opts *InitAppOpts) Execute() error {
 	manifest, err := manifest.CreateApp(opts.AppName, opts.AppType, opts.DockerfilePath)
 	if err != nil {
 		return fmt.Errorf("generate a manifest: %w", err)
@@ -113,7 +113,7 @@ func (opts *AppInitOpts) Execute() error {
 	return nil
 }
 
-func (opts *AppInitOpts) askAppType() error {
+func (opts *InitAppOpts) askAppType() error {
 	t, err := opts.prompt.SelectOne(
 		"Which type of infrastructure pattern best represents your application?",
 		`Your application's architecture. Most applications need additional AWS resources to run.
@@ -127,7 +127,7 @@ To help setup the infrastructure resources, select what "kind" or "type" of appl
 	return nil
 }
 
-func (opts *AppInitOpts) askAppName() error {
+func (opts *InitAppOpts) askAppName() error {
 	name, err := opts.prompt.Get(
 		fmt.Sprintf("What do you want to call this %s?", opts.AppType),
 		fmt.Sprintf(`The name will uniquely identify this application within your %s project.
@@ -142,7 +142,7 @@ Deployed resources (such as your service, logs) will contain this app's name and
 
 // askDockerfile prompts for the Dockerfile by looking at sub-directories with a Dockerfile.
 // If the user chooses to enter a custom path, then we prompt them for the path.
-func (opts *AppInitOpts) askDockerfile() error {
+func (opts *InitAppOpts) askDockerfile() error {
 	// TODO https://github.com/aws/amazon-ecs-cli-v2/issues/206
 	dockerfiles, err := opts.listDockerfiles()
 	if err != nil {
@@ -174,7 +174,7 @@ func (opts *AppInitOpts) askDockerfile() error {
 
 // listDockerfiles returns the list of Dockerfiles within the current working directory and a sub-directory level below.
 // If an error occurs while reading directories, returns the error.
-func (opts *AppInitOpts) listDockerfiles() ([]string, error) {
+func (opts *InitAppOpts) listDockerfiles() ([]string, error) {
 	wdFiles, err := afero.ReadDir(opts.fs, ".")
 	if err != nil {
 		return nil, fmt.Errorf("read directory: %w", err)
@@ -206,7 +206,7 @@ func (opts *AppInitOpts) listDockerfiles() ([]string, error) {
 }
 
 // LogRecommendedActions logs follow-up actions the user can take after successfully executing the command.
-func (opts *AppInitOpts) LogRecommendedActions() {
+func (opts *InitAppOpts) LogRecommendedActions() {
 	log.Infoln("Recommended follow-up actions:")
 	log.Infof("- Update your manifest %s to change the defaults.\n",
 		color.HighlightResource(opts.manifestPath))
@@ -218,7 +218,7 @@ func (opts *AppInitOpts) LogRecommendedActions() {
 
 // BuildAppInitCmd build the command for creating a new application.
 func BuildAppInitCmd() *cobra.Command {
-	opts := &AppInitOpts{}
+	opts := &InitAppOpts{}
 	cmd := &cobra.Command{
 		Use: "init",
 		Long: `Create a new application in a project.

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -99,7 +99,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPrompt := mocks.NewMockprompter(ctrl)
-			opts := &AppInitOpts{
+			opts := &InitAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
@@ -164,7 +164,7 @@ func TestAppInitOpts_Validate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
-			opts := AppInitOpts{
+			opts := InitAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
@@ -214,7 +214,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockWriter := archerMocks.NewMockManifestIO(ctrl)
-			opts := AppInitOpts{
+			opts := InitAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// AddEnvOpts contains the fields to collect for adding an environment.
-type AddEnvOpts struct {
+// InitEnvOpts contains the fields to collect for adding an environment.
+type InitEnvOpts struct {
 	ProjectName string
 	EnvName     string
 	EnvProfile  string
@@ -32,7 +32,7 @@ type AddEnvOpts struct {
 }
 
 // Ask asks for fields that are required but not passed in.
-func (opts *AddEnvOpts) Ask() error {
+func (opts *InitEnvOpts) Ask() error {
 	if opts.ProjectName == "" {
 		projectName, err := opts.prompter.Get(
 			"What is your project's name?",
@@ -63,7 +63,7 @@ func (opts *AddEnvOpts) Ask() error {
 }
 
 // Execute deploys a new environment with CloudFormation and adds it to SSM.
-func (opts *AddEnvOpts) Execute() error {
+func (opts *InitEnvOpts) Execute() error {
 	// Ensure the project actually exists before we do a deployment.
 	if _, err := opts.projectGetter.GetProject(opts.ProjectName); err != nil {
 		return err
@@ -106,7 +106,7 @@ func (opts *AddEnvOpts) Execute() error {
 
 // BuildEnvInitCmd builds the command for adding an environment.
 func BuildEnvInitCmd() *cobra.Command {
-	opts := AddEnvOpts{
+	opts := InitEnvOpts{
 		EnvProfile: "default",
 		prog:       spinner.New(),
 		prompter:   prompt.New(),

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -64,7 +64,7 @@ func TestEnvAdd_Ask(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			addEnv := &AddEnvOpts{
+			addEnv := &InitEnvOpts{
 				EnvName:     tc.inputEnv,
 				ProjectName: tc.inputProject,
 				prompter:    mockPrompter,
@@ -91,13 +91,13 @@ func TestEnvAdd_Execute(t *testing.T) {
 	defer ctrl.Finish()
 
 	testCases := map[string]struct {
-		addEnvOpts  AddEnvOpts
+		addEnvOpts  InitEnvOpts
 		expectedEnv archer.Environment
 		expectedErr error
 		mocking     func()
 	}{
 		"with a succesful call to add env": {
-			addEnvOpts: AddEnvOpts{
+			addEnvOpts: InitEnvOpts{
 				manager:       mockEnvStore,
 				projectGetter: mockProjStore,
 				deployer:      mockDeployer,
@@ -139,7 +139,7 @@ func TestEnvAdd_Execute(t *testing.T) {
 		},
 		"with a invalid project": {
 			expectedErr: mockError,
-			addEnvOpts: AddEnvOpts{
+			addEnvOpts: InitEnvOpts{
 				manager:       mockEnvStore,
 				projectGetter: mockProjStore,
 				deployer:      mockDeployer,

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -28,8 +28,8 @@ import (
 
 const defaultEnvironmentName = "test"
 
-// InitAppOpts holds the fields to bootstrap a new application.
-type InitAppOpts struct {
+// InitOpts holds the fields to bootstrap a new application.
+type InitOpts struct {
 	Project               string // namespace that this application belongs to.
 	AppName               string // unique identifier for the application.
 	AppType               string // type of application you're trying to build (LoadBalanced, Backend, etc.)
@@ -48,7 +48,7 @@ type InitAppOpts struct {
 }
 
 // Prepare loads contextual data such as any existing projects, the current workspace, etc.
-func (opts *InitAppOpts) Prepare() {
+func (opts *InitOpts) Prepare() {
 	log.Warningln("It's best to run this command in the root of your workspace.")
 	log.Infoln(`Welcome the the ECS CLI! We're going to walk you through some questions to help you get set up
 with a project on ECS. A project is a collection of containerized applications (or micro-services) 
@@ -74,7 +74,7 @@ that operate together.` + "\n")
 }
 
 // Ask prompts the user for the value of any required fields that are not already provided.
-func (opts *InitAppOpts) Ask() error {
+func (opts *InitOpts) Ask() error {
 	if opts.Project == "" {
 		if err := opts.askProjectName(); err != nil {
 			return err
@@ -94,7 +94,7 @@ func (opts *InitAppOpts) Ask() error {
 }
 
 // Validate returns an error if a command line flag provided value is invalid
-func (opts *InitAppOpts) Validate() error {
+func (opts *InitOpts) Validate() error {
 	if err := validateProjectName(opts.Project); err != nil {
 		return fmt.Errorf("project name %s is invalid: %w", opts.Project, err)
 	}
@@ -109,7 +109,7 @@ func (opts *InitAppOpts) Validate() error {
 }
 
 // Execute creates a project and initializes the workspace.
-func (opts *InitAppOpts) Execute() error {
+func (opts *InitOpts) Execute() error {
 	log.Infof("Ok great, we'll set up a %s named %s in project %s.\n",
 		color.HighlightUserInput(opts.AppType), color.HighlightUserInput(opts.AppName), color.HighlightUserInput(opts.Project))
 
@@ -125,7 +125,7 @@ func (opts *InitAppOpts) Execute() error {
 	return opts.deploy()
 }
 
-func (opts *InitAppOpts) askProjectName() error {
+func (opts *InitOpts) askProjectName() error {
 	if len(opts.existingProjects) == 0 {
 		log.Infoln("Looks like you don't have any existing projects. Let's create one!")
 		return opts.askNewProjectName()
@@ -144,7 +144,7 @@ func (opts *InitAppOpts) askProjectName() error {
 	return opts.askNewProjectName()
 }
 
-func (opts *InitAppOpts) askSelectExistingProjectName() error {
+func (opts *InitOpts) askSelectExistingProjectName() error {
 	projectName, err := opts.prompter.SelectOne(
 		"Which one do you want to add a new application to?",
 		"Applications in the same project share the same VPC, ECS Cluster and are discoverable via service discovery.",
@@ -156,7 +156,7 @@ func (opts *InitAppOpts) askSelectExistingProjectName() error {
 	return nil
 }
 
-func (opts *InitAppOpts) askNewProjectName() error {
+func (opts *InitOpts) askNewProjectName() error {
 	projectName, err := opts.prompter.Get(
 		"What would you like to call your project?",
 		"Applications under the same project share the same VPC and ECS Cluster and are discoverable via service discovery.",
@@ -168,7 +168,7 @@ func (opts *InitAppOpts) askNewProjectName() error {
 	return nil
 }
 
-func (opts *InitAppOpts) askAppType() error {
+func (opts *InitOpts) askAppType() error {
 	t, err := opts.prompter.SelectOne(
 		"What type of application do you want to make?",
 		"List of infrastructure patterns.",
@@ -181,7 +181,7 @@ func (opts *InitAppOpts) askAppType() error {
 	return nil
 }
 
-func (opts *InitAppOpts) askAppName() error {
+func (opts *InitOpts) askAppName() error {
 	name, err := opts.prompter.Get(
 		fmt.Sprintf("What do you want to call this %s?", opts.AppType),
 		"Collection of AWS services to achieve a business capability. Must be unique within a project.",
@@ -193,7 +193,7 @@ func (opts *InitAppOpts) askAppName() error {
 	return nil
 }
 
-func (opts *InitAppOpts) askShouldDeploy() error {
+func (opts *InitOpts) askShouldDeploy() error {
 	v, err := opts.prompter.Confirm("Would you like to deploy a staging environment?", "A \"test\" environment with your application deployed to it. This will allow you to test your application before placing it in production.")
 	if err != nil {
 		return fmt.Errorf("failed to confirm deployment: %w", err)
@@ -202,7 +202,7 @@ func (opts *InitAppOpts) askShouldDeploy() error {
 	return nil
 }
 
-func (opts *InitAppOpts) createProject() error {
+func (opts *InitOpts) createProject() error {
 	err := opts.projStore.CreateProject(&archer.Project{
 		Name: opts.Project,
 	})
@@ -215,7 +215,7 @@ func (opts *InitAppOpts) createProject() error {
 	return nil
 }
 
-func (opts *InitAppOpts) createManifest() error {
+func (opts *InitOpts) createManifest() error {
 	manifest, err := manifest.CreateApp(opts.AppName, opts.AppType, "") // TODO https://github.com/aws/amazon-ecs-cli-v2/issues/109
 	if err != nil {
 		return fmt.Errorf("failed to generate a manifest %w", err)
@@ -244,7 +244,7 @@ func (opts *InitAppOpts) createManifest() error {
 }
 
 // deploy prompts the user to deploy a test environment if the project doesn't already have one.
-func (opts *InitAppOpts) deploy() error {
+func (opts *InitOpts) deploy() error {
 	if opts.promptForShouldDeploy {
 		log.Infoln("All right, you're all set for local development.")
 		if err := opts.askShouldDeploy(); err != nil {
@@ -267,7 +267,7 @@ func (opts *InitAppOpts) deploy() error {
 	return opts.deployEnv()
 }
 
-func (opts *InitAppOpts) deployEnv() error {
+func (opts *InitOpts) deployEnv() error {
 	// TODO https://github.com/aws/amazon-ecs-cli-v2/issues/56
 	env := &archer.Environment{
 		Project:            opts.Project,
@@ -303,7 +303,7 @@ func (opts *InitAppOpts) deployEnv() error {
 
 // BuildInitCmd builds the command for bootstrapping an application.
 func BuildInitCmd() *cobra.Command {
-	opts := InitAppOpts{
+	opts := InitOpts{
 		prompter: prompt.New(),
 		prog:     spinner.New(),
 	}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -154,7 +154,7 @@ func TestInit_Ask(t *testing.T) {
 			mockProjectStore = mocks.NewMockProjectStore(ctrl)
 			mockPrompter = climocks.NewMockprompter(ctrl)
 
-			app := &InitAppOpts{
+			app := &InitOpts{
 				Project:          tc.inputProject,
 				AppName:          tc.inputApp,
 				AppType:          tc.inputType,
@@ -181,13 +181,13 @@ func TestInit_Prepare(t *testing.T) {
 	defer ctrl.Finish()
 
 	testCases := map[string]struct {
-		inputOpts              InitAppOpts
+		inputOpts              InitOpts
 		mocking                func()
 		wantedExistingProjects []string
 		wantedProject          string
 	}{
 		"with no project flag, empty workspace and existing projects": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "frontend",
 			},
 			wantedExistingProjects: []string{"project1", "project2"},
@@ -207,7 +207,7 @@ func TestInit_Prepare(t *testing.T) {
 			},
 		},
 		"with no project flag, empty workspace and error finding projects": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "frontend",
 			},
 			wantedExistingProjects: []string{},
@@ -225,7 +225,7 @@ func TestInit_Prepare(t *testing.T) {
 			},
 		},
 		"with no project flag and existing workspace": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "frontend",
 			},
 			wantedProject: "MyProject",
@@ -248,7 +248,7 @@ func TestInit_Prepare(t *testing.T) {
 		},
 
 		"with project flag": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "frontend",
 				Project: "MyProject",
 			},
@@ -287,24 +287,24 @@ func TestInit_Prepare(t *testing.T) {
 
 func TestInit_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		inputOpts       InitAppOpts
+		inputOpts       InitOpts
 		wantedErrPrefix string
 	}{
 		"with valid project and app": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "frontend",
 				Project: "coolproject",
 			},
 		},
 		"with invalid project name": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "coolapp",
 				Project: "!!!!",
 			},
 			wantedErrPrefix: "project name !!!! is invalid",
 		},
 		"with invalid app name": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName: "!!!",
 				Project: "coolproject",
 			},
@@ -335,12 +335,12 @@ func TestInit_Execute(t *testing.T) {
 	mockError := fmt.Errorf("error")
 
 	testCases := map[string]struct {
-		inputOpts  InitAppOpts
+		inputOpts  InitOpts
 		setupMocks func()
 		want       error
 	}{
 		"should return error if project error is not ProjectAlreadyExist": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project1",
 				AppType:               "Load Balanced Web App",
@@ -359,7 +359,7 @@ func TestInit_Execute(t *testing.T) {
 			want: mockError,
 		},
 		"should continue if project already exists": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project1",
 				AppType:               "Load Balanced Web App",
@@ -386,7 +386,7 @@ func TestInit_Execute(t *testing.T) {
 			want: nil,
 		},
 		"prompt for should deploy": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				Project:               "project3",
 				AppName:               "frontend",
 				AppType:               "Load Balanced Web App",
@@ -417,7 +417,7 @@ func TestInit_Execute(t *testing.T) {
 			want: nil,
 		},
 		"should echo error returned from call to workspace.Create": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppType:               "Load Balanced Web App",
 				Project:               "project3",
 				AppName:               "frontend",
@@ -444,7 +444,7 @@ func TestInit_Execute(t *testing.T) {
 			want: mockError,
 		},
 		"should echo error returned from call to envDeployer.DeployEnvironment": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project3",
 				AppType:               "Load Balanced Web App",
@@ -484,7 +484,7 @@ func TestInit_Execute(t *testing.T) {
 			want: mockError,
 		},
 		"should echo error returned from call to envDeployer.Wait": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project3",
 				AppType:               "Load Balanced Web App",
@@ -534,7 +534,7 @@ func TestInit_Execute(t *testing.T) {
 			want: mockError,
 		},
 		"should echo error returned from call to envStore.Create": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project3",
 				AppType:               "Load Balanced Web App",
@@ -589,7 +589,7 @@ func TestInit_Execute(t *testing.T) {
 			want: mockError,
 		},
 		"should create a new test environment": {
-			inputOpts: InitAppOpts{
+			inputOpts: InitOpts{
 				AppName:               "frontend",
 				Project:               "project3",
 				AppType:               "Load Balanced Web App",


### PR DESCRIPTION
Refactor renaming `Opts` structs that are not consistent with the file names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
