### PR TITLE
Use "/code " to highlight code samples in cmd examples

### DIFF
--- a/cmd/archer/template/macro.go
+++ b/cmd/archer/template/macro.go
@@ -30,9 +30,8 @@ func h2(text string) string {
 func code(text string) string {
 	lines := strings.Split(text, "\n")
 	for i, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), "$") {
-			// code sample
-			lines[i] = color.HiBlackString(line)
+		if strings.HasPrefix(strings.TrimSpace(line), "/code ") {
+			lines[i] = color.HiBlackString(strings.ReplaceAll(line, "/code ", ""))
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -224,7 +224,7 @@ func BuildAppInitCmd() *cobra.Command {
 This command is also run as part of "archer init".`,
 		Example: `
   Create a "frontend" web application.
-  $ archer app init --name frontend --app-type "Load Balanced Web App" --dockerfile ./frontend/Dockerfile`,
+  /code $ archer app init --name frontend --app-type "Load Balanced Web App" --dockerfile ./frontend/Dockerfile`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.projectName = viper.GetString(projectFlag) // inject from parent command
 			opts.fs = &afero.Afero{Fs: afero.NewOsFs()}

--- a/internal/pkg/cli/completion.go
+++ b/internal/pkg/cli/completion.go
@@ -57,16 +57,16 @@ func BuildCompletionCmd() *cobra.Command {
 The code must be evaluated to provide interactive completion of commands.`,
 		Example: `
   Install zsh completion
-  $ source <(archer completion zsh)
-  $ archer completion zsh > "${fpath[1]}/_archer" # to autoload on startup
+  /code $ source <(archer completion zsh)
+  /code $ archer completion zsh > "${fpath[1]}/_archer" # to autoload on startup
 
   Install bash completion on macOS using homebrew
-  $ brew install bash-completion   # if running 3.2
-  $ brew install bash-completion@2 # if running Bash 4.1+
-  $ archer completion bash > /usr/local/etc/bash_completion.d
+  /code $ brew install bash-completion   # if running 3.2
+  /code $ brew install bash-completion@2 # if running Bash 4.1+
+  /code $ archer completion bash > /usr/local/etc/bash_completion.d
 
   Install bash completion on linux
-  $ source <(archer completion bash)`,
+  /code $ source <(archer completion bash)`,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Shell = args[0]

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -125,10 +125,10 @@ func BuildEnvInitCmd() *cobra.Command {
 		Short: "Create a new environment in your project.",
 		Example: `
   Create a test environment in your "default" AWS profile
-  $ archer env init test
+  /code $ archer env init test
 
   Create a prod-iad environment using your "prod-admin" AWS profile
-  $ archer env init prod-iad --profile prod-admin --prod`,
+  /code $ archer env init prod-iad --profile prod-admin --prod`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				opts.EnvName = args[0]

--- a/internal/pkg/cli/env_list.go
+++ b/internal/pkg/cli/env_list.go
@@ -82,7 +82,7 @@ func BuildEnvListCmd() *cobra.Command {
 		Short: "Lists all the environments in a project",
 		Example: `
   Lists all the environments for the test project
-  $ archer env ls --project test`,
+  /code $ archer env ls --project test`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.ProjectName = viper.GetString("project")
 			return opts.Ask()

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -152,7 +152,7 @@ func BuildProjectInitCommand() *cobra.Command {
 A project is a collection of containerized applications (or micro-services) that operate together.`,
 		Example: `
   Create a new project named test
-  $ archer project init test`,
+  /code $ archer project init test`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return err
 		},

--- a/internal/pkg/cli/project_list.go
+++ b/internal/pkg/cli/project_list.go
@@ -43,7 +43,7 @@ func BuildProjectListCommand() *cobra.Command {
 		Short: "Lists all projects in your account",
 		Example: `
   List all the projects in your account and region
-  $ archer project ls`,
+  /code $ archer project ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ssmStore, err := ssm.NewStore()
 			if err != nil {


### PR DESCRIPTION
Sometimes we want the examples in the commands to **not** start with "$" (for example #229)

Start example code highlights with "/code " instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
