### PR TITLE
Consolidate the environment data models

### DIFF
--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -8,12 +8,12 @@ package archer
 // the location of the Environment (account and region), the name of the environment, as well as the project
 // the environment belongs to.
 type Environment struct {
-	Project     string `json:"project"`         // Name of the project this environment belongs to.
-	Name        string `json:"name" yaml:"env"` // Name of the environment, must be unique within a project.
-	Region      string `json:"region"`          // Name of the region this environment is stored in.
-	AccountID   string `json:"accountID"`       // Account ID of the account this environment is stored in.
-	Prod        bool   `json:"prod"`            // Whether or not this environment is a production environment.
-	RegistryURL string `json:"registryURL"`     // URL For ECR Registry for this environment.
+	Project     string `json:"project" yaml:"-"`     // Name of the project this environment belongs to.
+	Name        string `json:"name" yaml:"name"`     // Name of the environment, must be unique within a project.
+	Region      string `json:"region" yaml:"-"`      // Name of the region this environment is stored in.
+	AccountID   string `json:"accountID" yaml:"-"`   // Account ID of the account this environment is stored in.
+	Prod        bool   `json:"prod" yaml:"-"`        // Whether or not this environment is a production environment.
+	RegistryURL string `json:"registryURL" yaml:"-"` // URL For ECR Registry for this environment.
 }
 
 // DeployEnvironmentInput represents the fields required to setup and deploy an environment

--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -8,12 +8,12 @@ package archer
 // the location of the Environment (account and region), the name of the environment, as well as the project
 // the environment belongs to.
 type Environment struct {
-	Project     string `json:"project" yaml:"-"`     // Name of the project this environment belongs to.
-	Name        string `json:"name" yaml:"name"`     // Name of the environment, must be unique within a project.
-	Region      string `json:"region" yaml:"-"`      // Name of the region this environment is stored in.
-	AccountID   string `json:"accountID" yaml:"-"`   // Account ID of the account this environment is stored in.
-	Prod        bool   `json:"prod" yaml:"-"`        // Whether or not this environment is a production environment.
-	RegistryURL string `json:"registryURL" yaml:"-"` // URL For ECR Registry for this environment.
+	Project     string `json:"project"`     // Name of the project this environment belongs to.
+	Name        string `json:"name"`        // Name of the environment, must be unique within a project.
+	Region      string `json:"region"`      // Name of the region this environment is stored in.
+	AccountID   string `json:"accountID"`   // Account ID of the account this environment is stored in.
+	Prod        bool   `json:"prod"`        // Whether or not this environment is a production environment.
+	RegistryURL string `json:"registryURL"` // URL For ECR Registry for this environment.
 }
 
 // DeployEnvironmentInput represents the fields required to setup and deploy an environment

--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -8,12 +8,12 @@ package archer
 // the location of the Environment (account and region), the name of the environment, as well as the project
 // the environment belongs to.
 type Environment struct {
-	Project     string `json:"project"`     // Name of the project this environment belongs to.
-	Name        string `json:"name"`        // Name of the environment, must be unique within a project.
-	Region      string `json:"region"`      // Name of the region this environment is stored in.
-	AccountID   string `json:"accountID"`   // Account ID of the account this environment is stored in.
-	Prod        bool   `json:"prod"`        // Whether or not this environment is a production environment.
-	RegistryURL string `json:"registryURL"` // URL For ECR Registry for this environment.
+	Project     string `json:"project"`         // Name of the project this environment belongs to.
+	Name        string `json:"name" yaml:"env"` // Name of the environment, must be unique within a project.
+	Region      string `json:"region"`          // Name of the region this environment is stored in.
+	AccountID   string `json:"accountID"`       // Account ID of the account this environment is stored in.
+	Prod        bool   `json:"prod"`            // Whether or not this environment is a production environment.
+	RegistryURL string `json:"registryURL"`     // URL For ECR Registry for this environment.
 }
 
 // DeployEnvironmentInput represents the fields required to setup and deploy an environment

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -76,7 +76,7 @@ const (
 type PipelineManifest struct {
 	Version      PipelineSchemaMajorVersion `yaml:"version"`
 	Source       *Source                    `yaml:"source"`
-	Environments []PipelineStage            `yaml:"stages"`
+	Environments []archer.Environment       `yaml:"stages"`
 }
 
 // Source defines the source of the artifacts to be built and deployed.
@@ -85,18 +85,12 @@ type Source struct {
 	Properties   map[string]interface{} `yaml:"properties"`
 }
 
-// PipelineStage represents configuration for each deployment stage
-// of an application.
-type PipelineStage struct {
-	Name string `yaml:"env"`
-}
-
 // CreatePipeline returns a pipeline manifest object.
-func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest, error) {
+func CreatePipeline(provider Provider, stages ...archer.Environment) (archer.Manifest, error) {
 	// TODO: #221 Do more validations
-	var defaultStages []PipelineStage
+	var defaultStages []archer.Environment
 	if len(stages) == 0 {
-		defaultStages = []PipelineStage{
+		defaultStages = []archer.Environment{
 			{
 				Name: "test",
 			},

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -74,9 +74,9 @@ const (
 // PipelineManifest contains information that defines the relationship
 // and deployment ordering of your environments.
 type PipelineManifest struct {
-	Version      PipelineSchemaMajorVersion `yaml:"version"`
-	Source       *Source                    `yaml:"source"`
-	Environments []PipelineStage            `yaml:"stages"`
+	Version PipelineSchemaMajorVersion `yaml:"version"`
+	Source  *Source                    `yaml:"source"`
+	Stages  []PipelineStage            `yaml:"stages"`
 }
 
 // Source defines the source of the artifacts to be built and deployed.
@@ -118,7 +118,7 @@ func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest
 			ProviderName: provider.Name(),
 			Properties:   provider.Properties(),
 		},
-		Environments: append(defaultStages, stages...),
+		Stages: append(defaultStages, stages...),
 	}, nil
 }
 

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -71,9 +71,9 @@ const (
 	Ver1 PipelineSchemaMajorVersion = iota + 1
 )
 
-// PipelineManifest contains information that defines the relationship
+// pipelineManifest contains information that defines the relationship
 // and deployment ordering of your environments.
-type PipelineManifest struct {
+type pipelineManifest struct {
 	Version PipelineSchemaMajorVersion `yaml:"version"`
 	Source  *Source                    `yaml:"source"`
 	Stages  []PipelineStage            `yaml:"stages"`
@@ -122,7 +122,7 @@ func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest
 		}
 	}
 
-	return &PipelineManifest{
+	return &pipelineManifest{
 		Version: Ver1,
 		Source: &Source{
 			ProviderName: provider.Name(),
@@ -134,7 +134,7 @@ func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest
 
 // Marshal serializes the pipeline manifest object into byte array that
 // represents the pipeline.yml document.
-func (m *PipelineManifest) Marshal() ([]byte, error) {
+func (m *pipelineManifest) Marshal() ([]byte, error) {
 	box := templates.Box()
 	content, err := box.FindString("cicd/pipeline.yml")
 	if err != nil {
@@ -155,7 +155,7 @@ func (m *PipelineManifest) Marshal() ([]byte, error) {
 // manifest object. It returns an error if any issue occurs during
 // deserialization or the YAML input contains invalid fields.
 func UnmarshalPipeline(in []byte) (archer.Manifest, error) {
-	pm := PipelineManifest{}
+	pm := pipelineManifest{}
 	err := yaml.Unmarshal(in, &pm)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func UnmarshalPipeline(in []byte) (archer.Manifest, error) {
 	return nil, errors.New("unexpected error occurs while unmarshalling pipeline.yml")
 }
 
-func validateVersion(pm *PipelineManifest) (PipelineSchemaMajorVersion, error) {
+func validateVersion(pm *pipelineManifest) (PipelineSchemaMajorVersion, error) {
 	switch pm.Version {
 	case Ver1:
 		return Ver1, nil
@@ -188,7 +188,7 @@ func validateVersion(pm *PipelineManifest) (PipelineSchemaMajorVersion, error) {
 }
 
 // CFNTemplate serializes the manifest object into a CloudFormation template.
-func (m *PipelineManifest) CFNTemplate() (string, error) {
+func (m *pipelineManifest) CFNTemplate() (string, error) {
 	// TODO: #223 Generate CFN template for the archer pipeline
 	return "", nil
 }

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -89,8 +89,18 @@ type Source struct {
 // of a workspace. A stage consists of the Archer Environment the pipeline
 // is deloying to and the containerized applications that will be deployed.
 type PipelineStage struct {
-	*archer.Environment `yaml:",inline"`
-	Applications        []*archer.Application `yaml:"-"`
+	*AssociatedEnvironment `yaml:",inline"`
+	Applications           []*archer.Application `yaml:"-"`
+}
+
+// AssociatedEnvironment defines the necessary information a pipline stage
+// needs for an Archer Environment.
+type AssociatedEnvironment struct {
+	Project   string `yaml:"-"`    // Name of the project this environment belongs to.
+	Name      string `yaml:"name"` // Name of the environment, must be unique within a project.
+	Region    string `yaml:"-"`    // Name of the region this environment is stored in.
+	AccountID string `yaml:"-"`    // Account ID of the account this environment is stored in.
+	Prod      bool   `yaml:"-"`    // Whether or not this environment is a production environment.
 }
 
 // CreatePipeline returns a pipeline manifest object.
@@ -100,12 +110,12 @@ func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest
 	if len(stages) == 0 {
 		defaultStages = []PipelineStage{
 			{
-				Environment: &archer.Environment{
+				AssociatedEnvironment: &AssociatedEnvironment{
 					Name: "test",
 				},
 			},
 			{
-				Environment: &archer.Environment{
+				AssociatedEnvironment: &AssociatedEnvironment{
 					Name: "prod",
 				},
 			},

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -76,7 +76,7 @@ const (
 type PipelineManifest struct {
 	Version      PipelineSchemaMajorVersion `yaml:"version"`
 	Source       *Source                    `yaml:"source"`
-	Environments []archer.Environment       `yaml:"stages"`
+	Environments []PipelineStage            `yaml:"stages"`
 }
 
 // Source defines the source of the artifacts to be built and deployed.
@@ -85,17 +85,29 @@ type Source struct {
 	Properties   map[string]interface{} `yaml:"properties"`
 }
 
+// PipelineStage represents configuration for each deployment stage
+// of a workspace. A stage consists of the Archer Environment the pipeline
+// is deloying to and the containerized applications that will be deployed.
+type PipelineStage struct {
+	*archer.Environment `yaml:",inline"`
+	Applications        []*archer.Application `yaml:"-"`
+}
+
 // CreatePipeline returns a pipeline manifest object.
-func CreatePipeline(provider Provider, stages ...archer.Environment) (archer.Manifest, error) {
+func CreatePipeline(provider Provider, stages ...PipelineStage) (archer.Manifest, error) {
 	// TODO: #221 Do more validations
-	var defaultStages []archer.Environment
+	var defaultStages []PipelineStage
 	if len(stages) == 0 {
-		defaultStages = []archer.Environment{
+		defaultStages = []PipelineStage{
 			{
-				Name: "test",
+				Environment: &archer.Environment{
+					Name: "test",
+				},
 			},
 			{
-				Name: "prod",
+				Environment: &archer.Environment{
+					Name: "prod",
+				},
 			},
 		}
 	}

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -43,8 +43,8 @@ func TestCreatePipeline(t *testing.T) {
 		beforeEach     func() error
 		provider       Provider
 		expectedErr    error
-		inputStages    []archer.Environment
-		expectedStages []archer.Environment
+		inputStages    []PipelineStage
+		expectedStages []PipelineStage
 	}{
 		"happy case with default stages": {
 			provider: func() Provider {
@@ -55,12 +55,16 @@ func TestCreatePipeline(t *testing.T) {
 				require.NoError(t, err, "failed to create provider")
 				return p
 			}(),
-			expectedStages: []archer.Environment{
+			expectedStages: []PipelineStage{
 				{
-					Name: "test",
+					Environment: &archer.Environment{
+						Name: "test",
+					},
 				},
 				{
-					Name: "prod",
+					Environment: &archer.Environment{
+						Name: "prod",
+					},
 				},
 			},
 		},
@@ -73,20 +77,28 @@ func TestCreatePipeline(t *testing.T) {
 				require.NoError(t, err, "failed to create provider")
 				return p
 			}(),
-			inputStages: []archer.Environment{
+			inputStages: []PipelineStage{
 				{
-					Name: "chicken",
+					Environment: &archer.Environment{
+						Name: "chicken",
+					},
 				},
 				{
-					Name: "wings",
+					Environment: &archer.Environment{
+						Name: "wings",
+					},
 				},
 			},
-			expectedStages: []archer.Environment{
+			expectedStages: []PipelineStage{
 				{
-					Name: "chicken",
+					Environment: &archer.Environment{
+						Name: "chicken",
+					},
 				},
 				{
-					Name: "wings",
+					Environment: &archer.Environment{
+						Name: "wings",
+					},
 				},
 			},
 		},
@@ -128,10 +140,10 @@ source:
 stages:
     - 
       # The name of the environment to deploy to.
-      env: test
+      name: test
     - 
       # The name of the environment to deploy to.
-      env: prod
+      name: prod
 `
 	// reset the global map before each test case is run
 	provider, err := NewProvider(&GithubProperties{
@@ -166,9 +178,9 @@ source:
 
 stages:
     - 
-      env: test
+      name: test
     - 
-      env: prod
+      name: prod
 `,
 			expectedErr: &ErrInvalidPipelineManifestVersion{
 				PipelineSchemaMajorVersion(-1),
@@ -190,9 +202,9 @@ source:
 
 stages:
     - 
-      env: chicken
+      name: chicken
     - 
-      env: wings
+      name: wings
 `,
 			expectedManifest: &PipelineManifest{
 				Version: Ver1,
@@ -203,12 +215,16 @@ stages:
 						"branch":     "master",
 					},
 				},
-				Environments: []archer.Environment{
+				Environments: []PipelineStage{
 					{
-						Name: "chicken",
+						Environment: &archer.Environment{
+							Name: "chicken",
+						},
 					},
 					{
-						Name: "wings",
+						Environment: &archer.Environment{
+							Name: "wings",
+						},
 					},
 				},
 			},

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -110,7 +110,7 @@ func TestCreatePipeline(t *testing.T) {
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {
-				p, ok := m.(*PipelineManifest)
+				p, ok := m.(*pipelineManifest)
 				require.True(t, ok)
 				require.Equal(t, tc.expectedStages, p.Stages, "the stages are different from the expected")
 			}
@@ -162,7 +162,7 @@ stages:
 func TestUnmarshalPipeline(t *testing.T) {
 	testCases := map[string]struct {
 		inContent        string
-		expectedManifest *PipelineManifest
+		expectedManifest *pipelineManifest
 		expectedErr      error
 	}{
 		"invalid pipeline schema version": {
@@ -187,7 +187,7 @@ stages:
 		},
 		"invalid pipeline.yml": {
 			inContent:   `corrupted yaml`,
-			expectedErr: errors.New("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `corrupt...` into manifest.PipelineManifest"),
+			expectedErr: errors.New("yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `corrupt...` into manifest.pipelineManifest"),
 		},
 		"valid pipeline.yml": {
 			inContent: `
@@ -205,7 +205,7 @@ stages:
     - 
       name: wings
 `,
-			expectedManifest: &PipelineManifest{
+			expectedManifest: &pipelineManifest{
 				Version: Ver1,
 				Source: &Source{
 					ProviderName: "github",
@@ -237,7 +237,7 @@ stages:
 			if tc.expectedErr != nil {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			} else {
-				actualManifest, ok := m.(*PipelineManifest)
+				actualManifest, ok := m.(*pipelineManifest)
 				require.True(t, ok)
 				require.Equal(t, actualManifest, tc.expectedManifest)
 			}

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -42,8 +43,8 @@ func TestCreatePipeline(t *testing.T) {
 		beforeEach     func() error
 		provider       Provider
 		expectedErr    error
-		inputStages    []PipelineStage
-		expectedStages []PipelineStage
+		inputStages    []archer.Environment
+		expectedStages []archer.Environment
 	}{
 		"happy case with default stages": {
 			provider: func() Provider {
@@ -54,7 +55,7 @@ func TestCreatePipeline(t *testing.T) {
 				require.NoError(t, err, "failed to create provider")
 				return p
 			}(),
-			expectedStages: []PipelineStage{
+			expectedStages: []archer.Environment{
 				{
 					Name: "test",
 				},
@@ -72,7 +73,7 @@ func TestCreatePipeline(t *testing.T) {
 				require.NoError(t, err, "failed to create provider")
 				return p
 			}(),
-			inputStages: []PipelineStage{
+			inputStages: []archer.Environment{
 				{
 					Name: "chicken",
 				},
@@ -80,7 +81,7 @@ func TestCreatePipeline(t *testing.T) {
 					Name: "wings",
 				},
 			},
-			expectedStages: []PipelineStage{
+			expectedStages: []archer.Environment{
 				{
 					Name: "chicken",
 				},
@@ -202,7 +203,7 @@ stages:
 						"branch":     "master",
 					},
 				},
-				Environments: []PipelineStage{
+				Environments: []archer.Environment{
 					{
 						Name: "chicken",
 					},

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,12 +56,12 @@ func TestCreatePipeline(t *testing.T) {
 			}(),
 			expectedStages: []PipelineStage{
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "test",
 					},
 				},
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "prod",
 					},
 				},
@@ -79,24 +78,24 @@ func TestCreatePipeline(t *testing.T) {
 			}(),
 			inputStages: []PipelineStage{
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "chicken",
 					},
 				},
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "wings",
 					},
 				},
 			},
 			expectedStages: []PipelineStage{
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "chicken",
 					},
 				},
 				{
-					Environment: &archer.Environment{
+					AssociatedEnvironment: &AssociatedEnvironment{
 						Name: "wings",
 					},
 				},
@@ -217,12 +216,12 @@ stages:
 				},
 				Stages: []PipelineStage{
 					{
-						Environment: &archer.Environment{
+						AssociatedEnvironment: &AssociatedEnvironment{
 							Name: "chicken",
 						},
 					},
 					{
-						Environment: &archer.Environment{
+						AssociatedEnvironment: &AssociatedEnvironment{
 							Name: "wings",
 						},
 					},

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -113,7 +113,7 @@ func TestCreatePipeline(t *testing.T) {
 			} else {
 				p, ok := m.(*PipelineManifest)
 				require.True(t, ok)
-				require.Equal(t, tc.expectedStages, p.Environments, "the environments are different from the expected")
+				require.Equal(t, tc.expectedStages, p.Stages, "the stages are different from the expected")
 			}
 		})
 	}
@@ -215,7 +215,7 @@ stages:
 						"branch":     "master",
 					},
 				},
-				Environments: []PipelineStage{
+				Stages: []PipelineStage{
 					{
 						Environment: &archer.Environment{
 							Name: "chicken",

--- a/templates/cicd/pipeline.yml
+++ b/templates/cicd/pipeline.yml
@@ -11,10 +11,10 @@ source:
   # the artifacts should be sourced from.
   properties:{{range $key, $value := .Source.Properties}}
     {{$key}}: {{$value}}{{end}}
-{{$length := len .Environments}}{{if gt $length 0}}
+{{$length := len .Stages}}{{if gt $length 0}}
 # The deployment section defines the order the pipeline will deploy
 # to your environments
-stages:{{range .Environments}}
+stages:{{range .Stages}}
     - 
       # The name of the environment to deploy to.
       name: {{.Name}}{{end}}

--- a/templates/cicd/pipeline.yml
+++ b/templates/cicd/pipeline.yml
@@ -17,5 +17,5 @@ source:
 stages:{{range .Environments}}
     - 
       # The name of the environment to deploy to.
-      env: {{.Name}}{{end}}
+      name: {{.Name}}{{end}}
 {{end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
It consolidates the 2 environment data models into one so that we don't have 2 data models for the same type of entity: Archer Environment.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
This PR fixes #231 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
