### PR TITLE
Renamed the Repository field to OwnerAndRepository to be more explicit

### DIFF
--- a/internal/pkg/manifest/pipeline.go
+++ b/internal/pkg/manifest/pipeline.go
@@ -44,7 +44,9 @@ func (p *githubProvider) Properties() map[string]interface{} {
 type GitHubProperties struct {
 	// use tag from https://godoc.org/github.com/fatih/structs#example-Map--Tags
 	// to specify the name of the field in the output properties
-	Repository string `structs:"repository" yaml:"repository"`
+
+	// An example for OwnerAndRepository would be: "aws/amazon-ecs-cli-v2"
+	OwnerAndRepository string `structs:"repository" yaml:"repository"`
 	Branch     string `structs:"branch" yaml:"branch"`
 }
 

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -19,7 +19,7 @@ func TestNewProvider(t *testing.T) {
 	}{
 		"successfully create GitHub provider": {
 			providerConfig: &GitHubProperties{
-				Repository: "aws/amazon-ecs-cli-v2",
+				OwnerAndRepository: "aws/amazon-ecs-cli-v2",
 				Branch:     "master",
 			},
 		},
@@ -51,7 +51,7 @@ func TestCreatePipeline(t *testing.T) {
 		"errors out when no stage provided": {
 			provider: func() Provider {
 				p, err := NewProvider(&GitHubProperties{
-					Repository: "aws/amazon-ecs-cli-v2",
+					OwnerAndRepository: "aws/amazon-ecs-cli-v2",
 					Branch:     "master",
 				})
 				require.NoError(t, err, "failed to create provider")
@@ -63,7 +63,7 @@ func TestCreatePipeline(t *testing.T) {
 		"happy case with non-default stages": {
 			provider: func() Provider {
 				p, err := NewProvider(&GitHubProperties{
-					Repository: "aws/amazon-ecs-cli-v2",
+					OwnerAndRepository: "aws/amazon-ecs-cli-v2",
 					Branch:     "master",
 				})
 				require.NoError(t, err, "failed to create provider")
@@ -119,7 +119,7 @@ stages:
 `
 	// reset the global map before each test case is run
 	provider, err := NewProvider(&GitHubProperties{
-		Repository: "aws/amazon-ecs-cli-v2",
+		OwnerAndRepository: "aws/amazon-ecs-cli-v2",
 		Branch:     "master",
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Provide summary of changes -->
This makes pipeline Cloudformation template rendering a little bit easier because in the template we have separate fields for the repository owner and repository name.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
