### PR TITLE
Add newline to version outputs

### DIFF
--- a/cmd/archer/main.go
+++ b/cmd/archer/main.go
@@ -44,13 +44,19 @@ func buildRootCmd() *cobra.Command {
 	// Sets version for --version flag. Version command gives more detailed
 	// version information.
 	cmd.Version = version.Version
-	cmd.SetVersionTemplate(template.VersionFlag)
+	cmd.SetVersionTemplate("Archer version: {{.Version}}\n")
 
-	cmd.AddCommand(cli.BuildVersionCmd())
+	// NOTE: Order for each grouping below is significant in that it affects help menu output ordering.
+	// "Getting Started" command group.
 	cmd.AddCommand(cli.BuildInitCmd())
+
+	// "Develop" command group.
 	cmd.AddCommand(cli.BuildProjCmd())
 	cmd.AddCommand(cli.BuildEnvCmd())
 	cmd.AddCommand(cli.BuildAppCmd())
+
+	// "Settings" command group.
+	cmd.AddCommand(cli.BuildVersionCmd())
 	cmd.AddCommand(cli.BuildCompletionCmd())
 
 	cmd.SetUsageTemplate(template.RootUsage)

--- a/cmd/archer/template/version.go
+++ b/cmd/archer/template/version.go
@@ -1,7 +1,0 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-// Package template provides usage templates to render help menus.
-package template
-
-const VersionFlag = `Archer version: {{.Version}}`

--- a/internal/pkg/cli/version.go
+++ b/internal/pkg/cli/version.go
@@ -7,6 +7,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/group"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,10 @@ func BuildVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print the version number of Archer",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Archer version: %s, built for %s", version.Version, version.Platform)
+			fmt.Printf("Archer version: %s, built for %s\n", version.Version, version.Platform)
+		},
+		Annotations: map[string]string{
+			"group": group.Settings,
 		},
 	}
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Before:
```bash
$ ./bin/local/archer --version
Archer version: 82ad210$ ./bin/local/archer version
Archer version: 82ad210, built for local$
```

After:
```bash
$ ./bin/local/archer --version
Archer version: 7456c88
$ ./bin/local/archer version
Archer version: 7456c88, built for local
$  
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
