### PR TITLE
Refactor Init to use InitEnv cmd internally

### DIFF
--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -12,6 +12,7 @@ import (
 	archerMocks "github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -164,11 +165,11 @@ func TestAppInitOpts_Validate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
+			viper.Set(projectFlag, tc.inProjectName)
 			opts := InitAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
-				projectName:    tc.inProjectName,
 				fs:             &afero.Afero{Fs: afero.NewMemMapFs()},
 			}
 			if tc.mockFileSystem != nil {

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -160,7 +160,6 @@ func BuildEnvInitCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Warningln("It's best to run this command in the root of your workspace.")
 			if err := opts.Ask(); err != nil {
 				return err
 			}

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
 	"github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,15 +47,18 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			viper.Set(projectFlag, tc.inputProject)
 			addEnv := &InitEnvOpts{
-				EnvName:     tc.inputEnv,
-				projectName: tc.inputProject,
-				prompt:      mockPrompter,
+				EnvName: tc.inputEnv,
+				prompt:  mockPrompter,
 			}
 			tc.setupMocks()
 
+			// WHEN
 			err := addEnv.Ask()
 
+			// THEN
 			require.NoError(t, err)
 			require.Equal(t, mockEnv, addEnv.EnvName, "expected environment names to match")
 		})
@@ -89,9 +93,9 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
+			viper.Set(projectFlag, tc.inProjectName)
 			opts := &InitEnvOpts{
-				EnvName:     tc.inEnvName,
-				projectName: tc.inProjectName,
+				EnvName: tc.inEnvName,
 			}
 
 			// WHEN
@@ -201,12 +205,12 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			mockSpinner := climocks.NewMockprogress(ctrl)
 			mockIdentityService := climocks.NewMockidentityService(ctrl)
 
+			viper.Set(projectFlag, "project")
 			opts := &InitEnvOpts{
 				envCreator:    mockEnvStore,
 				projectGetter: mockProjStore,
 				envDeployer:   mockDeployer,
 				identity:      mockIdentityService,
-				projectName:   "project",
 				EnvName:       "env",
 				IsProduction:  true,
 				prog:          mockSpinner,

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -4,13 +4,13 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/identity"
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
 	"github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -108,17 +108,6 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 }
 
 func TestInitEnvOpts_Execute(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockEnvStore := mocks.NewMockEnvironmentStore(ctrl)
-	mockProjStore := mocks.NewMockProjectStore(ctrl)
-	mockDeployer := mocks.NewMockEnvironmentDeployer(ctrl)
-	mockSpinner := climocks.NewMockprogress(ctrl)
-	mockIdentityService := climocks.NewMockidentityService(ctrl)
-
-	var capturedArgument *archer.Environment
-
 	mockError := fmt.Errorf("error")
 	mockARN := "mockARN"
 	mockCaller := identity.Caller{
@@ -126,43 +115,23 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		addEnvOpts  InitEnvOpts
-		expectedEnv archer.Environment
 		expectedErr error
-		mocking     func()
+		mocking     func(t *testing.T, opts *InitEnvOpts)
 	}{
-		"with a succesful call to add env": {
-			addEnvOpts: InitEnvOpts{
-				envCreator:    mockEnvStore,
-				projectGetter: mockProjStore,
-				envDeployer:   mockDeployer,
-				projectName:   "project",
-				EnvName:       "env",
-				IsProduction:  true,
-				prog:          mockSpinner,
-				identity:      mockIdentityService,
-			},
-			expectedEnv: archer.Environment{
-				Name:        "env",
-				Project:     "project",
-				AccountID:   "1234",
-				Region:      "1234",
-				RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
-				Prod:        true,
-			},
-			mocking: func() {
+		"with a successful call to add env": {
+			mocking: func(t *testing.T, opts *InitEnvOpts) {
 				gomock.InOrder(
-					mockProjStore.
+					opts.projectGetter.(*mocks.MockProjectStore).
 						EXPECT().
 						GetProject(gomock.Any()).
 						Return(&archer.Project{}, nil),
-					mockIdentityService.EXPECT().Get().Times(1).Return(mockCaller, nil),
-					mockSpinner.EXPECT().Start(gomock.Eq("Preparing deployment...")),
-					mockDeployer.EXPECT().DeployEnvironment(gomock.Any()),
-					mockSpinner.EXPECT().Stop(gomock.Eq("Done!")),
-					mockSpinner.EXPECT().Start(gomock.Eq("Deploying env...")),
+					opts.identity.(*climocks.MockidentityService).EXPECT().Get().Times(1).Return(mockCaller, nil),
+					opts.prog.(*climocks.Mockprogress).EXPECT().Start(gomock.Eq("Preparing deployment...")),
+					opts.envDeployer.(*mocks.MockEnvironmentDeployer).EXPECT().DeployEnvironment(gomock.Any()),
+					opts.prog.(*climocks.Mockprogress).EXPECT().Stop(gomock.Eq("Done!")),
+					opts.prog.(*climocks.Mockprogress).EXPECT().Start(gomock.Eq("Deploying env...")),
 					// TODO: Assert Wait is called with stack name returned by DeployEnvironment.
-					mockDeployer.EXPECT().
+					opts.envDeployer.(*mocks.MockEnvironmentDeployer).EXPECT().
 						WaitForEnvironmentCreation(gomock.Any()).
 						Return(&archer.Environment{
 							Name:        "env",
@@ -172,41 +141,49 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 							RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
 							Prod:        true,
 						}, nil),
-					mockEnvStore.
+					opts.envCreator.(*mocks.MockEnvironmentStore).
 						EXPECT().
 						CreateEnvironment(gomock.Any()).
 						Do(func(env *archer.Environment) {
-							capturedArgument = env
+							require.Equal(t, &archer.Environment{
+								Name:        "env",
+								Project:     "project",
+								AccountID:   "1234",
+								Region:      "1234",
+								RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
+								Prod:        true,
+							}, env)
 						}),
-					mockSpinner.EXPECT().Stop(gomock.Eq("Done!")),
+					opts.prog.(*climocks.Mockprogress).EXPECT().Stop(gomock.Eq("Done!")),
 				)
 			},
 		},
+		"with an existing environment": {
+			mocking: func(t *testing.T, opts *InitEnvOpts) {
+				opts.projectGetter.(*mocks.MockProjectStore).
+					EXPECT().
+					GetProject(gomock.Any()).
+					Return(&archer.Project{}, nil)
+				opts.identity.(*climocks.MockidentityService).EXPECT().Get().Return(mockCaller, nil)
+				opts.prog.(*climocks.Mockprogress).EXPECT().Start(gomock.Eq("Preparing deployment..."))
+				opts.envDeployer.(*mocks.MockEnvironmentDeployer).EXPECT().
+					DeployEnvironment(gomock.Any()).
+					Return(&cloudformation.ErrStackAlreadyExists{})
+				opts.prog.(*climocks.Mockprogress).EXPECT().Stop(gomock.Eq("Done!"))
+				opts.envCreator.(*mocks.MockEnvironmentStore).
+					EXPECT().
+					CreateEnvironment(gomock.Any()).
+					Times(0)
+			},
+		},
 		"with an invalid project": {
-			expectedErr: errors.New("retrieve project project: error"),
-			addEnvOpts: InitEnvOpts{
-				envCreator:    mockEnvStore,
-				projectGetter: mockProjStore,
-				envDeployer:   mockDeployer,
-				projectName:   "project",
-				EnvName:       "env",
-				IsProduction:  true,
-				prog:          mockSpinner,
-			},
-			expectedEnv: archer.Environment{
-				Name:        "env",
-				Project:     "project",
-				AccountID:   "1234",
-				Region:      "1234",
-				RegistryURL: "902697171733.dkr.ecr.eu-west-3.amazonaws.com/project/env",
-				Prod:        true,
-			},
-			mocking: func() {
-				mockProjStore.
+			expectedErr: mockError,
+			mocking: func(t *testing.T, opts *InitEnvOpts) {
+				opts.projectGetter.(*mocks.MockProjectStore).
 					EXPECT().
 					GetProject(gomock.Any()).
 					Return(nil, mockError)
-				mockEnvStore.
+				opts.envCreator.(*mocks.MockEnvironmentStore).
 					EXPECT().
 					CreateEnvironment(gomock.Any()).
 					Times(0)
@@ -215,13 +192,31 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			// Setup mocks
-			tc.mocking()
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockEnvStore := mocks.NewMockEnvironmentStore(ctrl)
+			mockProjStore := mocks.NewMockProjectStore(ctrl)
+			mockDeployer := mocks.NewMockEnvironmentDeployer(ctrl)
+			mockSpinner := climocks.NewMockprogress(ctrl)
+			mockIdentityService := climocks.NewMockidentityService(ctrl)
 
-			err := tc.addEnvOpts.Execute()
+			opts := &InitEnvOpts{
+				envCreator:    mockEnvStore,
+				projectGetter: mockProjStore,
+				envDeployer:   mockDeployer,
+				identity:      mockIdentityService,
+				projectName:   "project",
+				EnvName:       "env",
+				IsProduction:  true,
+				prog:          mockSpinner,
+			}
+			tc.mocking(t, opts)
+
+			// WHEN
+			err := opts.Execute()
 			if tc.expectedErr == nil {
 				require.NoError(t, err)
-				require.Equal(t, tc.expectedEnv, *capturedArgument)
 			} else {
 				require.EqualError(t, err, tc.expectedErr.Error())
 			}

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -51,7 +51,10 @@ func validateApplicationType(val interface{}) error {
 }
 
 func validateEnvironmentName(val interface{}) error {
-	return basicNameValidation(val)
+	if err := basicNameValidation(val); err != nil {
+		return fmt.Errorf("environment name %v is invalid: %w", val, err)
+	}
+	return nil
 }
 
 func basicNameValidation(val interface{}) error {

--- a/internal/pkg/store/ssm/ssm_test.go
+++ b/internal/pkg/store/ssm/ssm_test.go
@@ -453,9 +453,7 @@ func TestStore_GetEnvironment(t *testing.T) {
 		"with no existing environment": {
 			mockGetParameter: func(t *testing.T, param *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 				require.Equal(t, testEnvironmentPath, *param.Name)
-				return &ssm.GetParameterOutput{
-					Parameter: &ssm.Parameter{},
-				}, nil
+				return nil, awserr.New(ssm.ErrCodeParameterNotFound, "bloop", nil)
 			},
 			wantedErr: &store.ErrNoSuchEnvironment{
 				ProjectName:     testEnvironment.Project,


### PR DESCRIPTION
Resolves #109

We now call `env init` from within `archer init` which removes duplicate code across two commands.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
