### PR TITLE
Add buildspec to source control in master

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,56 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      golang: 1.13
+  pre_build:
+    commands:
+      - echo "cd into $CODEBUILD_SRC_DIR"
+      - cd $CODEBUILD_SRC_DIR
+      - export GOMOD=$CODEBUILD_SRC_DIR/go.mod:GOMOD
+      - export GOPATH="/go"
+  build:
+    commands:
+      - echo "Compilation context:"
+      - echo "CODEBUILD_SOURCE_VERSION=$CODEBUILD_SOURCE_VERSION"
+      - make gen-mocks
+      - make release
+    finally:
+      - echo "Built artifacts:"
+      - ls -lah ./bin/local
+      - ./bin/local/archer-amd64 --version
+  post_build:
+    commands:
+      - VERSION=`./bin/local/archer-amd64 --version`
+      - VERSION=`echo $VERSION | grep -oE "[^ ]+$"`
+      - COMMIT_ID=`git rev-parse HEAD`
+      - COMMIT_VERSION=${COMMIT_ID:0:7}
+      - echo "Creating latest and version-tagged artifacts..."
+      - cp ./bin/local/archer.exe ./bin/local/archer-windows-latest.exe
+      - cp ./bin/local/archer.exe ./bin/local/archer-windows-$COMMIT_VERSION.exe
+      - mv ./bin/local/archer.exe ./bin/local/archer-windows-$VERSION.exe
+      - cp ./bin/local/archer ./bin/local/archer-darwin-latest
+      - cp ./bin/local/archer ./bin/local/archer-darwin-$COMMIT_VERSION
+      - mv ./bin/local/archer ./bin/local/archer-darwin-$VERSION
+      - cp ./bin/local/archer-amd64 ./bin/local/archer-linux-latest
+      - cp ./bin/local/archer-amd64 ./bin/local/archer-linux-$COMMIT_VERSION
+      - mv ./bin/local/archer-amd64 ./bin/local/archer-linux-$VERSION
+      - echo "Creating manifest file..."
+      - MANIFESTFILE="$COMMIT_ID.manifest"
+      - echo ./bin/local/archer-windows-latest.exe >> $MANIFESTFILE
+      - echo ./bin/local/archer-windows-$COMMIT_VERSION.exe >> $MANIFESTFILE
+      - echo ./bin/local/archer-windows-$VERSION.exe >> $MANIFESTFILE
+      - echo ./bin/local/archer-darwin-latest >> $MANIFESTFILE
+      - echo ./bin/local/archer-darwin-$COMMIT_VERSION >> $MANIFESTFILE
+      - echo ./bin/local/archer-darwin-$VERSION >> $MANIFESTFILE
+      - echo ./bin/local/archer-linux-latest >> $MANIFESTFILE
+      - echo ./bin/local/archer-linux-$COMMIT_VERSION >> $MANIFESTFILE
+      - echo ./bin/local/archer-linux-$VERSION >> $MANIFESTFILE
+    finally:
+      - echo "Built artifacts:"
+      - ls -lah ./bin/local
+      - ./bin/local/archer-linux-latest --version
+artifacts:
+  files:
+    - '**/*'


### PR DESCRIPTION
This PR adds a buildspec which outputs nine labeled binaries each time it is run (ie, on PR merge): latest, commit-hash-only, and version, for each operating system supported in `make release`.

Commit hash is produced by taking the first seven characters of `git rev-parse HEAD`. 
Version tag is produced by the last word of the `--version` flag. 
Latest will be continually overwritten.

Addresses our continuing need for easily accessible binaries for bug bashes and testing efforts. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
