### PR TITLE
Reach parity between "archer project init" and "archer init"

### DIFF
--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -68,7 +68,7 @@ func (opts *InitProjectOpts) Ask() error {
 	log.Infoln("Looks like you have some projects already.")
 	useExistingProject, err := opts.prompt.Confirm("Would you like to use one of your existing projects?", "", prompt.WithTrueDefault())
 	if err != nil {
-		return fmt.Errorf("new project confirmation: %w", err)
+		return fmt.Errorf("prompt to confirm using existing project: %w", err)
 	}
 	if useExistingProject {
 		log.Infoln("Ok, here are your existing projects.")

--- a/internal/pkg/cli/project_init_test.go
+++ b/internal/pkg/cli/project_init_test.go
@@ -4,109 +4,260 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
 	"github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
 
-func TestProjectInit_Execute(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockProjectStore := mocks.NewMockProjectStore(ctrl)
-	mockWorkspace := mocks.NewMockWorkspace(ctrl)
+func TestInitProjectOpts_Ask(t *testing.T) {
+	testCases := map[string]struct {
+		inProjectName string
+		expect        func(opts *InitProjectOpts)
+
+		wantedProjectName string
+		wantedErr         string
+	}{
+		"do nothing if name is provided": {
+			inProjectName: "metrics",
+			expect:        func(opts *InitProjectOpts) {},
+
+			wantedProjectName: "metrics",
+		},
+		"set the project name workspace.Summary": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(&archer.WorkspaceSummary{ProjectName: "metrics"}, nil)
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Times(0)
+			},
+			wantedProjectName: "metrics",
+		},
+		"return error from new project name": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Return([]*archer.Project{}, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantedErr: "prompt get project name: my error",
+		},
+		"enter new project name if no existing projects": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Return([]*archer.Project{}, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantedProjectName: "metrics",
+		},
+		"return error from project selection": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Return([]*archer.Project{
+					{
+						Name: "metrics",
+					},
+					{
+						Name: "payments",
+					},
+				}, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
+			},
+			wantedErr: "prompt select project name: my error",
+		},
+		"use existing projects": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Return([]*archer.Project{
+					{
+						Name: "metrics",
+					},
+					{
+						Name: "payments",
+					},
+				}, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+			},
+			wantedProjectName: "metrics",
+		},
+		"enter new project name if user opts out of selection": {
+			expect: func(opts *InitProjectOpts) {
+				opts.ws.(*mocks.MockWorkspace).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
+				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListProjects().Return([]*archer.Project{
+					{
+						Name: "metrics",
+					},
+					{
+						Name: "payments",
+					},
+				}, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+			},
+			wantedProjectName: "metrics",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			opts := &InitProjectOpts{
+				ProjectName:  tc.inProjectName,
+				projectStore: mocks.NewMockProjectStore(ctrl),
+				ws:           mocks.NewMockWorkspace(ctrl),
+				prompt:       climocks.NewMockprompter(ctrl),
+			}
+			tc.expect(opts)
+
+			// WHEN
+			err := opts.Ask()
+
+			// THEN
+			if tc.wantedErr != "" {
+				require.EqualError(t, err, tc.wantedErr)
+			} else {
+				require.Nil(t, err)
+			}
+			require.Equal(t, tc.wantedProjectName, opts.ProjectName)
+		})
+	}
+}
+
+func TestInitProjectOpts_Validate(t *testing.T) {
+	testCases := map[string]struct {
+		inProjectName string
+		wantedError   error
+	}{
+		"valid project name": {
+			inProjectName: "metrics",
+		},
+		"invalid project name": {
+			inProjectName: "123chicken",
+			wantedError:   errValueBadFormat,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			opts := &InitProjectOpts{
+				ProjectName: tc.inProjectName,
+			}
+
+			// WHEN
+			err := opts.Validate()
+
+			// THEN
+			require.True(t, errors.Is(err, tc.wantedError))
+		})
+	}
+}
+
+func TestInitProjectOpts_Execute(t *testing.T) {
 	mockError := fmt.Errorf("error")
-	var capturedArgument *archer.Project
-	defer ctrl.Finish()
 
 	testCases := map[string]struct {
-		initProjectOpts InitProjectOpts
 		expectedProject archer.Project
 		expectedError   error
-		mocking         func()
+		mocking         func(t *testing.T, mockProjectStore *mocks.MockProjectStore, mockWorkspace *mocks.MockWorkspace)
 	}{
-		"with a succesful call to add env": {
-			initProjectOpts: InitProjectOpts{
-				ProjectName: "project",
-				manager:     mockProjectStore,
-				ws:          mockWorkspace,
-			},
+		"with a succesfull call to add env": {
 			expectedProject: archer.Project{
 				Name: "project",
 			},
-			mocking: func() {
-				mockWorkspace.
-					EXPECT().
-					Create(gomock.Eq("project"))
+			mocking: func(t *testing.T, mockProjectStore *mocks.MockProjectStore, mockWorkspace *mocks.MockWorkspace) {
 				mockProjectStore.
 					EXPECT().
 					CreateProject(gomock.Any()).
 					Do(func(project *archer.Project) {
-						capturedArgument = project
+						require.Equal(t, project.Name, "project")
 					})
+				mockWorkspace.
+					EXPECT().
+					Create(gomock.Eq("project"))
 			},
 		},
-		"should return error from CreateProject": {
-			initProjectOpts: InitProjectOpts{
-				ProjectName: "project",
-				manager:     mockProjectStore,
-				ws:          mockWorkspace,
+
+		"should ignore ErrProjectAlreadyExists from CreateProject": {
+			expectedProject: archer.Project{
+				Name: "project",
 			},
+			mocking: func(t *testing.T, mockProjectStore *mocks.MockProjectStore, mockWorkspace *mocks.MockWorkspace) {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Any()).
+					Do(func(project *archer.Project) {
+						require.Equal(t, project.Name, "project")
+					}).
+					Return(&store.ErrProjectAlreadyExists{ProjectName: "project"})
+				mockWorkspace.
+					EXPECT().
+					Create(gomock.Any())
+			},
+		},
+
+		"should return error from CreateProject": {
 			expectedError: mockError,
-			mocking: func() {
+			mocking: func(t *testing.T, mockProjectStore *mocks.MockProjectStore, mockWorkspace *mocks.MockWorkspace) {
+				mockProjectStore.
+					EXPECT().
+					CreateProject(gomock.Any()).
+					Return(mockError)
 				mockWorkspace.
 					EXPECT().
 					Create(gomock.Any()).
 					Times(0)
-
-				mockProjectStore.
-					EXPECT().
-					CreateProject(gomock.Any()).
-					Return(mockError)
-
 			},
 		},
 
 		"should return error from workspace.Create": {
-			initProjectOpts: InitProjectOpts{
-				ProjectName: "project",
-				manager:     mockProjectStore,
-				ws:          mockWorkspace,
-			},
 			expectedError: mockError,
-			mocking: func() {
-				mockWorkspace.
-					EXPECT().
-					Create(gomock.Eq("project")).
-					Return(mockError)
+			mocking: func(t *testing.T, mockProjectStore *mocks.MockProjectStore, mockWorkspace *mocks.MockWorkspace) {
 				mockProjectStore.
 					EXPECT().
 					CreateProject(gomock.Any()).
 					Return(nil)
-
+				mockWorkspace.
+					EXPECT().
+					Create(gomock.Eq("project")).
+					Return(mockError)
 			},
-		},
-		"with invalid project name": {
-			initProjectOpts: InitProjectOpts{
-				ProjectName: "123chicken",
-				manager:     mockProjectStore,
-				ws:          mockWorkspace,
-			},
-			expectedError: errValueBadFormat,
-			mocking: func() {},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			// Setup mocks
-			tc.mocking()
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockProjectStore := mocks.NewMockProjectStore(ctrl)
+			mockWorkspace := mocks.NewMockWorkspace(ctrl)
 
-			err := tc.initProjectOpts.Execute()
+			opts := &InitProjectOpts{
+				ProjectName:  "project",
+				projectStore: mockProjectStore,
+				ws:           mockWorkspace,
+			}
+			tc.mocking(t, mockProjectStore, mockWorkspace)
+
+			// WHEN
+			err := opts.Execute()
+
+			// THEN
 			if tc.expectedError == nil {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedProject, *capturedArgument)
 			} else {
 				require.Equal(t, tc.expectedError, err)
 			}

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
+	// ManifestDirectoryName is the name of the directory where application manifests will be stored.
+	ManifestDirectoryName = "ecs-project"
+
 	workspaceSummaryFileName  = ".ecs-workspace"
-	manifestDirectoryName     = "ecs-project"
 	maximumParentDirsToSearch = 5
 	manifestFileSuffix        = "-app.yml"
 )
@@ -138,7 +140,7 @@ func (ws *Service) createManifestDirectory() error {
 	if existingWorkspace != "" {
 		return nil
 	}
-	return ws.fsUtils.Mkdir(manifestDirectoryName, 0755)
+	return ws.fsUtils.Mkdir(ManifestDirectoryName, 0755)
 }
 
 func (ws *Service) manifestDirectoryPath() (string, error) {
@@ -146,7 +148,7 @@ func (ws *Service) manifestDirectoryPath() (string, error) {
 		return ws.manifestDir, nil
 	}
 	// Are we in the manifest directory?
-	inEcsDir := filepath.Base(ws.workingDir) == manifestDirectoryName
+	inEcsDir := filepath.Base(ws.workingDir) == ManifestDirectoryName
 	if inEcsDir {
 		ws.manifestDir = ws.workingDir
 		return ws.manifestDir, nil
@@ -154,7 +156,7 @@ func (ws *Service) manifestDirectoryPath() (string, error) {
 
 	searchingDir := ws.workingDir
 	for try := 0; try < maximumParentDirsToSearch; try++ {
-		currentDirectoryPath := filepath.Join(searchingDir, manifestDirectoryName)
+		currentDirectoryPath := filepath.Join(searchingDir, ManifestDirectoryName)
 		inCurrentDirPath, err := ws.fsUtils.DirExists(currentDirectoryPath)
 		if err != nil {
 			return "", err
@@ -167,7 +169,7 @@ func (ws *Service) manifestDirectoryPath() (string, error) {
 	}
 	return "", &ErrWorkspaceNotFound{
 		CurrentDirectory:      ws.workingDir,
-		ManifestDirectoryName: manifestDirectoryName,
+		ManifestDirectoryName: ManifestDirectoryName,
 		NumberOfLevelsChecked: maximumParentDirsToSearch,
 	}
 }


### PR DESCRIPTION
This is a requirement for #109.  
Currently,  `project init` misses the additional work that we put into `init`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
