### PR TITLE
Move DeployEnvironmentInput to the deploy pkg

### DIFF
--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -6,9 +6,8 @@ package archer
 
 import "github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 
-// Environment represents the configuration of a particular Environment in a Project. It includes
-// the location of the Environment (account and region), the name of the environment, as well as the project
-// the environment belongs to.
+// Environment represents the configuration of a particular environment in a project. It includes
+// the environment's account and region, name, as well as the project it belongs to.
 type Environment struct {
 	Project     string `json:"project"`     // Name of the project this environment belongs to.
 	Name        string `json:"name"`        // Name of the environment, must be unique within a project.
@@ -42,6 +41,6 @@ type EnvironmentCreator interface {
 
 // EnvironmentDeployer can deploy an environment
 type EnvironmentDeployer interface {
-	DeployEnvironment(env *deploy.DeployEnvironmentInput) error
-	WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*Environment, error)
+	DeployEnvironment(env *deploy.CreateEnvironmentInput) error
+	WaitForEnvironmentCreation(env *deploy.CreateEnvironmentInput) (*Environment, error)
 }

--- a/internal/pkg/archer/env.go
+++ b/internal/pkg/archer/env.go
@@ -4,6 +4,8 @@
 // Package archer contains the structs that represent archer concepts, and the associated interfaces to manipulate them.
 package archer
 
+import "github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
+
 // Environment represents the configuration of a particular Environment in a Project. It includes
 // the location of the Environment (account and region), the name of the environment, as well as the project
 // the environment belongs to.
@@ -14,15 +16,6 @@ type Environment struct {
 	AccountID   string `json:"accountID"`   // Account ID of the account this environment is stored in.
 	Prod        bool   `json:"prod"`        // Whether or not this environment is a production environment.
 	RegistryURL string `json:"registryURL"` // URL For ECR Registry for this environment.
-}
-
-// DeployEnvironmentInput represents the fields required to setup and deploy an environment
-type DeployEnvironmentInput struct {
-	Project                  string // Name of the project this environment belongs to.
-	Name                     string // Name of the environment, must be unique within a project.
-	Prod                     bool   // Whether or not this environment is a production environment.
-	PublicLoadBalancer       bool   // Whether or not this environment should contain a shared public load balancer between applications.
-	ToolsAccountPrincipalARN string // The Principal ARN of the tools account.
 }
 
 // EnvironmentStore can List, Create and Get environments in an underlying project management store
@@ -49,6 +42,6 @@ type EnvironmentCreator interface {
 
 // EnvironmentDeployer can deploy an environment
 type EnvironmentDeployer interface {
-	DeployEnvironment(env *DeployEnvironmentInput) error
-	WaitForEnvironmentCreation(env *DeployEnvironmentInput) (*Environment, error)
+	DeployEnvironment(env *deploy.DeployEnvironmentInput) error
+	WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*Environment, error)
 }

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -26,7 +26,7 @@ type PackageAppOpts struct {
 func NewPackageAppOpts() *PackageAppOpts {
 	commitID, err := exec.Command("git", "rev-parse", "--short", "HEAD").CombinedOutput()
 	if err != nil {
-		// If we can't retrieve a commit ID we default the image tag to 'latest'
+		// If we can't retrieve a commit ID we default the image tag to "latest".
 		return &PackageAppOpts{
 			Tag:    "latest",
 			prompt: prompt.New(),

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -78,7 +78,7 @@ func (opts *InitEnvOpts) Execute() error {
 		return fmt.Errorf("get identity: %w", err)
 	}
 
-	deployEnvInput := &deploy.DeployEnvironmentInput{
+	deployEnvInput := &deploy.CreateEnvironmentInput{
 		Name:                     opts.EnvName,
 		Project:                  viper.GetString(projectFlag),
 		Prod:                     opts.IsProduction,

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/identity"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store/ssm"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
@@ -77,7 +78,7 @@ func (opts *InitEnvOpts) Execute() error {
 		return fmt.Errorf("get identity: %w", err)
 	}
 
-	deployEnvInput := &archer.DeployEnvironmentInput{
+	deployEnvInput := &deploy.DeployEnvironmentInput{
 		Name:                     opts.EnvName,
 		Project:                  viper.GetString(projectFlag),
 		Prod:                     opts.IsProduction,

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/amazon-ecs-cli-v2/templates"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -51,7 +52,7 @@ func New(sess *session.Session) CloudFormation {
 // If the stack already exists, returns a ErrStackAlreadyExists.
 // If the change set to create the stack cannot be executed, returns a ErrNotExecutableChangeSet.
 // Otherwise, returns a wrapped error.
-func (cf CloudFormation) DeployEnvironment(env *archer.DeployEnvironmentInput) error {
+func (cf CloudFormation) DeployEnvironment(env *deploy.DeployEnvironmentInput) error {
 	return cf.deploy(newEnvStackConfig(env, cf.box))
 }
 
@@ -83,7 +84,7 @@ func (cf CloudFormation) deploy(stackConfig stackConfiguration) error {
 // WaitForEnvironmentCreation will block until the environment's CloudFormation stack has completed or errored.
 // Once the deployment is complete, it read the stack output and create an environment with the resources from
 // the stack like ECR Repo.
-func (cf CloudFormation) WaitForEnvironmentCreation(env *archer.DeployEnvironmentInput) (*archer.Environment, error) {
+func (cf CloudFormation) WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*archer.Environment, error) {
 	cfEnv := newEnvStackConfig(env, cf.box)
 	deployedStack, err := cf.waitForStackCreation(cfEnv)
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -52,7 +52,7 @@ func New(sess *session.Session) CloudFormation {
 // If the stack already exists, returns a ErrStackAlreadyExists.
 // If the change set to create the stack cannot be executed, returns a ErrNotExecutableChangeSet.
 // Otherwise, returns a wrapped error.
-func (cf CloudFormation) DeployEnvironment(env *deploy.DeployEnvironmentInput) error {
+func (cf CloudFormation) DeployEnvironment(env *deploy.CreateEnvironmentInput) error {
 	return cf.deploy(newEnvStackConfig(env, cf.box))
 }
 
@@ -84,7 +84,7 @@ func (cf CloudFormation) deploy(stackConfig stackConfiguration) error {
 // WaitForEnvironmentCreation will block until the environment's CloudFormation stack has completed or errored.
 // Once the deployment is complete, it read the stack output and create an environment with the resources from
 // the stack like ECR Repo.
-func (cf CloudFormation) WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*archer.Environment, error) {
+func (cf CloudFormation) WaitForEnvironmentCreation(env *deploy.CreateEnvironmentInput) (*archer.Environment, error) {
 	cfEnv := newEnvStackConfig(env, cf.box)
 	deployedStack, err := cf.waitForStackCreation(cfEnv)
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/identity"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -39,7 +39,7 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 	id, err := identity.Get()
 	require.NoError(t, err)
 
-	environmentToDeploy := archer.DeployEnvironmentInput{Name: randStringBytes(10), Project: randStringBytes(10), PublicLoadBalancer: true, ToolsAccountPrincipalARN: id.ARN}
+	environmentToDeploy := deploy.DeployEnvironmentInput{Name: randStringBytes(10), Project: randStringBytes(10), PublicLoadBalancer: true, ToolsAccountPrincipalARN: id.ARN}
 	envStackName := fmt.Sprintf("%s-%s", environmentToDeploy.Project, environmentToDeploy.Name)
 
 	t.Run("Deploys an Environment to CloudFormation", func(t *testing.T) {

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -39,10 +39,10 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 	id, err := identity.Get()
 	require.NoError(t, err)
 
-	environmentToDeploy := deploy.DeployEnvironmentInput{Name: randStringBytes(10), Project: randStringBytes(10), PublicLoadBalancer: true, ToolsAccountPrincipalARN: id.ARN}
+	environmentToDeploy := deploy.CreateEnvironmentInput{Name: randStringBytes(10), Project: randStringBytes(10), PublicLoadBalancer: true, ToolsAccountPrincipalARN: id.ARN}
 	envStackName := fmt.Sprintf("%s-%s", environmentToDeploy.Project, environmentToDeploy.Name)
 
-	t.Run("Deploys an Environment to CloudFormation", func(t *testing.T) {
+	t.Run("Deploys an environment to CloudFormation", func(t *testing.T) {
 		// Given our stack doesn't exist
 		output, err := cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
 			StackName: aws.String(envStackName),

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -359,7 +359,7 @@ func TestWaitForStackCreation(t *testing.T) {
 }
 
 func TestWaitForEnvironmentCreation(t *testing.T) {
-	deploymentInput := archer.DeployEnvironmentInput{
+	deploymentInput := deploy.DeployEnvironmentInput{
 		Name:    "test",
 		Project: "project",
 	}
@@ -367,7 +367,7 @@ func TestWaitForEnvironmentCreation(t *testing.T) {
 
 	testCases := map[string]struct {
 		cf    CloudFormation
-		input archer.DeployEnvironmentInput
+		input deploy.DeployEnvironmentInput
 		want  error
 	}{
 		"error in waitForStackCreation call": {

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -359,7 +359,7 @@ func TestWaitForStackCreation(t *testing.T) {
 }
 
 func TestWaitForEnvironmentCreation(t *testing.T) {
-	deploymentInput := deploy.DeployEnvironmentInput{
+	deploymentInput := deploy.CreateEnvironmentInput{
 		Name:    "test",
 		Project: "project",
 	}
@@ -367,7 +367,7 @@ func TestWaitForEnvironmentCreation(t *testing.T) {
 
 	testCases := map[string]struct {
 		cf    CloudFormation
-		input deploy.DeployEnvironmentInput
+		input deploy.CreateEnvironmentInput
 		want  error
 	}{
 		"error in waitForStackCreation call": {

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -16,7 +16,7 @@ import (
 // envStackConfig is for providing all the values to set up an
 // environment stack and to interpret the outputs from it.
 type envStackConfig struct {
-	*deploy.DeployEnvironmentInput
+	*deploy.CreateEnvironmentInput
 	box packd.Box
 }
 
@@ -38,9 +38,9 @@ const (
 
 // newEnvStackConfig sets up a struct which can provide values to CloudFormation for
 // spinning up an environment.
-func newEnvStackConfig(input *deploy.DeployEnvironmentInput, box packd.Box) *envStackConfig {
+func newEnvStackConfig(input *deploy.CreateEnvironmentInput, box packd.Box) *envStackConfig {
 	return &envStackConfig{
-		DeployEnvironmentInput: input,
+		CreateEnvironmentInput: input,
 		box:                    box,
 	}
 }

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -15,7 +16,7 @@ import (
 // envStackConfig is for providing all the values to set up an
 // environment stack and to interpret the outputs from it.
 type envStackConfig struct {
-	*archer.DeployEnvironmentInput
+	*deploy.DeployEnvironmentInput
 	box packd.Box
 }
 
@@ -37,7 +38,7 @@ const (
 
 // newEnvStackConfig sets up a struct which can provide values to CloudFormation for
 // spinning up an environment.
-func newEnvStackConfig(input *archer.DeployEnvironmentInput, box packd.Box) *envStackConfig {
+func newEnvStackConfig(input *deploy.DeployEnvironmentInput, box packd.Box) *envStackConfig {
 	return &envStackConfig{
 		DeployEnvironmentInput: input,
 		box:                    box,

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -143,8 +143,8 @@ func mockEnvironmentStack(stackArn, ecrOutput string) *cloudformation.Stack {
 	}
 }
 
-func mockDeployEnvironmentInput() *deploy.DeployEnvironmentInput {
-	return &deploy.DeployEnvironmentInput{
+func mockDeployEnvironmentInput() *deploy.CreateEnvironmentInput {
+	return &deploy.CreateEnvironmentInput{
 		Name:                     "env",
 		Project:                  "project",
 		Prod:                     true,

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/gobuffalo/packd"
@@ -142,8 +143,8 @@ func mockEnvironmentStack(stackArn, ecrOutput string) *cloudformation.Stack {
 	}
 }
 
-func mockDeployEnvironmentInput() *archer.DeployEnvironmentInput {
-	return &archer.DeployEnvironmentInput{
+func mockDeployEnvironmentInput() *deploy.DeployEnvironmentInput {
+	return &deploy.DeployEnvironmentInput{
 		Name:                     "env",
 		Project:                  "project",
 		Prod:                     true,

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -4,8 +4,8 @@
 // Package deploy holds the structures to deploy applications and environments.
 package deploy
 
-// DeployEnvironmentInput represents the fields required to setup and deploy an environment.
-type DeployEnvironmentInput struct {
+// CreateEnvironmentInput represents the fields required to deploy an environment.
+type CreateEnvironmentInput struct {
 	Project                  string // Name of the project this environment belongs to.
 	Name                     string // Name of the environment, must be unique within a project.
 	Prod                     bool   // Whether or not this environment is a production environment.

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -1,0 +1,14 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deploy holds the structures to deploy applications and environments.
+package deploy
+
+// DeployEnvironmentInput represents the fields required to setup and deploy an environment.
+type DeployEnvironmentInput struct {
+	Project                  string // Name of the project this environment belongs to.
+	Name                     string // Name of the environment, must be unique within a project.
+	Prod                     bool   // Whether or not this environment is a production environment.
+	PublicLoadBalancer       bool   // Whether or not this environment should contain a shared public load balancer between applications.
+	ToolsAccountPrincipalARN string // The Principal ARN of the tools account.
+}

--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -86,7 +86,7 @@ type Source struct {
 }
 
 // PipelineStage represents configuration for each deployment stage
-// of a workspace. A stage consists of the Archer Environment the pipeline
+// of a workspace. A stage consists of the Archer environment the pipeline
 // is deloying to and the containerized applications that will be deployed.
 type PipelineStage struct {
 	*AssociatedEnvironment `yaml:",inline"`
@@ -94,7 +94,7 @@ type PipelineStage struct {
 }
 
 // AssociatedEnvironment defines the necessary information a pipline stage
-// needs for an Archer Environment.
+// needs for an Archer environment.
 type AssociatedEnvironment struct {
 	Project   string `yaml:"-"`    // Name of the project this environment belongs to.
 	Name      string `yaml:"name"` // Name of the environment, must be unique within a project.

--- a/internal/pkg/store/ssm/ssm.go
+++ b/internal/pkg/store/ssm/ssm.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-Package ssm implements CRUD operations for Package, Environment and
-Pipeline configuration. This configuration contains the archer projects
+Package ssm implements CRUD operations for project, environment, application and
+pipeline configuration. This configuration contains the archer projects
 a customer has, and the environments and pipelines associated with each
 project.
 */
@@ -47,7 +47,7 @@ type identityService interface {
 	Get() (identity.Caller, error)
 }
 
-// SSM store is in charge of fetching and creating Projects, Environment and Pipeline
+// SSM store is in charge of fetching and creating projects, environment and pipeline
 // configuration in SSM.
 type SSM struct {
 	systemManager ssmiface.SSMAPI
@@ -183,7 +183,7 @@ func (s *SSM) CreateEnvironment(environment *archer.Environment) error {
 		return fmt.Errorf("create environment %s in project %s: %w", environment.Name, environment.Project, err)
 	}
 
-	log.Printf("Created Environment with version %v", *paramOutput.Version)
+	log.Printf("Created environment with version %v", *paramOutput.Version)
 	return nil
 
 }

--- a/mocks/mock_env.go
+++ b/mocks/mock_env.go
@@ -216,7 +216,7 @@ func (m *MockEnvironmentDeployer) EXPECT() *MockEnvironmentDeployerMockRecorder 
 }
 
 // DeployEnvironment mocks base method
-func (m *MockEnvironmentDeployer) DeployEnvironment(env *deploy.DeployEnvironmentInput) error {
+func (m *MockEnvironmentDeployer) DeployEnvironment(env *deploy.CreateEnvironmentInput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployEnvironment", env)
 	ret0, _ := ret[0].(error)
@@ -230,7 +230,7 @@ func (mr *MockEnvironmentDeployerMockRecorder) DeployEnvironment(env interface{}
 }
 
 // WaitForEnvironmentCreation mocks base method
-func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*archer.Environment, error) {
+func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *deploy.CreateEnvironmentInput) (*archer.Environment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForEnvironmentCreation", env)
 	ret0, _ := ret[0].(*archer.Environment)

--- a/mocks/mock_env.go
+++ b/mocks/mock_env.go
@@ -5,9 +5,11 @@
 package mocks
 
 import (
-	archer "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	archer "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockEnvironmentStore is a mock of EnvironmentStore interface
@@ -214,7 +216,7 @@ func (m *MockEnvironmentDeployer) EXPECT() *MockEnvironmentDeployerMockRecorder 
 }
 
 // DeployEnvironment mocks base method
-func (m *MockEnvironmentDeployer) DeployEnvironment(env *archer.DeployEnvironmentInput) error {
+func (m *MockEnvironmentDeployer) DeployEnvironment(env *deploy.DeployEnvironmentInput) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployEnvironment", env)
 	ret0, _ := ret[0].(error)
@@ -228,7 +230,7 @@ func (mr *MockEnvironmentDeployerMockRecorder) DeployEnvironment(env interface{}
 }
 
 // WaitForEnvironmentCreation mocks base method
-func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *archer.DeployEnvironmentInput) (*archer.Environment, error) {
+func (m *MockEnvironmentDeployer) WaitForEnvironmentCreation(env *deploy.DeployEnvironmentInput) (*archer.Environment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForEnvironmentCreation", env)
 	ret0, _ := ret[0].(*archer.Environment)


### PR DESCRIPTION
1. Moved the `DeployEnvironmentInput` struct to `deploy` pkg
2. Renamed the struct to just `Environment`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
