### PR TITLE
Implement Project Resources Implementation in CF

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.25.19 h1:sp3xP91qIAVhWufyn9qM6Zhhn6kX06WJQcmhRj7QTXc=
+github.com/aws/aws-sdk-go v1.25.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.25 h1:j3HLOqcDWjNox1DyvJRs+kVQF42Ghtv6oL6cVBfXS3U=
 github.com/aws/aws-sdk-go v1.25.25/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -164,3 +164,15 @@ func stackExists(err error) bool {
 	}
 	return false
 }
+
+// stackExists returns true if the underlying error is a stack already exists error.
+func stackSetExists(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		switch aerr.Code() {
+		case cloudformation.ErrCodeNameAlreadyExistsException:
+			// An ErrCodeNameAlreadyExistsException occurs when a stack set already exists.
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/identity"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
@@ -23,6 +24,201 @@ import (
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
+}
+
+func Test_Project_Infrastructure(t *testing.T) {
+	sess, err := testSession()
+	require.NoError(t, err)
+	identity := identity.New(sess)
+	callerInfo, err := identity.Get()
+	require.NoError(t, err)
+	require.NoError(t, err)
+	deployer := cloudformation.New(sess)
+	cfClient := awsCF.New(sess)
+	require.NoError(t, err)
+
+	t.Run("Deploys Project Admin Roles to CloudFormation and Creates StackSet", func(t *testing.T) {
+		project := archer.Project{Name: randStringBytes(10), AccountID: callerInfo.Account}
+		projectRoleStackName := fmt.Sprintf("%s-infrastructure-roles", project.Name)
+		projectStackSetName := fmt.Sprintf("%s-infrastructure", project.Name)
+
+		// Given our stack doesn't exist
+		roleStackOutput, err := cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: aws.String(projectRoleStackName),
+		})
+
+		require.True(t, len(roleStackOutput.Stacks) == 0, "Stack %s should not exist.", projectRoleStackName)
+
+		// Make sure we delete the stacks after the test is done
+		defer func() {
+			cfClient.DeleteStack(&awsCF.DeleteStackInput{
+				StackName: aws.String(projectRoleStackName),
+			})
+
+			cfClient.DeleteStackSet(&awsCF.DeleteStackSetInput{
+				StackSetName: aws.String(projectStackSetName),
+			})
+
+			cfClient.WaitUntilStackDeleteComplete(&awsCF.DescribeStacksInput{
+				StackName: aws.String(projectRoleStackName),
+			})
+		}()
+
+		err = deployer.CreateProjectResources(&project)
+		require.NoError(t, err)
+
+		// We should create the project StackSet
+		_, err = cfClient.DescribeStackSet(&awsCF.DescribeStackSetInput{
+			StackSetName: aws.String(projectStackSetName),
+		})
+		require.NoError(t, err)
+
+		// We should create the project roles stack
+		roleStackOutput, err = cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: aws.String(projectRoleStackName),
+		})
+		require.NoError(t, err)
+
+		require.True(t, len(roleStackOutput.Stacks) == 1, "Stack %s should have been deployed.", projectRoleStackName)
+		deployedStack := roleStackOutput.Stacks[0]
+		expectedResultsForKey := map[string]func(*awsCF.Output){
+			"ExecutionRoleARN": func(output *awsCF.Output) {
+				require.True(t,
+					strings.HasSuffix(*output.OutputValue, fmt.Sprintf("role/%s-executionrole", project.Name)),
+					fmt.Sprintf("ExecutionRoleARN should be named {project}-executionrole but was %s", *output.OutputValue))
+			},
+			"AdministrationRoleARN": func(output *awsCF.Output) {
+				require.True(t,
+					strings.HasSuffix(*output.OutputValue, fmt.Sprintf("role/%s-adminrole", project.Name)),
+					fmt.Sprintf("AdministrationRoleARN should be named {project}-adminrole but was %s", *output.OutputValue))
+			},
+		}
+		require.True(t, len(deployedStack.Outputs) == len(expectedResultsForKey),
+			"There should have been %d output values - instead there were %d. The value of the CF stack was %s",
+			len(expectedResultsForKey),
+			len(deployedStack.Outputs),
+			deployedStack.GoString(),
+		)
+		for _, output := range deployedStack.Outputs {
+			key := *output.OutputKey
+			validationFunction := expectedResultsForKey[key]
+			require.NotNil(t, validationFunction, "Unexpected output key %s in stack.", key)
+			validationFunction(output)
+		}
+	})
+
+	t.Run("Deploys Project Infrastructure (KMS Key, ECR Repo, S3 Bucket)", func(t *testing.T) {
+		project := archer.Project{Name: randStringBytes(10), AccountID: callerInfo.Account}
+		projectRoleStackName := fmt.Sprintf("%s-infrastructure-roles", project.Name)
+		projectStackSetName := fmt.Sprintf("%s-infrastructure", project.Name)
+
+		// Make sure we delete the stacks after the test is done
+		defer func() {
+			// Clean up any StackInstances we may have created.
+			if stackInstances, err := cfClient.ListStackInstances(&awsCF.ListStackInstancesInput{
+				StackSetName: aws.String(projectStackSetName),
+			}); err == nil && stackInstances.Summaries[0] != nil {
+				projectStackInstance := stackInstances.Summaries[0]
+				cfClient.DeleteStackInstances(&awsCF.DeleteStackInstancesInput{
+					Accounts:     []*string{projectStackInstance.Account},
+					Regions:      []*string{projectStackInstance.Region},
+					RetainStacks: aws.Bool(false),
+					StackSetName: projectStackInstance.StackSetId,
+				})
+
+				cfClient.WaitUntilStackDeleteComplete(&awsCF.DescribeStacksInput{
+					StackName: projectStackInstance.StackId,
+				})
+			}
+			// Delete the StackSet once all the StackInstances are cleaned up
+			cfClient.DeleteStackSet(&awsCF.DeleteStackSetInput{
+				StackSetName: aws.String(projectStackSetName),
+			})
+
+			cfClient.DeleteStack(&awsCF.DeleteStackInput{
+				StackName: aws.String(projectRoleStackName),
+			})
+		}()
+
+		// Given our stack doesn't exist
+		roleStackOutput, err := cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: aws.String(projectRoleStackName),
+		})
+
+		require.True(t, len(roleStackOutput.Stacks) == 0, "Stack %s should not exist.", projectRoleStackName)
+
+		err = deployer.CreateProjectResources(&project)
+		require.NoError(t, err)
+
+		// Add an application only
+		err = deployer.AddAppToProject(
+			&project,
+			&archer.Application{
+				Name: "myapp",
+			},
+		)
+
+		require.NoError(t, err)
+
+		// No new substacks should be created
+		stackInstances, err := cfClient.ListStackInstances(&awsCF.ListStackInstancesInput{
+			StackSetName: aws.String(projectStackSetName),
+		})
+		require.NoError(t, err)
+		require.Equal(t, 0, len(stackInstances.Summaries), "Adding apps to a project without any envs shouldn't create any stack instancess.")
+
+		// Add an application only
+		err = deployer.AddEnvToProject(
+			&project,
+			&archer.Environment{
+				Name:      "test",
+				Region:    *sess.Config.Region,
+				AccountID: "000312697014",
+			},
+		)
+		stackInstances, err = cfClient.ListStackInstances(&awsCF.ListStackInstancesInput{
+			StackSetName: aws.String(projectStackSetName),
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(stackInstances.Summaries), "Adding an env should create a new stack instance.")
+		projectStackInstance := stackInstances.Summaries[0]
+		// We should create the project roles stack
+		projectInfraStacks, err := cfClient.DescribeStacks(&awsCF.DescribeStacksInput{
+			StackName: projectStackInstance.StackId,
+		})
+		require.NoError(t, err)
+
+		deployedStack := projectInfraStacks.Stacks[0]
+		expectedResultsForKey := map[string]func(*awsCF.Output){
+			"KMSKeyARN": func(output *awsCF.Output) {
+				require.NotNil(t,
+					*output.OutputValue,
+					"KMSKeyARN should not be nil")
+			},
+			"PipelineBucket": func(output *awsCF.Output) {
+				require.NotNil(t,
+					*output.OutputValue,
+					"PipelineBucket should not be nil")
+			},
+			"ECRRepomyapp": func(output *awsCF.Output) {
+				require.True(t,
+					strings.HasSuffix(*output.OutputValue, fmt.Sprintf("repository/%s/myapp", project.Name)),
+					fmt.Sprintf("ECRRepomyapp should be suffixed with repository/{project}/myapp but was %s", *output.OutputValue))
+			},
+		}
+		require.True(t, len(deployedStack.Outputs) == len(expectedResultsForKey),
+			"There should have been %d output values - instead there were %d. The value of the CF stack was %s",
+			len(expectedResultsForKey),
+			len(deployedStack.Outputs),
+			deployedStack.GoString(),
+		)
+		for _, output := range deployedStack.Outputs {
+			key := *output.OutputKey
+			validationFunction := expectedResultsForKey[key]
+			require.NotNil(t, validationFunction, "Unexpected output key %s in stack.", key)
+			validationFunction(output)
+		}
+	})
 }
 
 // This test can take quite long as it spins up a CloudFormation stack
@@ -52,9 +248,6 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 		// Make sure we delete the stack after the test is done
 		defer func() {
 			cfClient.DeleteStack(&awsCF.DeleteStackInput{
-				StackName: aws.String(envStackName),
-			})
-			cfClient.WaitUntilStackDeleteComplete(&awsCF.DescribeStacksInput{
 				StackName: aws.String(envStackName),
 			})
 		}()

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -36,6 +36,12 @@ type mockCloudFormation struct {
 	mockDescribeChangeSet                func(t *testing.T, in *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error)
 	mockWaitUntilStackCreateComplete     func(t *testing.T, in *cloudformation.DescribeStacksInput) error
 	mockDescribeStacks                   func(t *testing.T, in *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+	mockCreateStackSet                   func(t *testing.T, in *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error)
+	mockDescribeStackSet                 func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error)
+	mockUpdateStackSet                   func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error)
+	mockListStackInstances               func(t *testing.T, in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error)
+	mockCreateStackInstances             func(t *testing.T, in *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error)
+	mockDescribeStackSetOperation        func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error)
 }
 
 func (cf mockCloudFormation) CreateChangeSet(in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
@@ -60,6 +66,30 @@ func (cf mockCloudFormation) WaitUntilStackCreateComplete(in *cloudformation.Des
 
 func (cf mockCloudFormation) DescribeStacks(in *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
 	return cf.mockDescribeStacks(cf.t, in)
+}
+
+func (cf mockCloudFormation) CreateStackSet(in *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error) {
+	return cf.mockCreateStackSet(cf.t, in)
+}
+
+func (cf mockCloudFormation) DescribeStackSet(in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+	return cf.mockDescribeStackSet(cf.t, in)
+}
+
+func (cf mockCloudFormation) UpdateStackSet(in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+	return cf.mockUpdateStackSet(cf.t, in)
+}
+
+func (cf mockCloudFormation) ListStackInstances(in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
+	return cf.mockListStackInstances(cf.t, in)
+}
+
+func (cf mockCloudFormation) CreateStackInstances(in *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error) {
+	return cf.mockCreateStackInstances(cf.t, in)
+}
+
+func (cf mockCloudFormation) DescribeStackSetOperation(in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+	return cf.mockDescribeStackSetOperation(cf.t, in)
 }
 
 type mockStackConfiguration struct {
@@ -395,6 +425,7 @@ func TestWaitForEnvironmentCreation(t *testing.T) {
 		})
 	}
 }
+
 func getMockWaitStackCreateCFClient(t *testing.T, stackName string, shouldThrowError, shouldReturnEmptyStacks bool) CloudFormation {
 	return CloudFormation{
 		client: &mockCloudFormation{
@@ -442,6 +473,7 @@ func getMockStackConfiguration() stackConfiguration {
 		},
 	}
 }
+
 func emptyBox() packd.Box {
 	return packd.NewMemoryBox()
 }

--- a/internal/pkg/deploy/cloudformation/errors.go
+++ b/internal/pkg/deploy/cloudformation/errors.go
@@ -43,16 +43,37 @@ func (err *ErrTemplateNotFound) Error() string {
 }
 
 // Is returns true if the target's template location and parent error are equal to this error's template location and parent error.
-func (e *ErrTemplateNotFound) Is(target error) bool {
+func (err *ErrTemplateNotFound) Is(target error) bool {
 	t, ok := target.(*ErrTemplateNotFound)
 	if !ok {
 		return false
 	}
-	return (e.templateLocation == t.templateLocation) &&
-		(errors.Is(e.parentErr, t.parentErr))
+	return (err.templateLocation == t.templateLocation) &&
+		(errors.Is(err.parentErr, t.parentErr))
 }
 
 // Unwrap returns the original error.
 func (err *ErrTemplateNotFound) Unwrap() error {
 	return err.parentErr
+}
+
+// ErrStackSetOutOfDate occurs when we try to read and then update a StackSet but
+// between reading it and actually updating it, someone else either started or completed
+// an update.
+type ErrStackSetOutOfDate struct {
+	projectName string
+	parentErr   error
+}
+
+func (err *ErrStackSetOutOfDate) Error() string {
+	return fmt.Sprintf("cannot update project resources for project %s because the stack set update was out of date (feel free to try again)", err.projectName)
+}
+
+// Is returns true if the target's template location and parent error are equal to this error's template location and parent error.
+func (err *ErrStackSetOutOfDate) Is(target error) bool {
+	t, ok := target.(*ErrStackSetOutOfDate)
+	if !ok {
+		return false
+	}
+	return err.projectName == t.projectName
 }

--- a/internal/pkg/deploy/cloudformation/project.go
+++ b/internal/pkg/deploy/cloudformation/project.go
@@ -1,0 +1,268 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation/stack"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+// CreateProjectResources sets up everything required for our project-wide resources.
+// These resources include things that are regional, rather than scoped to a particular
+// environment, such as ECR Repos, CodePipeline KMS keys & S3 buckets.
+// We deploy project resources through StackSets - that way we can have one
+// template that we update and all regional stacks are updated.
+func (cf CloudFormation) CreateProjectResources(project *archer.Project) error {
+	projectConfig := stack.NewProjectStackConfig(project, cf.box)
+
+	// First deploy the project roles needed by StackSets. These roles
+	// allow the stack set to set up our regional stacks.
+	if err := cf.deploy(projectConfig); err == nil {
+		_, err := cf.waitForStackCreation(projectConfig)
+		if err != nil {
+			return err
+		}
+	} else {
+		// If the stack already exists - we can move on
+		// to creating the StackSet.
+		var alreadyExists *ErrStackAlreadyExists
+		if !errors.As(err, &alreadyExists) {
+			return err
+		}
+	}
+
+	blankProjectTemplate, err := projectConfig.ResourceTemplate(&stack.ProjectResourcesConfig{
+		Project: projectConfig.Project.Name,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	_, err = cf.client.CreateStackSet(&cloudformation.CreateStackSetInput{
+		Description:           aws.String(projectConfig.StackSetDescription()),
+		StackSetName:          aws.String(projectConfig.StackSetName()),
+		TemplateBody:          aws.String(blankProjectTemplate),
+		ExecutionRoleName:     aws.String(projectConfig.StackSetExecutionRoleName()),
+		AdministrationRoleARN: aws.String(projectConfig.StackSetAdminRoleARN()),
+		Tags:                  projectConfig.Tags(),
+	})
+
+	if err != nil && !stackSetExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+// AddAppToProject attempts to add new App specific resources to the Project resource stack.
+// Currently, this means that we'll set up an ECR repo with a policy for all envs to be able
+// to pull from it.
+func (cf CloudFormation) AddAppToProject(project *archer.Project, newApp *archer.Application) error {
+	projectConfig := stack.NewProjectStackConfig(project, cf.box)
+	previouslyDeployedConfig, err := cf.getLastDeployedProjectConfig(projectConfig)
+	if err != nil {
+		return fmt.Errorf("adding %s app resources to project %s: %w", newApp.Name, project.Name, err)
+	}
+
+	// We'll generate a new list of Accounts to add to our project
+	// infrastructure by appending the environment's account if it
+	// doesn't already exist.
+	appList := []string{}
+	shouldAddNewApp := true
+	for _, app := range previouslyDeployedConfig.Apps {
+		appList = append(appList, app)
+		if app == newApp.Name {
+			shouldAddNewApp = false
+		}
+	}
+
+	if !shouldAddNewApp {
+		return nil
+	}
+
+	appList = append(appList, newApp.Name)
+
+	newDeploymentConfig := stack.ProjectResourcesConfig{
+		Version:  previouslyDeployedConfig.Version + 1,
+		Apps:     appList,
+		Accounts: previouslyDeployedConfig.Accounts,
+		Project:  projectConfig.Project.Name,
+	}
+	if err := cf.deployProjectConfig(projectConfig, &newDeploymentConfig); err != nil {
+		return fmt.Errorf("adding %s app resources to project: %w", newApp.Name, err)
+	}
+
+	return nil
+}
+
+// AddEnvToProject takes a new environment and updates the Project configuration
+// with new Account IDs in resource policies (KMS Keys and ECR Repos) - and
+// sets up a new stack instance if the environment is in a new region.
+func (cf CloudFormation) AddEnvToProject(project *archer.Project, env *archer.Environment) error {
+	projectConfig := stack.NewProjectStackConfig(project, cf.box)
+	previouslyDeployedConfig, err := cf.getLastDeployedProjectConfig(projectConfig)
+	if err != nil {
+		return fmt.Errorf("getting previous deployed stackset %w", err)
+	}
+
+	// We'll generate a new list of Accounts to add to our project
+	// infrastructure by appending the environment's account if it
+	// doesn't already exist.
+	accountList := []string{}
+	shouldAddNewAccountID := true
+	for _, accountID := range previouslyDeployedConfig.Accounts {
+		accountList = append(accountList, accountID)
+		if accountID == env.AccountID {
+			shouldAddNewAccountID = false
+		}
+	}
+
+	if shouldAddNewAccountID {
+		accountList = append(accountList, env.AccountID)
+	}
+
+	newDeploymentConfig := stack.ProjectResourcesConfig{
+		Version:  previouslyDeployedConfig.Version + 1,
+		Apps:     previouslyDeployedConfig.Apps,
+		Accounts: accountList,
+		Project:  projectConfig.Project.Name,
+	}
+
+	if err := cf.deployProjectConfig(projectConfig, &newDeploymentConfig); err != nil {
+		return fmt.Errorf("adding %s environment resources to project: %w", env.Name, err)
+	}
+
+	if err := cf.addNewProjectStackInstances(projectConfig, env); err != nil {
+		return fmt.Errorf("adding new stack instance for environment %s: %w", env.Name, err)
+	}
+
+	return nil
+}
+
+func (cf CloudFormation) deployProjectConfig(projectConfig *stack.ProjectStackConfig, resources *stack.ProjectResourcesConfig) error {
+	newTemplateToDeploy, err := projectConfig.ResourceTemplate(resources)
+	if err != nil {
+		return err
+	}
+	// Every time we deploy the StackSet, we include a version field in the stack metadata.
+	// When we go to update the StackSet, we include that version + 1 as the "Operation ID".
+	// This ensures that we don't overwrite any changes that may have been applied between
+	// us reading the stack and actually updating it.
+	// As an example:
+	//  * We read the stack with Version 1
+	//  * Someone else reads the stack with Version 1
+	//  * We update the StackSet with Version 2, the update completes.
+	//  * Someone else tries to update the StackSet with their stale version 2.
+	//  * "2" has already been used as an operation ID, and the stale write fails.
+	input := cloudformation.UpdateStackSetInput{
+		TemplateBody:          aws.String(newTemplateToDeploy),
+		OperationId:           aws.String(fmt.Sprintf("%d", resources.Version)),
+		StackSetName:          aws.String(projectConfig.StackSetName()),
+		Description:           aws.String(projectConfig.StackSetDescription()),
+		ExecutionRoleName:     aws.String(projectConfig.StackSetExecutionRoleName()),
+		AdministrationRoleARN: aws.String(projectConfig.StackSetAdminRoleARN()),
+		Tags:                  projectConfig.Tags(),
+	}
+	output, err := cf.client.UpdateStackSet(&input)
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cloudformation.ErrCodeOperationIdAlreadyExistsException, cloudformation.ErrCodeOperationInProgressException, cloudformation.ErrCodeStaleRequestException:
+				return &ErrStackSetOutOfDate{projectName: projectConfig.Project.Name, parentErr: err}
+			}
+		}
+		return fmt.Errorf("updating project resources: %w", err)
+	}
+
+	return cf.waitForStackSetOperation(projectConfig.StackSetName(), *output.OperationId)
+
+}
+
+// addNewStackInstances takes an environment and determines if we need to create a new
+// stack instance. We only spin up a new stack instance if the env is in a new region.
+func (cf CloudFormation) addNewProjectStackInstances(projectConfig *stack.ProjectStackConfig, env *archer.Environment) error {
+	stackInstances, err := cf.client.ListStackInstances(&cloudformation.ListStackInstancesInput{
+		StackSetName: aws.String(projectConfig.StackSetName()),
+	})
+
+	if err != nil {
+		return fmt.Errorf("fetching existing project stack instances: %w", err)
+	}
+
+	// We only want to deploy a new StackInstance if we're
+	// adding an environment in a new region.
+	shouldDeployNewStackInstance := true
+	for _, stackInstance := range stackInstances.Summaries {
+		if *stackInstance.Region == env.Region {
+			shouldDeployNewStackInstance = false
+		}
+	}
+
+	if !shouldDeployNewStackInstance {
+		return nil
+	}
+
+	// Set up a new Stack Instance for the new region. The Stack Instance will inherit
+	// the latest StackSet template.
+	createStacksOutput, err := cf.client.CreateStackInstances(&cloudformation.CreateStackInstancesInput{
+		Accounts:     []*string{aws.String(projectConfig.Project.AccountID)},
+		Regions:      []*string{aws.String(env.Region)},
+		StackSetName: aws.String(projectConfig.StackSetName()),
+	})
+
+	if err != nil {
+		return fmt.Errorf("creating new project stack instances: %w", err)
+	}
+
+	return cf.waitForStackSetOperation(projectConfig.StackSetName(), *createStacksOutput.OperationId)
+}
+
+func (cf CloudFormation) getLastDeployedProjectConfig(projectConfig *stack.ProjectStackConfig) (*stack.ProjectResourcesConfig, error) {
+	// Check the existing deploy stack template. From that template, we'll parse out the list of apps and accounts that
+	// are deployed in the stack.
+	describeOutput, err := cf.client.DescribeStackSet(&cloudformation.DescribeStackSetInput{
+		StackSetName: aws.String(projectConfig.StackSetName()),
+	})
+	previouslyDeployedConfig, err := stack.ProjectConfigFrom(describeOutput.StackSet.TemplateBody)
+	if err != nil {
+		return nil, fmt.Errorf("parsing previous deployed stackset %w", err)
+	}
+	return previouslyDeployedConfig, nil
+}
+
+func (cf CloudFormation) waitForStackSetOperation(stackSetName, operationID string) error {
+	for {
+		response, err := cf.client.DescribeStackSetOperation(&cloudformation.DescribeStackSetOperationInput{
+			OperationId:  aws.String(operationID),
+			StackSetName: aws.String(stackSetName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("fetching stack set operation status: %w", err)
+		}
+
+		if *response.StackSetOperation.Status == "STOPPED" {
+			return fmt.Errorf("project operation %s in stack set %s was manually stopped", operationID, stackSetName)
+		}
+
+		if *response.StackSetOperation.Status == "FAILED" {
+			return fmt.Errorf("project operation %s in stack set %s failed", operationID, stackSetName)
+		}
+
+		if *response.StackSetOperation.Status == "SUCCEEDED" {
+			return nil
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/internal/pkg/deploy/cloudformation/project_test.go
+++ b/internal/pkg/deploy/cloudformation/project_test.go
@@ -1,0 +1,649 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation/stack"
+	"github.com/aws/amazon-ecs-cli-v2/templates"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/gobuffalo/packd"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCreateProjectResources(t *testing.T) {
+	mockProject := archer.Project{
+		Name:      "testproject",
+		AccountID: "1234",
+	}
+	testCases := map[string]struct {
+		mockCFClient func() *mockCloudFormation
+		want         error
+	}{
+		"Infrastructure Roles Stack Fails": {
+			mockCFClient: func() *mockCloudFormation {
+				return &mockCloudFormation{
+					t: t,
+					mockCreateChangeSet: func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
+						return nil, fmt.Errorf("error creating stack")
+					},
+				}
+			},
+			want: fmt.Errorf("failed to create changeSet for stack testproject-infrastructure-roles: error creating stack"),
+		},
+		"Infrastructure Roles Stack Already Exists": {
+			mockCFClient: func() *mockCloudFormation {
+				return &mockCloudFormation{
+					t: t,
+					mockCreateChangeSet: func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
+						msg := fmt.Sprintf("Stack [%s-%s] already exists and cannot be created again with the changeSet [ecscli-%s]", mockProjectName, mockEnvironmentName, mockChangeSetID)
+						return nil, awserr.New("ValidationError", msg, nil)
+					},
+					mockCreateStackSet: func(t *testing.T, in *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error) {
+						return nil, nil
+					},
+				}
+			},
+		},
+		"StackSet Already Exists": {
+			mockCFClient: func() *mockCloudFormation {
+				client := getMockSuccessfulDeployCFClient(t, "stackname")
+				client.mockCreateStackSet = func(t *testing.T, in *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error) {
+					return nil, awserr.New(cloudformation.ErrCodeNameAlreadyExistsException, "StackSetAlreadyExiststs", nil)
+				}
+				return client
+			},
+		},
+		"Infrastructure Roles StackSet Created": {
+			mockCFClient: func() *mockCloudFormation {
+				client := getMockSuccessfulDeployCFClient(t, "stackname")
+				client.mockCreateStackSet = func(t *testing.T, in *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error) {
+					require.Equal(t, "ECS CLI Project Resources (ECR repos, KMS keys, S3 buckets)", *in.Description)
+					require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+					require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+					require.Equal(t, "testproject-executionrole", *in.ExecutionRoleName)
+					require.Equal(t, "arn:aws:iam::1234:role/testproject-adminrole", *in.AdministrationRoleARN)
+					require.True(t, len(in.Tags) == 1, "There should be one tag for the project")
+					require.Equal(t, "ecs-project", *in.Tags[0].Key)
+					require.Equal(t, mockProject.Name, *in.Tags[0].Value)
+
+					return nil, nil
+				}
+				return client
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cf := CloudFormation{
+				client: tc.mockCFClient(),
+				box:    templates.Box(),
+			}
+			got := cf.CreateProjectResources(&mockProject)
+
+			if tc.want != nil {
+				require.EqualError(t, tc.want, got.Error())
+			} else {
+				require.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestAddEnvToProject(t *testing.T) {
+	mockProject := archer.Project{
+		Name:      "testproject",
+		AccountID: "1234",
+	}
+	testCases := map[string]struct {
+		cf      CloudFormation
+		project *archer.Project
+		env     *archer.Environment
+		want    error
+	}{
+		"with no existing deployments and adding an env": {
+			project: &mockProject,
+			env:     &archer.Environment{Name: "test", AccountID: "1234", Region: "us-west-2"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						require.Equal(t, "ECS CLI Project Resources (ECR repos, KMS keys, S3 buckets)", *in.Description)
+						require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+						require.Equal(t, "testproject-executionrole", *in.ExecutionRoleName)
+						require.Equal(t, "arn:aws:iam::1234:role/testproject-adminrole", *in.AdministrationRoleARN)
+						require.True(t, len(in.Tags) == 1, "There should be one tag for the project")
+						require.Equal(t, "ecs-project", *in.Tags[0].Key)
+						require.Equal(t, mockProject.Name, *in.Tags[0].Value)
+
+						require.Equal(t, "1", *in.OperationId)
+
+						require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+						configToDeploy, err := stack.ProjectConfigFrom(in.TemplateBody)
+						require.NoError(t, err)
+						require.ElementsMatch(t, []string{mockProject.AccountID}, configToDeploy.Accounts)
+						require.Empty(t, configToDeploy.Apps, "There should be no new apps to deploy")
+						require.Equal(t, 1, configToDeploy.Version)
+						return &cloudformation.UpdateStackSetOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					},
+					mockListStackInstances: func(t *testing.T, in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
+						return &cloudformation.ListStackInstancesOutput{
+							Summaries: []*cloudformation.StackInstanceSummary{},
+						}, nil
+					},
+					mockCreateStackInstances: func(t *testing.T, in *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error) {
+						require.ElementsMatch(t, []*string{aws.String(mockProject.AccountID)}, in.Accounts)
+						require.ElementsMatch(t, []*string{aws.String("us-west-2")}, in.Regions)
+						require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+						return &cloudformation.CreateStackInstancesOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					},
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+
+		"with no new account ID added": {
+			project: &mockProject,
+			env:     &archer.Environment{Name: "test", AccountID: "1234", Region: "us-west-2"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{
+							Metadata: stack.ProjectResourcesConfig{
+								Accounts: []string{"1234"},
+							},
+						})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						require.Equal(t, "ECS CLI Project Resources (ECR repos, KMS keys, S3 buckets)", *in.Description)
+						require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+						require.Equal(t, "testproject-executionrole", *in.ExecutionRoleName)
+						require.Equal(t, "arn:aws:iam::1234:role/testproject-adminrole", *in.AdministrationRoleARN)
+						require.True(t, len(in.Tags) == 1, "There should be one tag for the project")
+						require.Equal(t, "ecs-project", *in.Tags[0].Key)
+						require.Equal(t, mockProject.Name, *in.Tags[0].Value)
+
+						require.Equal(t, "1", *in.OperationId)
+
+						require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+						configToDeploy, err := stack.ProjectConfigFrom(in.TemplateBody)
+						require.NoError(t, err)
+						// Ensure there are no duplicate accounts
+						require.ElementsMatch(t, []string{mockProject.AccountID}, configToDeploy.Accounts)
+						require.Empty(t, configToDeploy.Apps, "There should be no new apps to deploy")
+						require.Equal(t, 1, configToDeploy.Version)
+						return &cloudformation.UpdateStackSetOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					},
+					mockListStackInstances: func(t *testing.T, in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
+						return &cloudformation.ListStackInstancesOutput{
+							Summaries: []*cloudformation.StackInstanceSummary{},
+						}, nil
+					},
+					mockCreateStackInstances: func(t *testing.T, in *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error) {
+						require.ElementsMatch(t, []*string{aws.String(mockProject.AccountID)}, in.Accounts)
+						require.ElementsMatch(t, []*string{aws.String("us-west-2")}, in.Regions)
+						require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+						return &cloudformation.CreateStackInstancesOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					},
+
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+
+		"with existing stack instances in same region but different account (no new stack instances, but update stackset)": {
+			project: &mockProject,
+			env:     &archer.Environment{Name: "test", AccountID: "1234", Region: "us-west-2"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{Metadata: stack.ProjectResourcesConfig{
+							Accounts: []string{"4567"},
+							Version:  1,
+						}})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+						configToDeploy, err := stack.ProjectConfigFrom(in.TemplateBody)
+						require.NoError(t, err)
+						require.ElementsMatch(t, []string{mockProject.AccountID, "4567"}, configToDeploy.Accounts)
+						require.Empty(t, configToDeploy.Apps, "There should be no new apps to deploy")
+						require.Equal(t, 2, configToDeploy.Version)
+
+						return &cloudformation.UpdateStackSetOutput{
+							OperationId: aws.String("2"),
+						}, nil
+					},
+					mockListStackInstances: func(t *testing.T, in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
+						return &cloudformation.ListStackInstancesOutput{
+							Summaries: []*cloudformation.StackInstanceSummary{
+								&cloudformation.StackInstanceSummary{
+									Region:  aws.String("us-west-2"),
+									Account: aws.String(mockProject.AccountID),
+								},
+							},
+						}, nil
+					},
+					mockCreateStackInstances: func(t *testing.T, in *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error) {
+						t.FailNow()
+						return nil, nil
+					},
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.cf.AddEnvToProject(tc.project, tc.env)
+
+			if tc.want != nil {
+				require.EqualError(t, got, tc.want.Error())
+			} else {
+				require.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestAddAppToProject(t *testing.T) {
+	mockProject := archer.Project{
+		Name:      "testproject",
+		AccountID: "1234",
+	}
+	testCases := map[string]struct {
+		cf      CloudFormation
+		project *archer.Project
+		app     *archer.Application
+		want    error
+	}{
+		"with no existing deployments and adding an app": {
+			project: &mockProject,
+			app:     &archer.Application{Name: "TestApp"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						require.Equal(t, "ECS CLI Project Resources (ECR repos, KMS keys, S3 buckets)", *in.Description)
+						require.Equal(t, "testproject-infrastructure", *in.StackSetName)
+						require.Equal(t, "testproject-executionrole", *in.ExecutionRoleName)
+						require.Equal(t, "arn:aws:iam::1234:role/testproject-adminrole", *in.AdministrationRoleARN)
+						require.True(t, len(in.Tags) == 1, "There should be one tag for the project")
+						require.Equal(t, "ecs-project", *in.Tags[0].Key)
+						require.Equal(t, mockProject.Name, *in.Tags[0].Value)
+						// We should increment the version
+						require.Equal(t, "1", *in.OperationId)
+
+						require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+						configToDeploy, err := stack.ProjectConfigFrom(in.TemplateBody)
+						require.NoError(t, err)
+						require.ElementsMatch(t, []string{"TestApp"}, configToDeploy.Apps)
+						require.Empty(t, configToDeploy.Accounts, "There should be no new accounts to deploy")
+						require.Equal(t, 1, configToDeploy.Version)
+						return &cloudformation.UpdateStackSetOutput{
+							OperationId: aws.String("1"),
+						}, nil
+					},
+					mockListStackInstances: func(t *testing.T, in *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
+						return &cloudformation.ListStackInstancesOutput{
+							Summaries: []*cloudformation.StackInstanceSummary{},
+						}, nil
+					},
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+		"with new app to existing project with existing apps": {
+			project: &mockProject,
+			app:     &archer.Application{Name: "test"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{Metadata: stack.ProjectResourcesConfig{
+							Apps:    []string{"firsttest"},
+							Version: 1,
+						}})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						require.NotZero(t, *in.TemplateBody, "TemplateBody should not be empty")
+						configToDeploy, err := stack.ProjectConfigFrom(in.TemplateBody)
+						require.NoError(t, err)
+						require.ElementsMatch(t, []string{"test", "firsttest"}, configToDeploy.Apps)
+						require.Empty(t, configToDeploy.Accounts, "There should be no new apps to deploy")
+						require.Equal(t, 2, configToDeploy.Version)
+
+						return &cloudformation.UpdateStackSetOutput{
+							OperationId: aws.String("2"),
+						}, nil
+					},
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+		"with ewxisting app to existing project with existing apps": {
+			project: &mockProject,
+			app:     &archer.Application{Name: "test"},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					// Given there hasn't been a StackSet update - the metadata in the stack body will be empty.
+					mockDescribeStackSet: func(t *testing.T, in *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
+						body, err := yaml.Marshal(stack.DeployedProjectMetadata{Metadata: stack.ProjectResourcesConfig{
+							Apps:    []string{"test"},
+							Version: 1,
+						}})
+						require.NoError(t, err)
+						return &cloudformation.DescribeStackSetOutput{
+							StackSet: &cloudformation.StackSet{
+								TemplateBody: aws.String(string(body)),
+							},
+						}, nil
+					},
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						t.FailNow()
+						return nil, nil
+					},
+				},
+				box: templates.Box(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.cf.AddAppToProject(tc.project, tc.app)
+
+			if tc.want != nil {
+				require.EqualError(t, got, tc.want.Error())
+			} else {
+				require.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestWaitForStackSetOperation(t *testing.T) {
+	waitingForOperation := true
+	testCases := map[string]struct {
+		cf   CloudFormation
+		want error
+	}{
+		"operation succeeded": {
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("SUCCEEDED"),
+							},
+						}, nil
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+		},
+		"operation failed": {
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("FAILED"),
+							},
+						}, nil
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+			want: fmt.Errorf("project operation operation in stack set stackset failed"),
+		},
+		"operation stopped": {
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String("STOPPED"),
+							},
+						}, nil
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+			want: fmt.Errorf("project operation operation in stack set stackset was manually stopped"),
+		},
+		"operation non-terminal to succeeded": {
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockDescribeStackSetOperation: func(t *testing.T, in *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
+						// First, say the status is running. Then during the next call, set the status to succeeded.
+						status := "RUNNING"
+						if !waitingForOperation {
+							status = "SUCCEEDED"
+						}
+						waitingForOperation = false
+						return &cloudformation.DescribeStackSetOperationOutput{
+							StackSetOperation: &cloudformation.StackSetOperation{
+								Status: aws.String(status),
+							},
+						}, nil
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.cf.waitForStackSetOperation("stackset", "operation")
+
+			if tc.want != nil {
+				require.EqualError(t, got, tc.want.Error())
+			} else {
+				require.NoError(t, got)
+			}
+		})
+	}
+}
+
+func TestDeployProjectConfig_ErrWrapping(t *testing.T) {
+	mockProject := archer.Project{Name: "project", AccountID: "12345"}
+
+	testCases := map[string]struct {
+		cf   CloudFormation
+		want error
+	}{
+		"ErrCodeOperationIdAlreadyExistsException": {
+			want: &ErrStackSetOutOfDate{projectName: mockProject.Name},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						return nil, awserr.New(cloudformation.ErrCodeOperationIdAlreadyExistsException, "operation already exists", nil)
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+		},
+		"ErrCodeOperationInProgressException": {
+			want: &ErrStackSetOutOfDate{projectName: mockProject.Name},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						return nil, awserr.New(cloudformation.ErrCodeOperationInProgressException, "something is in progres", nil)
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+		},
+		"ErrCodeStaleRequestException": {
+			want: &ErrStackSetOutOfDate{projectName: mockProject.Name},
+			cf: CloudFormation{
+				client: &mockCloudFormation{
+					t: t,
+					mockUpdateStackSet: func(t *testing.T, in *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
+						return nil, awserr.New(cloudformation.ErrCodeStaleRequestException, "something is stale", nil)
+					},
+				},
+				box: boxWithTemplateFile(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockProjectResources := stack.ProjectResourcesConfig{}
+			got := tc.cf.deployProjectConfig(stack.NewProjectStackConfig(&mockProject, boxWithProjectTemplate()), &mockProjectResources)
+			require.NotNil(t, got)
+			require.True(t, errors.Is(tc.want, got), "Got %v but expected %v", got, tc.want)
+		})
+	}
+}
+
+// Useful for mocking a successfully deployed stack
+func getMockSuccessfulDeployCFClient(t *testing.T, stackName string) *mockCloudFormation {
+	return &mockCloudFormation{
+		t: t,
+		mockCreateChangeSet: func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
+			return &cloudformation.CreateChangeSetOutput{
+				Id:      aws.String("changesetID"),
+				StackId: aws.String(stackName),
+			}, nil
+		},
+		mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+
+			return nil
+		},
+		mockWaitUntilStackCreateComplete: func(t *testing.T, input *cloudformation.DescribeStacksInput) error {
+			return nil
+		},
+		mockDescribeChangeSet: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error) {
+			return &cloudformation.DescribeChangeSetOutput{
+				ExecutionStatus: aws.String(cloudformation.ExecutionStatusAvailable),
+			}, nil
+		},
+		mockExecuteChangeSet: func(t *testing.T, in *cloudformation.ExecuteChangeSetInput) (output *cloudformation.ExecuteChangeSetOutput, e error) {
+			return nil, nil
+		},
+		mockDescribeStacks: func(t *testing.T, input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					&cloudformation.Stack{
+						StackId: aws.String(fmt.Sprintf("arn:aws:cloudformation:eu-west-3:902697171733:stack/%s", stackName)),
+					},
+				},
+			}, nil
+		},
+	}
+}
+
+func boxWithProjectTemplate() packd.Box {
+	box := packd.NewMemoryBox()
+
+	box.AddString("project/cf.yml", mockTemplate)
+
+	return box
+}

--- a/internal/pkg/deploy/cloudformation/stack/errors.go
+++ b/internal/pkg/deploy/cloudformation/stack/errors.go
@@ -1,0 +1,34 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrTemplateNotFound occurs when we can't find a predefined template.
+type ErrTemplateNotFound struct {
+	templateLocation string
+	parentErr        error
+}
+
+func (err *ErrTemplateNotFound) Error() string {
+	return fmt.Sprintf("failed to find the cloudformation template at %s", err.templateLocation)
+}
+
+// Is returns true if the target's template location and parent error are equal to this error's template location and parent error.
+func (err *ErrTemplateNotFound) Is(target error) bool {
+	t, ok := target.(*ErrTemplateNotFound)
+	if !ok {
+		return false
+	}
+	return (err.templateLocation == t.templateLocation) &&
+		(errors.Is(err.parentErr, t.parentErr))
+}
+
+// Unwrap returns the original error.
+func (err *ErrTemplateNotFound) Unwrap() error {
+	return err.parentErr
+}

--- a/internal/pkg/deploy/cloudformation/stack/project.go
+++ b/internal/pkg/deploy/cloudformation/stack/project.go
@@ -1,0 +1,152 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"sort"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gobuffalo/packd"
+)
+
+// DeployedProjectMetadata wraps the Metadata field of a deployed
+// project StackSet.
+type DeployedProjectMetadata struct {
+	Metadata ProjectResourcesConfig `yaml:"Metadata"`
+}
+
+// ProjectResourcesConfig is a configuration for a deployed Project
+// StackSet.
+type ProjectResourcesConfig struct {
+	Accounts []string `yaml:"Accounts,flow"`
+	Apps     []string `yaml:"Apps,flow"`
+	Project  string   `yaml:"Project"`
+	Version  int      `yaml:"Version"`
+}
+
+// ProjectStackConfig is for providing all the values to set up an
+// environment stack and to interpret the outputs from it.
+type ProjectStackConfig struct {
+	Project *archer.Project
+	box     packd.Box
+}
+
+const (
+	projectTemplatePath           = "project/project.yml"
+	projectResourcesTemplatePath  = "project/cf.yml"
+	projectAdminRoleParamName     = "AdminRoleName"
+	projectExecutionRoleParamName = "ExecutionRoleName"
+)
+
+// ProjectConfigFrom takes a template file and extracts the metadata block,
+// and parses it into a projectStackConfig
+func ProjectConfigFrom(template *string) (*ProjectResourcesConfig, error) {
+	resourceConfig := DeployedProjectMetadata{}
+	err := yaml.Unmarshal([]byte(*template), &resourceConfig)
+	return &resourceConfig.Metadata, err
+}
+
+// NewProjectStackConfig sets up a struct which can provide values to CloudFormation for
+// spinning up an environment.
+func NewProjectStackConfig(input *archer.Project, box packd.Box) *ProjectStackConfig {
+	return &ProjectStackConfig{
+		Project: input,
+		box:     box,
+	}
+}
+
+// Template returns the environment CloudFormation template.
+func (e *ProjectStackConfig) Template() (string, error) {
+	template, err := e.box.FindString(projectTemplatePath)
+	if err != nil {
+		return "", &ErrTemplateNotFound{templateLocation: projectTemplatePath, parentErr: err}
+	}
+	return template, nil
+}
+
+// ResourceTemplate generates a StackSet template with all the Project-wide resources (ECR Repos, KMS keys, S3 buckets)
+func (e *ProjectStackConfig) ResourceTemplate(config *ProjectResourcesConfig) (string, error) {
+	stackSetTemplate, err := e.box.FindString(projectResourcesTemplatePath)
+	if err != nil {
+		return "", &ErrTemplateNotFound{templateLocation: projectResourcesTemplatePath, parentErr: err}
+	}
+
+	template, err := template.New("resourcetemplate").Parse(stackSetTemplate)
+	if err != nil {
+		return "", err
+	}
+	// Sort the account IDs and Apps so that the template we generate is deterministic
+	sort.Strings(config.Accounts)
+	sort.Strings(config.Apps)
+
+	var buf bytes.Buffer
+	if err := template.Execute(&buf, config); err != nil {
+		return "", err
+	}
+
+	return string(buf.Bytes()), nil
+}
+
+// Parameters returns the parameters to be passed into a environment CloudFormation template.
+func (e *ProjectStackConfig) Parameters() []*cloudformation.Parameter {
+	return []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(projectAdminRoleParamName),
+			ParameterValue: aws.String(e.stackSetAdminRoleName()),
+		},
+		{
+			ParameterKey:   aws.String(projectExecutionRoleParamName),
+			ParameterValue: aws.String(e.StackSetExecutionRoleName()),
+		},
+	}
+}
+
+// Tags returns the tags that should be applied to the project CloudFormation stack.
+func (e *ProjectStackConfig) Tags() []*cloudformation.Tag {
+	return []*cloudformation.Tag{
+		{
+			Key:   aws.String(projectTagKey),
+			Value: aws.String(e.Project.Name),
+		},
+	}
+}
+
+// StackName returns the name of the CloudFormation stack (based on the project name).
+func (e *ProjectStackConfig) StackName() string {
+	return fmt.Sprintf("%s-infrastructure-roles", e.Project.Name)
+}
+
+// StackSetName returns the name of the CloudFormation StackSet (based on the project name).
+func (e *ProjectStackConfig) StackSetName() string {
+	return fmt.Sprintf("%s-infrastructure", e.Project.Name)
+}
+
+// StackSetDescription returns the description of the StackSet for project resources.
+func (e *ProjectStackConfig) StackSetDescription() string {
+	return "ECS CLI Project Resources (ECR repos, KMS keys, S3 buckets)"
+}
+
+func (e *ProjectStackConfig) stackSetAdminRoleName() string {
+	return fmt.Sprintf("%s-adminrole", e.Project.Name)
+}
+
+// StackSetAdminRoleARN returns the role ARN of the role used to administer the Project
+// StackSet.
+func (e *ProjectStackConfig) StackSetAdminRoleARN() string {
+	//TODO find a partition-neutral way to construct this ARN
+	return fmt.Sprintf("arn:aws:iam::%s:role/%s", e.Project.AccountID, e.stackSetAdminRoleName())
+}
+
+// StackSetExecutionRoleName returns the role name of the role used to actually create
+// Project resources.
+func (e *ProjectStackConfig) StackSetExecutionRoleName() string {
+	return fmt.Sprintf("%s-executionrole", e.Project.Name)
+}

--- a/internal/pkg/deploy/cloudformation/stack/project_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/project_test.go
@@ -1,0 +1,149 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/gobuffalo/packd"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	mockTemplate = "mockTemplate"
+)
+
+func TestProjTemplate(t *testing.T) {
+	testCases := map[string]struct {
+		box            packd.Box
+		expectedOutput string
+		want           error
+	}{
+		"should return error given template not found": {
+			box:  emptyProjectBox(),
+			want: fmt.Errorf("failed to find the cloudformation template at %s", projectTemplatePath),
+		},
+		"should return template body when present": {
+			box:            projectBoxWithTemplateFile(),
+			expectedOutput: mockTemplate,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			projStack := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, tc.box)
+			got, err := projStack.Template()
+
+			if tc.want != nil {
+				require.EqualError(t, tc.want, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestProjResourceTemplate(t *testing.T) {
+	testCases := map[string]struct {
+		box            packd.Box
+		expectedOutput string
+		want           error
+	}{
+		"should return error given template not found": {
+			box:  emptyProjectBox(),
+			want: fmt.Errorf("failed to find the cloudformation template at %s", projectResourcesTemplatePath),
+		},
+		"should return template body when present": {
+			box:            projectBoxWithTemplateFile(),
+			expectedOutput: mockTemplate,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			projStack := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, tc.box)
+			got, err := projStack.ResourceTemplate(&ProjectResourcesConfig{})
+
+			if tc.want != nil {
+				require.EqualError(t, tc.want, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectedOutput, got)
+			}
+		})
+	}
+}
+
+func TestProjectParameters(t *testing.T) {
+	proj := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, emptyProjectBox())
+	expectedParams := []*cloudformation.Parameter{
+		{
+			ParameterKey:   aws.String(projectAdminRoleParamName),
+			ParameterValue: aws.String("testproject-adminrole"),
+		},
+		{
+			ParameterKey:   aws.String(projectExecutionRoleParamName),
+			ParameterValue: aws.String("testproject-executionrole"),
+		},
+	}
+	require.ElementsMatch(t, expectedParams, proj.Parameters())
+}
+
+func TestProjectTags(t *testing.T) {
+	proj := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, emptyProjectBox())
+	expectedTags := []*cloudformation.Tag{
+		{
+			Key:   aws.String(projectTagKey),
+			Value: aws.String(proj.Project.Name),
+		},
+	}
+	require.ElementsMatch(t, expectedTags, proj.Tags())
+}
+
+func TestProjectStackName(t *testing.T) {
+	proj := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, emptyProjectBox())
+	require.Equal(t, fmt.Sprintf("%s-infrastructure-roles", proj.Project.Name), proj.StackName())
+}
+
+func TestProjectStackSetName(t *testing.T) {
+	proj := NewProjectStackConfig(&archer.Project{Name: "testproject", AccountID: "1234"}, emptyProjectBox())
+	require.Equal(t, fmt.Sprintf("%s-infrastructure", proj.Project.Name), proj.StackSetName())
+}
+
+func TestTemplateToProjectConfig(t *testing.T) {
+	given := `AWSTemplateFormatVersion: '2010-09-09'
+Description: Cross-regional resources to support the CodePipeline for a workspace
+Metadata:
+  Version: 7
+  Apps:
+  - testapp1
+  - testapp2
+  Accounts:
+  - 0000000000
+`
+	config, err := ProjectConfigFrom(&given)
+	require.NoError(t, err)
+	require.Equal(t, ProjectResourcesConfig{
+		Accounts: []string{"0000000000"},
+		Version:  7,
+		Apps:     []string{"testapp1", "testapp2"},
+	}, *config)
+}
+
+func emptyProjectBox() packd.Box {
+	return packd.NewMemoryBox()
+}
+
+func projectBoxWithTemplateFile() packd.Box {
+	box := packd.NewMemoryBox()
+
+	box.AddString(projectTemplatePath, mockTemplate)
+	box.AddString(projectResourcesTemplatePath, mockTemplate)
+	return box
+}

--- a/internal/pkg/deploy/cloudformation/stack/tags.go
+++ b/internal/pkg/deploy/cloudformation/stack/tags.go
@@ -1,0 +1,10 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack
+
+const (
+	projectTagKey = "ecs-project"
+	envTagKey     = "ecs-environment"
+	appTagKey     = "ecs-application"
+)

--- a/templates/project/cf.yml
+++ b/templates/project/cf.yml
@@ -1,0 +1,118 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+AWSTemplateFormatVersion: '2010-09-09' {{$accounts := .Accounts}} {{$project := .Project}} {{$apps := .Apps}}
+# Cross-regional resources deployed via a stackset in the tools account
+# to support the CodePipeline for a workspace
+Description: Cross-regional resources to support the CodePipeline for a workspace
+Metadata:
+  Version: {{.Version}}
+  Apps: {{if not $apps}}[]{{else}}{{range $app := $apps}}
+  - {{$app}}{{end}}{{end}}
+  Accounts: {{if not $accounts}}[]{{else}}{{range $account := $accounts}}
+  - {{$account}}{{end}}{{end}}
+Resources:
+  KMSKey:
+    # Used by the CodePipeline in the tools account to en/decrypt the
+    # artifacts between stages
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: !Ref AWS::StackName
+        Statement:
+          -
+            # Allows the key to be administered in the tools account
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - "kms:Create*"
+              - "kms:Describe*"
+              - "kms:Enable*"
+              - "kms:List*"
+              - "kms:Put*"
+              - "kms:Update*"
+              - "kms:Revoke*"
+              - "kms:Disable*"
+              - "kms:Get*"
+              - "kms:Delete*"
+              - "kms:ScheduleKeyDeletion"
+              - "kms:CancelKeyDeletion"
+            Resource: "*"
+          -
+            # Allow use of the key in the tools account and all environment accounts
+            Effect: Allow
+            Principal:
+              AWS:
+                - !Sub arn:aws:iam::${AWS::AccountId}:root
+                {{range $accounts}}
+                - arn:aws:iam::{{.}}:root{{end}}
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+  PipelineBuiltArtifactBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn: PipelineBuiltArtifactBucket
+    Properties:
+      Bucket: !Ref PipelineBuiltArtifactBucket
+      PolicyDocument:
+        Statement:
+          -
+            Action:
+              - s3:*
+            Effect: Allow
+            Resource:
+              - !Sub arn:aws:s3:::${PipelineBuiltArtifactBucket}
+              - !Sub arn:aws:s3:::${PipelineBuiltArtifactBucket}/*
+            Principal:
+              AWS:
+                - !Sub arn:aws:iam::${AWS::AccountId}:root
+                {{range $accounts}}
+                - arn:aws:iam::{{.}}:root{{end}}
+  PipelineBuiltArtifactBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      VersioningConfiguration:
+        Status: Enabled
+    DeletionPolicy: Retain
+
+{{range $app := $apps}}
+  ECRRepo{{$app}}:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: {{$project}}/{{$app}}
+      RepositoryPolicyText:
+        Version: '2008-10-17'
+        Statement:
+        - Sid: AllowPushPull
+          Effect: Allow
+          Principal:
+              AWS:
+                - !Sub arn:aws:iam::${AWS::AccountId}:root
+                {{range $accounts}}
+                - arn:aws:iam::{{.}}:root{{end}}
+          Action:
+          - ecr:GetDownloadUrlForLayer
+          - ecr:BatchGetImage
+          - ecr:BatchCheckLayerAvailability
+          - ecr:PutImage
+          - ecr:InitiateLayerUpload
+          - ecr:UploadLayerPart
+          - ecr:CompleteLayerUpload
+{{end}}
+Outputs:
+  KMSKeyARN:
+    Description: KMS Key used by CodePipeline for encrypting artifacts.
+    Value: !GetAtt KMSKey.Arn
+  PipelineBucket:
+    Description: Bucket used for CodePipeline to stage resources in.
+    Value: !Ref PipelineBuiltArtifactBucket
+{{range $app := $apps}}  ECRRepo{{$app}}:
+    Description: ECR Repo used to store images of the {{$app}} app.
+    Value: !GetAtt ECRRepo{{$app}}.Arn
+{{end}}

--- a/templates/project/project.yml
+++ b/templates/project/project.yml
@@ -1,0 +1,90 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+AWSTemplateFormatVersion: 2010-09-09
+Description: Configure the AWSCloudFormationStackSetAdministrationRole to enable use of AWS CloudFormation StackSets.
+Parameters:
+  AdminRoleName:
+    Type: String
+  ExecutionRoleName:
+    Type: String
+Resources:
+  AdministrationRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref AdminRoleName
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: cloudformation.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: AssumeRole-AWSCloudFormationStackSetExecutionRole
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource:
+                  - !Sub 'arn:aws:iam::*:role/${AdminRoleName}'
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref ExecutionRoleName
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !GetAtt AdministrationRole.Arn
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: ExecutionRolePolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+              - Sid: StackSetRequiredPermissions
+                Effect: Allow
+                Action:
+                  - cloudformation:*
+                  - s3:*
+                  - sns:*
+                Resource: "*"
+              - Sid: ManageKMSKeys
+                Effect: Allow
+                Action:
+                  - kms:*
+                Resource: "*"
+              - Sid: ManageECRRepos
+                Effect: Allow
+                Action:
+                  - ecr:DescribeImageScanFindings
+                  - ecr:GetLifecyclePolicyPreview
+                  - ecr:CreateRepository
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:GetAuthorizationToken
+                  - ecr:ListTagsForResource
+                  - ecr:ListImages
+                  - ecr:DeleteLifecyclePolicy
+                  - ecr:DeleteRepository
+                  - ecr:SetRepositoryPolicy
+                  - ecr:BatchGetImage
+                  - ecr:DescribeImages
+                  - ecr:DescribeRepositories
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetRepositoryPolicy
+                  - ecr:GetLifecyclePolicy
+                Resource: "*"
+Outputs:
+  ExecutionRoleARN:
+    Description: ExecutionRole used by this project to set up ECR Repos, KMS Keys and S3 buckets
+    Value: !GetAtt ExecutionRole.Arn
+  AdministrationRoleARN:
+    Description: AdministrationRole used by this project to manage this project's StackSet
+    Value: !GetAtt AdministrationRole.Arn


### PR DESCRIPTION
    This change adds the ability to create a StackSet
    for project infrastructure.

    This includes ECR Repos, KMS Keys, S3 buckets, etc.

    This is the 1st pass at this (since it was getting big).

    The basic flow will be:
    1. Project init > Sets up 1 stack for StackSet roles,
       set up a StackSet (pretty quick ~ 7 seconds)

    2. When adding an environment, spins up a StackSet if
       the environment is in a region no existing envs are in.

    3. When adding a new application or account, update all existing
       StackSet instances.