### PR TITLE
Apply environment overrides to a LBFargateManifest configuration

### DIFF
--- a/internal/pkg/manifest/app_manifest_test.go
+++ b/internal/pkg/manifest/app_manifest_test.go
@@ -6,7 +6,6 @@ package manifest
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,7 +70,6 @@ memory: 1024
 count: 1
 http:
   path: "*"
-public: false
 variables:
   LOG_LEVEL: "WARN"
 secrets:
@@ -83,7 +81,6 @@ scaling:
 environments:
   test:
     count: 3
-    public: true
 `,
 			requireCorrectValues: func(t *testing.T, i interface{}) {
 				actualManifest, ok := i.(*LBFargateManifest)
@@ -106,7 +103,6 @@ environments:
 								"DB_PASSWORD": "MYSQL_DB_PASSWORD",
 							},
 						},
-						Public: aws.Bool(false),
 						Scaling: &AutoScalingConfig{
 							MinCount:     1,
 							MaxCount:     50,
@@ -118,7 +114,6 @@ environments:
 							ContainersConfig: ContainersConfig{
 								Count: 3,
 							},
-							Public: aws.Bool(true),
 						},
 					},
 				}

--- a/internal/pkg/manifest/app_manifest_test.go
+++ b/internal/pkg/manifest/app_manifest_test.go
@@ -6,6 +6,7 @@ package manifest
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,7 +106,7 @@ environments:
 								"DB_PASSWORD": "MYSQL_DB_PASSWORD",
 							},
 						},
-						Public: false,
+						Public: aws.Bool(false),
 						Scaling: &AutoScalingConfig{
 							MinCount:     1,
 							MaxCount:     50,
@@ -117,7 +118,7 @@ environments:
 							ContainersConfig: ContainersConfig{
 								Count: 3,
 							},
-							Public: true,
+							Public: aws.Bool(true),
 						},
 					},
 				}

--- a/internal/pkg/manifest/lb_fargate_manifest.go
+++ b/internal/pkg/manifest/lb_fargate_manifest.go
@@ -29,7 +29,6 @@ type ImageWithPort struct {
 type LBFargateConfig struct {
 	RoutingRule      `yaml:"http,flow"`
 	ContainersConfig `yaml:",inline"`
-	Public           *bool              `yaml:"public"` // A pointer because we don't want the environment override to default to false.
 	Scaling          *AutoScalingConfig `yaml:",flow"`
 }
 
@@ -59,7 +58,6 @@ type AutoScalingConfig struct {
 // NewLoadBalancedFargateManifest creates a new public load balanced web service with an exposed port of 80, receives
 // all the requests from the load balancer and has a single task with minimal CPU and Memory thresholds.
 func NewLoadBalancedFargateManifest(appName string, dockerfile string) *LBFargateManifest {
-	isPublic := false
 	return &LBFargateManifest{
 		AppManifest: AppManifest{
 			Name: appName,
@@ -80,7 +78,6 @@ func NewLoadBalancedFargateManifest(appName string, dockerfile string) *LBFargat
 				Memory: 512,
 				Count:  1,
 			},
-			Public: &isPublic,
 		},
 	}
 }
@@ -128,10 +125,6 @@ func (m *LBFargateManifest) EnvConf(envName string) LBFargateConfig {
 			TargetMemory: m.Scaling.TargetMemory,
 		}
 	}
-	isPublic := false
-	if m.Public != nil {
-		isPublic = *m.Public
-	}
 	conf := LBFargateConfig{
 		RoutingRule: RoutingRule{
 			Path: m.Path,
@@ -143,7 +136,6 @@ func (m *LBFargateManifest) EnvConf(envName string) LBFargateConfig {
 			Variables: envVars,
 			Secrets:   secrets,
 		},
-		Public:  &isPublic,
 		Scaling: scaling,
 	}
 
@@ -166,9 +158,6 @@ func (m *LBFargateManifest) EnvConf(envName string) LBFargateConfig {
 	}
 	for k, v := range target.Secrets {
 		conf.Secrets[k] = v
-	}
-	if target.Public != nil {
-		conf.Public = target.Public
 	}
 	if target.Scaling != nil {
 		if conf.Scaling == nil {

--- a/internal/pkg/manifest/lb_fargate_manifest_test.go
+++ b/internal/pkg/manifest/lb_fargate_manifest_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,9 +30,6 @@ image:
 http:
   # Requests to this path will be forwarded to your service.
   path: '*'
-
-# Determines whether the application will have a public IP or not.
-public: false
 
 # Number of CPU units for the task.
 cpu: 256
@@ -116,7 +112,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 						"TWILIO_TOKEN": "1111",
 					},
 				},
-				Public: aws.Bool(false),
 				Scaling: &AutoScalingConfig{
 					MinCount:     1,
 					MaxCount:     2,
@@ -133,7 +128,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 							"DDB_TABLE_NAME": "awards-prod",
 						},
 					},
-					Public: aws.Bool(true),
 					Scaling: &AutoScalingConfig{
 						MaxCount: 5,
 					},
@@ -155,7 +149,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 						"TWILIO_TOKEN": "1111",
 					},
 				},
-				Public: aws.Bool(true),
 				Scaling: &AutoScalingConfig{
 					MinCount:  1,
 					MaxCount:  5,
@@ -171,7 +164,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 					Memory: 1024,
 					Count:  1,
 				},
-				Public: aws.Bool(false),
 				Scaling: &AutoScalingConfig{
 					MinCount:     1,
 					MaxCount:     2,
@@ -196,7 +188,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 							"TWILIO_TOKEN": "2222",
 						},
 					},
-					Public: aws.Bool(true),
 					Scaling: &AutoScalingConfig{
 						MinCount:     2,
 						MaxCount:     5,
@@ -221,7 +212,6 @@ func TestLBFargateManifest_EnvConf(t *testing.T) {
 						"TWILIO_TOKEN": "2222",
 					},
 				},
-				Public: aws.Bool(true),
 				Scaling: &AutoScalingConfig{
 					MinCount:     2,
 					MaxCount:     5,

--- a/templates/lb-fargate-service/manifest.yml
+++ b/templates/lb-fargate-service/manifest.yml
@@ -17,9 +17,6 @@ http:
   # Requests to this path will be forwarded to your service.
   path: '{{.Path}}'
 
-# Determines whether the application will have a public IP or not.
-public: {{.Public}}
-
 # Number of CPU units for the task.
 cpu: {{.CPU}}
 # Amount of memory in MiB used by the task.


### PR DESCRIPTION
Add a new method `EnvConf` that returns the manifest's configuration for a given environment.

Resolves #252

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
