### PR TITLE
Implement preliminary pipeline CFN dynamic rendering

### DIFF
--- a/internal/pkg/deploy/cloudformation/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/pipeline.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -42,7 +41,7 @@ func (p *pipelineStackConfig) Template() (string, error) {
 		return "", &ErrTemplateNotFound{templateLocation: pipelineCfnTemplatePath, parentErr: err}
 	}
 	
-	tpl, err := template.New("pipelineCfn").Parse(removeComments(content))
+	tpl, err := template.New("pipelineCfn").Parse(content)
 	if err != nil {
 		return "", fmt.Errorf("parse CloudFormation template for project %s, pipeline %s, error: %w",
 		p.ProjectName, p.Name, err)
@@ -53,17 +52,6 @@ func (p *pipelineStackConfig) Template() (string, error) {
 		p.ProjectName, p.Name, err)
 	}
 	return buf.String(), nil
-}
-
-func removeComments(tmpl string) string {
-	lines := strings.Split(tmpl, "\n")
-	commentRemoved := make([]string, 0, len(lines))
-	for _, line := range strings.Split(tmpl, "\n") {
-		if !commentRegex.MatchString(line) {
-			commentRemoved = append(commentRemoved, line)
-		}
-	}
-	return strings.Join(commentRemoved, "\n")
 }
 
 func (p *pipelineStackConfig) Parameters() []*cloudformation.Parameter {

--- a/internal/pkg/deploy/cloudformation/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/pipeline.go
@@ -6,7 +6,6 @@ package cloudformation
 import (
 	"bytes"
 	"fmt"
-	"regexp"
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -17,9 +16,6 @@ import (
 )
 
 const pipelineCfnTemplatePath = "cicd/pipeline_cfn.yml"
-
-// matches a line of comment in the template
-var commentRegex = regexp.MustCompile(`\s*#.*`)
 
 type pipelineStackConfig struct {
 	*deploy.CreatePipelineInput

--- a/internal/pkg/deploy/cloudformation/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/pipeline.go
@@ -4,11 +4,23 @@
 package cloudformation
 
 import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"text/template"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
+	"github.com/aws/amazon-ecs-cli-v2/templates"
 )
+
+const pipelineCfnTemplatePath = "cicd/pipeline_cfn.yml"
+
+// matches a line of comment in the template
+var commentRegex = regexp.MustCompile(`\s*#.*`)
 
 type pipelineStackConfig struct {
 	*deploy.CreatePipelineInput
@@ -25,8 +37,33 @@ func (p *pipelineStackConfig) StackName() string {
 }
 
 func (p *pipelineStackConfig) Template() (string, error) {
-	// TODO: Render the template
-	return "", nil
+	content, err := templates.Box().FindString(pipelineCfnTemplatePath)
+	if err != nil {
+		return "", &ErrTemplateNotFound{templateLocation: pipelineCfnTemplatePath, parentErr: err}
+	}
+	
+	tpl, err := template.New("pipelineCfn").Parse(removeComments(content))
+	if err != nil {
+		return "", fmt.Errorf("parse CloudFormation template for project %s, pipeline %s, error: %w",
+		p.ProjectName, p.Name, err)
+	}
+	var buf bytes.Buffer
+	if err := tpl.Execute(&buf, p); err != nil {
+		return "", fmt.Errorf("execute CloudFormation template for project %s, pipeline %s, error: %w",
+		p.ProjectName, p.Name, err)
+	}
+	return buf.String(), nil
+}
+
+func removeComments(tmpl string) string {
+	lines := strings.Split(tmpl, "\n")
+	commentRemoved := make([]string, 0, len(lines))
+	for _, line := range strings.Split(tmpl, "\n") {
+		if !commentRegex.MatchString(line) {
+			commentRemoved = append(commentRemoved, line)
+		}
+	}
+	return strings.Join(commentRemoved, "\n")
 }
 
 func (p *pipelineStackConfig) Parameters() []*cloudformation.Parameter {

--- a/internal/pkg/deploy/cloudformation/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_test.go
@@ -63,8 +63,6 @@ func TestPipelineTemplateRendering(t *testing.T) {
 	)
 	tmpl, err := pipeline.Template()
     require.NoError(t, err, "template serialization failed")
-	err = ioutil.WriteFile("/workplace/yenlinc/amazon-ecs-archer/test.yml", []byte(tmpl), 0777)
-	require.NoError(t, err, "template write failed")
     require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
 }
 

--- a/internal/pkg/deploy/cloudformation/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_test.go
@@ -63,8 +63,9 @@ func TestPipelineTemplateRendering(t *testing.T) {
 	)
 	tmpl, err := pipeline.Template()
     require.NoError(t, err, "template serialization failed")
+	err = ioutil.WriteFile("/workplace/yenlinc/amazon-ecs-archer/test.yml", []byte(tmpl), 0777)
+	require.NoError(t, err, "template write failed")
     require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
-	
 }
 
 func mockAssociatedEnv(envName, region string, isProd bool) *deploy.AssociatedEnvironment {

--- a/internal/pkg/deploy/cloudformation/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_test.go
@@ -61,12 +61,10 @@ func TestPipelineTemplateRendering(t *testing.T) {
 	pipeline := newPipelineStackConfig(
 		mockCreatePipelineInput(),
 	)
-
 	tmpl, err := pipeline.Template()
     require.NoError(t, err, "template serialization failed")
     require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
 	
-	err = ioutil.WriteFile("/workplace/yenlinc/amazon-ecs-archer/test.yml", []byte(tmpl), 0777)
 }
 
 func mockAssociatedEnv(envName, region string, isProd bool) *deploy.AssociatedEnvironment {

--- a/internal/pkg/deploy/cloudformation/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 const (
-	projectName = "chickenProject"
+	projectName  = "chickenProject"
 	pipelineName = "wingspipeline"
 
-	toolsAccountID = "620297136107"
-	envAccountID =  "786043277641"
+	toolsAccountID = "012345678910"
+	envAccountID   = "109876543210"
 )
 
 func TestPipelineParameters(t *testing.T) {
@@ -55,61 +55,61 @@ func TestPipelineStackName(t *testing.T) {
 }
 
 func TestPipelineTemplateRendering(t *testing.T) {
-    expectedTemplate, err := ioutil.ReadFile("./testdata/rendered_pipeline_cfn_template.yml")
-    require.NoError(t, err, "expected template can not be read")
+	expectedTemplate, err := ioutil.ReadFile("./testdata/rendered_pipeline_cfn_template.yml")
+	require.NoError(t, err, "expected template can not be read")
 
 	pipeline := newPipelineStackConfig(
 		mockCreatePipelineInput(),
 	)
 	tmpl, err := pipeline.Template()
-    require.NoError(t, err, "template serialization failed")
-    require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
+	require.NoError(t, err, "template serialization failed")
+	require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
 }
 
 func mockAssociatedEnv(envName, region string, isProd bool) *deploy.AssociatedEnvironment {
 	return &deploy.AssociatedEnvironment{
-		Name: envName,
-		Region: region,
+		Name:      envName,
+		Region:    region,
 		AccountID: envAccountID,
-		Prod: isProd,
+		Prod:      isProd,
 	}
 }
 
-func mockCreatePipelineInput() *deploy.CreatePipelineInput {	
+func mockCreatePipelineInput() *deploy.CreatePipelineInput {
 	return &deploy.CreatePipelineInput{
 		ProjectName: projectName,
-		Name:            pipelineName         ,
+		Name:        pipelineName,
 		Source: &deploy.Source{
 			ProviderName: "GitHub",
 			Properties: map[string]interface{}{
-				"repository": "hencrice/amazon-ecs-cli-v2",
-				"branch":     "master",
+				"repository":                 "hencrice/amazon-ecs-cli-v2",
+				"branch":                     "master",
 				deploy.GithubSecretIdKeyName: "testGitHubSecret",
 			},
 		},
 		Stages: []deploy.PipelineStage{
 			{
 				AssociatedEnvironment: mockAssociatedEnv("test", "us-west-2", false),
-				LocalApplications: []string{"frontend", "backend"},
+				LocalApplications:     []string{"frontend", "backend"},
 			},
 			{
 				AssociatedEnvironment: mockAssociatedEnv("prod", "us-east-1", true),
-				LocalApplications: []string{"frontend", "backend"},
+				LocalApplications:     []string{"frontend", "backend"},
 			},
 		},
 		ArtifactBuckets: []deploy.ArtifactBucket{
 			{
 				BucketArn: "arn:aws:s3:::chicken-us-east-1",
-				KeyArn: fmt.Sprintf("arn:aws:kms:us-east-1:%s:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e", toolsAccountID),
+				KeyArn:    fmt.Sprintf("arn:aws:kms:us-east-1:%s:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e", toolsAccountID),
 			},
 			{
 				BucketArn: "arn:aws:s3:::chicken-us-west-2",
-				KeyArn: fmt.Sprintf("arn:aws:kms:us-west-2:%s:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc", toolsAccountID),
+				KeyArn:    fmt.Sprintf("arn:aws:kms:us-west-2:%s:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc", toolsAccountID),
 			},
 			// assume the pipeline is hosted in a region that does not contain any archer environment
 			{
 				BucketArn: "arn:aws:s3:::chicken-us-west-1",
-				KeyArn: fmt.Sprintf("arn:aws:kms:us-west-1:%s:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1", toolsAccountID),
+				KeyArn:    fmt.Sprintf("arn:aws:kms:us-west-1:%s:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1", toolsAccountID),
 			},
 		},
 	}

--- a/internal/pkg/deploy/cloudformation/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/pipeline_test.go
@@ -4,6 +4,8 @@
 package cloudformation
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -16,11 +18,14 @@ import (
 const (
 	projectName = "chickenProject"
 	pipelineName = "wingspipeline"
+
+	toolsAccountID = "620297136107"
+	envAccountID =  "786043277641"
 )
 
 func TestPipelineParameters(t *testing.T) {
 	pipeline := newPipelineStackConfig(
-		mockDeployPipelineInput(),
+		mockCreatePipelineInput(),
 	)
 
 	require.Nil(t, pipeline.Parameters(), "pipeline cloudformation template should not expose any parameters")
@@ -28,7 +33,7 @@ func TestPipelineParameters(t *testing.T) {
 
 func TestPipelineTags(t *testing.T) {
 	pipeline := newPipelineStackConfig(
-		mockDeployPipelineInput(),
+		mockCreatePipelineInput(),
 	)
 
 	expectedTags := []*cloudformation.Tag{
@@ -42,33 +47,48 @@ func TestPipelineTags(t *testing.T) {
 
 func TestPipelineStackName(t *testing.T) {
 	pipeline := newPipelineStackConfig(
-		mockDeployPipelineInput(),
+		mockCreatePipelineInput(),
 	)
 
 	require.Equal(t, projectName+"-"+pipelineName,
 		pipeline.StackName(), "unexpected StackName")
 }
 
+func TestPipelineTemplateRendering(t *testing.T) {
+    expectedTemplate, err := ioutil.ReadFile("./testdata/rendered_pipeline_cfn_template.yml")
+    require.NoError(t, err, "expected template can not be read")
+
+	pipeline := newPipelineStackConfig(
+		mockCreatePipelineInput(),
+	)
+
+	tmpl, err := pipeline.Template()
+    require.NoError(t, err, "template serialization failed")
+    require.Equal(t, string(tmpl), string(expectedTemplate), "the rendered template differs from the expected")
+	
+	err = ioutil.WriteFile("/workplace/yenlinc/amazon-ecs-archer/test.yml", []byte(tmpl), 0777)
+}
+
 func mockAssociatedEnv(envName, region string, isProd bool) *deploy.AssociatedEnvironment {
 	return &deploy.AssociatedEnvironment{
 		Name: envName,
 		Region: region,
-		AccountId: "012345678910",
+		AccountID: envAccountID,
 		Prod: isProd,
 	}
 }
 
-func mockDeployPipelineInput() *deploy.CreatePipelineInput {	
+func mockCreatePipelineInput() *deploy.CreatePipelineInput {	
 	return &deploy.CreatePipelineInput{
 		ProjectName: projectName,
 		Name:            pipelineName         ,
 		Source: &deploy.Source{
 			ProviderName: "GitHub",
 			Properties: map[string]interface{}{
-				"repository": "aws/somethingCool",
+				"repository": "hencrice/amazon-ecs-cli-v2",
 				"branch":     "master",
+				deploy.GithubSecretIdKeyName: "testGitHubSecret",
 			},
-
 		},
 		Stages: []deploy.PipelineStage{
 			{
@@ -78,6 +98,21 @@ func mockDeployPipelineInput() *deploy.CreatePipelineInput {
 			{
 				AssociatedEnvironment: mockAssociatedEnv("prod", "us-east-1", true),
 				LocalApplications: []string{"frontend", "backend"},
+			},
+		},
+		ArtifactBuckets: []deploy.ArtifactBucket{
+			{
+				BucketArn: "arn:aws:s3:::chicken-us-east-1",
+				KeyArn: fmt.Sprintf("arn:aws:kms:us-east-1:%s:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e", toolsAccountID),
+			},
+			{
+				BucketArn: "arn:aws:s3:::chicken-us-west-2",
+				KeyArn: fmt.Sprintf("arn:aws:kms:us-west-2:%s:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc", toolsAccountID),
+			},
+			// assume the pipeline is hosted in a region that does not contain any archer environment
+			{
+				BucketArn: "arn:aws:s3:::chicken-us-west-1",
+				KeyArn: fmt.Sprintf("arn:aws:kms:us-west-1:%s:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1", toolsAccountID),
 			},
 		},
 	}

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -1,0 +1,378 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CodePipeline for the chickenProject
+Parameters:
+  GitHubOAuthSecretId:
+    Description: The secretId of the GitHub OAuth token stored in the Secrets Manager
+    Type: String
+    Default: testGitHubSecret
+Resources:
+  BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-CodeBuildRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  BuildProjectPolicy:
+    Type: AWS::IAM::Policy
+    DependsOn: BuildProjectRole
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetBucketPolicy
+              - s3:GetObject
+              - s3:ListBucket
+            Resource:
+              - arn:aws:s3:::chicken-us-east-1
+              - !Join ['', ['arn:aws:s3:::chicken-us-east-1', '/*']]
+              - arn:aws:s3:::chicken-us-west-2
+              - !Join ['', ['arn:aws:s3:::chicken-us-west-2', '/*']]
+              - arn:aws:s3:::chicken-us-west-1
+              - !Join ['', ['arn:aws:s3:::chicken-us-west-1', '/*']]
+          -
+            Effect: Allow
+            Action:
+              - kms:*
+            Resource:
+              - arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              - arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              - arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+          -
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      Roles:
+        -
+          !Ref BuildProjectRole
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref AWS::StackName
+      Description: !Ref AWS::StackName
+      EncryptionKey: !ImportValue ArtifactKey
+      ServiceRole: !GetAtt BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                docker: 18
+            build:
+              commands:
+                - ls
+          artifacts:
+            files: '**/*'
+      TimeoutInMinutes: 60
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-codepipeline-role
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codepipeline.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  PipelineRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-codepipeline-policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - codepipeline:*
+              - iam:ListRoles
+              - cloudformation:Describe*
+              - cloudFormation:List*
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - cloudformation:CreateStack
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeStacks
+              - cloudformation:UpdateStack
+              - cloudformation:CreateChangeSet
+              - cloudformation:DeleteChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:SetStackPolicy
+              - cloudformation:ValidateTemplate
+              - iam:PassRole
+              - s3:ListAllMyBuckets
+              - s3:GetBucketLocation
+            Resource:
+              - "*"
+          -
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:
+              - arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              - arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              - arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+          -
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetBucketPolicy
+              - s3:GetObject
+              - s3:ListBucket
+            Resource:
+              - arn:aws:s3:::chicken-us-east-1
+              - !Join ['', ['arn:aws:s3:::chicken-us-east-1', '/*']]
+              - arn:aws:s3:::chicken-us-west-2
+              - !Join ['', ['arn:aws:s3:::chicken-us-west-2', '/*']]
+              - arn:aws:s3:::chicken-us-west-1
+              - !Join ['', ['arn:aws:s3:::chicken-us-west-1', '/*']]
+          -
+            Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource:
+              - arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+              - arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+      Roles:
+        -
+          !Ref PipelineRole
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    DependsOn:
+      - PipelineRole
+      - PipelineRolePolicy
+    Properties:
+      ArtifactStores:
+        -
+          Region: us-east-1
+          ArtifactStore:
+            Type: S3
+            Location: chicken-us-east-1
+            EncryptionKey:
+              Id: arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              Type: KMS
+        -
+          Region: us-west-2
+          ArtifactStore:
+            Type: S3
+            Location: chicken-us-west-2
+            EncryptionKey:
+              Id: arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              Type: KMS
+        -
+          Region: us-west-1
+          ArtifactStore:
+            Type: S3
+            Location: chicken-us-west-1
+            EncryptionKey:
+              Id: arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+              Type: KMS
+      RoleArn: !GetAtt PipelineRole.Arn
+      Name: !Ref AWS::StackName
+      Stages:
+        - Name: Source
+          Actions:
+            - Name: SourceCodeFor-chickenProject
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: 1
+                Provider: GitHub
+              Configuration:
+                Owner: hencrice
+                Repo: amazon-ecs-cli-v2
+                Branch: master
+                OAuthToken: !Sub
+                    - '{{resolve:secretsmanager:${SecretId}}}'
+                    - { SecretId: !Ref GitHubOAuthSecretId }
+              OutputArtifacts:
+                - Name: SCCheckoutArtifact
+              RunOrder: 1
+        -
+          Name: Build
+          Actions:
+          -
+            Name: Build
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref BuildProject
+            RunOrder: 1
+            InputArtifacts:
+              - Name: SCCheckoutArtifact
+            OutputArtifacts:
+              - Name: BuildOutput
+        
+        
+        - Name: DeployTochickenProject-test
+          Actions:
+            - Name: CreateChangeSet-frontend-test
+              Region: us-west-2
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-frontend-test
+                ActionMode: CHANGE_SET_REPLACE
+                StackName: chickenProject-frontend-test
+                Capabilities: CAPABILITY_NAMED_IAM
+                TemplatePath: BuildOutput::frontend-test.yaml
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 2
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+            - Name: DeployChangeSet-frontend-test
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-frontend-test
+                ActionMode: CHANGE_SET_EXECUTE
+                StackName: chickenProject-frontend-test
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 3
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+            - Name: CreateChangeSet-backend-test
+              Region: us-west-2
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-backend-test
+                ActionMode: CHANGE_SET_REPLACE
+                StackName: chickenProject-backend-test
+                Capabilities: CAPABILITY_NAMED_IAM
+                TemplatePath: BuildOutput::backend-test.yaml
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 2
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+            - Name: DeployChangeSet-backend-test
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-backend-test
+                ActionMode: CHANGE_SET_EXECUTE
+                StackName: chickenProject-backend-test
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 3
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+        - Name: DeployTochickenProject-prod
+          Actions:
+            - Name: CreateChangeSet-frontend-prod
+              Region: us-east-1
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-frontend-prod
+                ActionMode: CHANGE_SET_REPLACE
+                StackName: chickenProject-frontend-prod
+                Capabilities: CAPABILITY_NAMED_IAM
+                TemplatePath: BuildOutput::frontend-prod.yaml
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 2
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+            - Name: DeployChangeSet-frontend-prod
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-frontend-prod
+                ActionMode: CHANGE_SET_EXECUTE
+                StackName: chickenProject-frontend-prod
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 3
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+            - Name: CreateChangeSet-backend-prod
+              Region: us-east-1
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-backend-prod
+                ActionMode: CHANGE_SET_REPLACE
+                StackName: chickenProject-backend-prod
+                Capabilities: CAPABILITY_NAMED_IAM
+                TemplatePath: BuildOutput::backend-prod.yaml
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 2
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+            - Name: DeployChangeSet-backend-prod
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: chickenProject-backend-prod
+                ActionMode: CHANGE_SET_EXECUTE
+                StackName: chickenProject-backend-prod
+                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 3
+              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -66,9 +66,9 @@ Resources:
             # across (cross-regional) pipeline stages, with each stage
             # backed by a (regional) S3 bucket.
             Resource:
-              - arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
-              - arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
-              - arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+              - arn:aws:kms:us-east-1:012345678910:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              - arn:aws:kms:us-west-2:012345678910:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              - arn:aws:kms:us-west-1:012345678910:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
           -
             Effect: Allow
             Action:
@@ -164,9 +164,9 @@ Resources:
               - kms:Encrypt
               - kms:GenerateDataKey
             Resource:
-              - arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
-              - arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
-              - arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+              - arn:aws:kms:us-east-1:012345678910:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              - arn:aws:kms:us-west-2:012345678910:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              - arn:aws:kms:us-west-1:012345678910:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
           -
             Effect: Allow
             Action:
@@ -186,8 +186,8 @@ Resources:
             Action:
               - sts:AssumeRole
             Resource:
-              - arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
-              - arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+              - arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
+              - arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
       Roles:
         -
           !Ref PipelineRole
@@ -205,7 +205,7 @@ Resources:
             Type: S3
             Location: chicken-us-east-1
             EncryptionKey:
-              Id: arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
+              Id: arn:aws:kms:us-east-1:012345678910:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
               Type: KMS
         
         -
@@ -214,7 +214,7 @@ Resources:
             Type: S3
             Location: chicken-us-west-2
             EncryptionKey:
-              Id: arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
+              Id: arn:aws:kms:us-west-2:012345678910:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
               Type: KMS
         
         -
@@ -223,7 +223,7 @@ Resources:
             Type: S3
             Location: chicken-us-west-1
             EncryptionKey:
-              Id: arn:aws:kms:us-west-1:620297136107:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
+              Id: arn:aws:kms:us-west-1:012345678910:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
               Type: KMS
       RoleArn: !GetAtt PipelineRole.Arn
       Name: !Ref AWS::StackName
@@ -295,7 +295,7 @@ Resources:
                 # TODO: We need the actual name of the CFN execution role here
                 # (created while an environment AWS account is provisioned
                 # through Archer).
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               # After we complete #220, the manual approval action will have a
@@ -305,7 +305,7 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
             # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-test
               Region: us-west-2
@@ -327,7 +327,7 @@ Resources:
                 # TODO: We need the actual name of the CFN execution role here
                 # (created while an environment AWS account is provisioned
                 # through Archer).
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               # After we complete #220, the manual approval action will have a
@@ -337,7 +337,7 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
         # prod is the same as the name of the environment
         # this pipeline stage deploys to
         - Name: DeployTo-chickenProject-prod
@@ -363,7 +363,7 @@ Resources:
                 # TODO: We need the actual name of the CFN execution role here
                 # (created while an environment AWS account is provisioned
                 # through Archer).
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               # After we complete #220, the manual approval action will have a
@@ -373,7 +373,7 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
             # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-prod
               Region: us-east-1
@@ -395,7 +395,7 @@ Resources:
                 # TODO: We need the actual name of the CFN execution role here
                 # (created while an environment AWS account is provisioned
                 # through Archer).
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               # After we complete #220, the manual approval action will have a
@@ -405,4 +405,4 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -240,9 +240,9 @@ Resources:
               - Name: BuildOutput
         
         
-        - Name: DeployTochickenProject-test
+        - Name: DeployTo-chickenProject-test
           Actions:
-            - Name: CreateChangeSet-frontend-test
+            - Name: CreateOrUpdate-frontend-test
               Region: us-west-2
               ActionTypeId:
                 Category: Deploy
@@ -251,7 +251,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ChangeSetName: chickenProject-frontend-test
-                ActionMode: CHANGE_SET_REPLACE
+                ActionMode: CREATE_UPDATE
                 StackName: chickenProject-frontend-test
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend-test.yaml
@@ -260,22 +260,7 @@ Resources:
                 - Name: BuildOutput
               RunOrder: 2
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
-            - Name: DeployChangeSet-frontend-test
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: CloudFormation
-              Configuration:
-                ChangeSetName: chickenProject-frontend-test
-                ActionMode: CHANGE_SET_EXECUTE
-                StackName: chickenProject-frontend-test
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
-              InputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 3
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
-            - Name: CreateChangeSet-backend-test
+            - Name: CreateOrUpdate-backend-test
               Region: us-west-2
               ActionTypeId:
                 Category: Deploy
@@ -284,7 +269,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ChangeSetName: chickenProject-backend-test
-                ActionMode: CHANGE_SET_REPLACE
+                ActionMode: CREATE_UPDATE
                 StackName: chickenProject-backend-test
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend-test.yaml
@@ -293,24 +278,9 @@ Resources:
                 - Name: BuildOutput
               RunOrder: 2
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
-            - Name: DeployChangeSet-backend-test
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: CloudFormation
-              Configuration:
-                ChangeSetName: chickenProject-backend-test
-                ActionMode: CHANGE_SET_EXECUTE
-                StackName: chickenProject-backend-test
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
-              InputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 3
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
-        - Name: DeployTochickenProject-prod
+        - Name: DeployTo-chickenProject-prod
           Actions:
-            - Name: CreateChangeSet-frontend-prod
+            - Name: CreateOrUpdate-frontend-prod
               Region: us-east-1
               ActionTypeId:
                 Category: Deploy
@@ -319,7 +289,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ChangeSetName: chickenProject-frontend-prod
-                ActionMode: CHANGE_SET_REPLACE
+                ActionMode: CREATE_UPDATE
                 StackName: chickenProject-frontend-prod
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend-prod.yaml
@@ -328,22 +298,7 @@ Resources:
                 - Name: BuildOutput
               RunOrder: 2
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
-            - Name: DeployChangeSet-frontend-prod
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: CloudFormation
-              Configuration:
-                ChangeSetName: chickenProject-frontend-prod
-                ActionMode: CHANGE_SET_EXECUTE
-                StackName: chickenProject-frontend-prod
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
-              InputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 3
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
-            - Name: CreateChangeSet-backend-prod
+            - Name: CreateOrUpdate-backend-prod
               Region: us-east-1
               ActionTypeId:
                 Category: Deploy
@@ -352,7 +307,7 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 ChangeSetName: chickenProject-backend-prod
-                ActionMode: CHANGE_SET_REPLACE
+                ActionMode: CREATE_UPDATE
                 StackName: chickenProject-backend-prod
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend-prod.yaml
@@ -360,19 +315,4 @@ Resources:
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
-              RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
-            - Name: DeployChangeSet-backend-prod
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: CloudFormation
-              Configuration:
-                ChangeSetName: chickenProject-backend-prod
-                ActionMode: CHANGE_SET_EXECUTE
-                StackName: chickenProject-backend-prod
-                RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
-              InputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 3
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -1,6 +1,14 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#     http://aws.amazon.com/apache2.0/
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CodePipeline for the chickenProject
 Parameters:
+  # TODO: #273 make this source-provider-agnostic
   GitHubOAuthSecretId:
     Description: The secretId of the GitHub OAuth token stored in the Secrets Manager
     Type: String
@@ -9,6 +17,7 @@ Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role
     Properties:
+      # StackName is <projectName>-<pipelineName>
       RoleName: !Sub ${AWS::StackName}-CodeBuildRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -36,6 +45,9 @@ Resources:
               - s3:GetBucketPolicy
               - s3:GetObject
               - s3:ListBucket
+            # TODO: This might not be necessary. We may only need the bucket
+            # that is in the same region as the pipeline.
+            # Loop through all the artifact buckets created in the stackset
             Resource:
               - arn:aws:s3:::chicken-us-east-1
               - !Join ['', ['arn:aws:s3:::chicken-us-east-1', '/*']]
@@ -46,7 +58,13 @@ Resources:
           -
             Effect: Allow
             Action:
+              # TODO: scope this down if possible
               - kms:*
+            # TODO: This might not be necessary. We may only need the KMS key
+            # that is in the same region as the pipeline.
+            # Loop through all the KMS keys used to en/decrypt artifacts
+            # across (cross-regional) pipeline stages, with each stage
+            # backed by a (regional) S3 bucket.
             Resource:
               - arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
               - arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
@@ -66,6 +84,8 @@ Resources:
     Properties:
       Name: !Ref AWS::StackName
       Description: !Ref AWS::StackName
+      # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
+      # created in the same region as this pipeline.
       EncryptionKey: !ImportValue ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
@@ -77,6 +97,8 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
+        # TODO: Fill in the actual build commands
+        # TODO: Fill in the paths to the CFN templates that this pipeline will deploy
         BuildSpec: |
           version: 0.2
           phases:
@@ -176,6 +198,7 @@ Resources:
       - PipelineRolePolicy
     Properties:
       ArtifactStores:
+        
         -
           Region: us-east-1
           ArtifactStore:
@@ -184,6 +207,7 @@ Resources:
             EncryptionKey:
               Id: arn:aws:kms:us-east-1:620297136107:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
               Type: KMS
+        
         -
           Region: us-west-2
           ArtifactStore:
@@ -192,6 +216,7 @@ Resources:
             EncryptionKey:
               Id: arn:aws:kms:us-west-2:620297136107:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
               Type: KMS
+        
         -
           Region: us-west-1
           ArtifactStore:
@@ -208,13 +233,18 @@ Resources:
             - Name: SourceCodeFor-chickenProject
               ActionTypeId:
                 Category: Source
+                # TODO: #273 For CodeCommit, this needs to be AWS. Let's do that later
                 Owner: ThirdParty
                 Version: 1
                 Provider: GitHub
               Configuration:
-                Owner: hencrice
+                # TODO: #273 For now this set of configurations is GitHub-specific,
+                # change it to be more generic
+                Owner: amazon-ecs-cli-v2
                 Repo: amazon-ecs-cli-v2
                 Branch: master
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+                # Use the *entire* SecretString with version AWSCURRENT
                 OAuthToken: !Sub
                     - '{{resolve:secretsmanager:${SecretId}}}'
                     - { SecretId: !Ref GitHubOAuthSecretId }
@@ -240,8 +270,11 @@ Resources:
               - Name: BuildOutput
         
         
+        # test is the same as the name of the environment
+        # this pipeline stage deploys to
         - Name: DeployTo-chickenProject-test
           Actions:
+            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-frontend-test
               Region: us-west-2
               ActionTypeId:
@@ -250,16 +283,30 @@ Resources:
                 Version: 1
                 Provider: CloudFormation
               Configuration:
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
                 ChangeSetName: chickenProject-frontend-test
                 ActionMode: CREATE_UPDATE
                 StackName: chickenProject-frontend-test
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend-test.yaml
+                # The ARN of the IAM role (in the env accountn) that
+                # AWS CloudFormation assumes when it operates on resources
+                # in a stack in an environment account.
+                # TODO: We need the actual name of the CFN execution role here
+                # (created while an environment AWS account is provisioned
+                # through Archer).
                 RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
+              # After we complete #220, the manual approval action will have a
+              # RunOrder of 1 such that it can block the deployment if this
+              # is a prod stage
               RunOrder: 2
+              # The ARN of the environment manager IAM role (in the env
+              # account) that performs the declared action. This is assumed
+              # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-test
               Region: us-west-2
               ActionTypeId:
@@ -268,18 +315,34 @@ Resources:
                 Version: 1
                 Provider: CloudFormation
               Configuration:
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
                 ChangeSetName: chickenProject-backend-test
                 ActionMode: CREATE_UPDATE
                 StackName: chickenProject-backend-test
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend-test.yaml
+                # The ARN of the IAM role (in the env accountn) that
+                # AWS CloudFormation assumes when it operates on resources
+                # in a stack in an environment account.
+                # TODO: We need the actual name of the CFN execution role here
+                # (created while an environment AWS account is provisioned
+                # through Archer).
                 RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
+              # After we complete #220, the manual approval action will have a
+              # RunOrder of 1 such that it can block the deployment if this
+              # is a prod stage
               RunOrder: 2
+              # The ARN of the environment manager IAM role (in the env
+              # account) that performs the declared action. This is assumed
+              # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-test-EnvManagerRole
+        # prod is the same as the name of the environment
+        # this pipeline stage deploys to
         - Name: DeployTo-chickenProject-prod
           Actions:
+            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-frontend-prod
               Region: us-east-1
               ActionTypeId:
@@ -288,16 +351,30 @@ Resources:
                 Version: 1
                 Provider: CloudFormation
               Configuration:
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
                 ChangeSetName: chickenProject-frontend-prod
                 ActionMode: CREATE_UPDATE
                 StackName: chickenProject-frontend-prod
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend-prod.yaml
+                # The ARN of the IAM role (in the env accountn) that
+                # AWS CloudFormation assumes when it operates on resources
+                # in a stack in an environment account.
+                # TODO: We need the actual name of the CFN execution role here
+                # (created while an environment AWS account is provisioned
+                # through Archer).
                 RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
+              # After we complete #220, the manual approval action will have a
+              # RunOrder of 1 such that it can block the deployment if this
+              # is a prod stage
               RunOrder: 2
+              # The ARN of the environment manager IAM role (in the env
+              # account) that performs the declared action. This is assumed
+              # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole
+            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-prod
               Region: us-east-1
               ActionTypeId:
@@ -306,13 +383,26 @@ Resources:
                 Version: 1
                 Provider: CloudFormation
               Configuration:
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
                 ChangeSetName: chickenProject-backend-prod
                 ActionMode: CREATE_UPDATE
                 StackName: chickenProject-backend-prod
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend-prod.yaml
+                # The ARN of the IAM role (in the env accountn) that
+                # AWS CloudFormation assumes when it operates on resources
+                # in a stack in an environment account.
+                # TODO: We need the actual name of the CFN execution role here
+                # (created while an environment AWS account is provisioned
+                # through Archer).
                 RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
+              # After we complete #220, the manual approval action will have a
+              # RunOrder of 1 such that it can block the deployment if this
+              # is a prod stage
               RunOrder: 2
+              # The ARN of the environment manager IAM role (in the env
+              # account) that performs the declared action. This is assumed
+              # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::786043277641:role/chickenProject-prod-EnvManagerRole

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	
+
 	"github.com/aws/aws-sdk-go/aws/arn"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
@@ -25,8 +25,8 @@ type CreateEnvironmentInput struct {
 }
 
 const (
-	GithubProviderName = "GitHub"
-	GithubSecretIdKeyName = "githubOAuthSecretId"
+	GithubProviderName    = "GitHub"
+	GithubSecretIdKeyName = "githubPersonalAccessTokenSecretId"
 )
 
 // CreatePipelineInput represents the fields required to deploy a pipeline.
@@ -34,7 +34,7 @@ type CreatePipelineInput struct {
 	// Name of the project this pipeline belongs to
 	ProjectName string
 	// Name of the pipeline
-	Name   string
+	Name string
 	// The source code provider for this pipeline
 	Source *Source
 	// The stages of the pipeline. The order of stages in this list
@@ -55,13 +55,13 @@ type ArtifactBucket struct {
 }
 
 // Region parses out the region from the ARN of the KMS key associated with
-// the artifact bucket. 
+// the artifact bucket.
 func (a *ArtifactBucket) Region() (string, error) {
 	// We assume the bucket and the key are in the same AWS region.
 	parsedArn, err := arn.Parse(a.KeyArn)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse region out of key ARN: %s, error: %w",
-		a.BucketArn, err)
+			a.BucketArn, err)
 	}
 	return parsedArn.Region, nil
 }
@@ -71,7 +71,7 @@ func (a *ArtifactBucket) BucketName() (string, error) {
 	parsedArn, err := arn.Parse(a.BucketArn)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse the name of the bucket out of bucket ARN: %s, error: %w",
-		a.BucketArn, err)
+			a.BucketArn, err)
 	}
 	return parsedArn.Resource, nil
 }
@@ -80,17 +80,17 @@ func (a *ArtifactBucket) BucketName() (string, error) {
 type Source struct {
 	// The name of the source code provider. For example, "GitHub"
 	ProviderName string
-	
+
 	// Contains provider-specific configurations, such as:
 	// "repository": "aws/amazon-ecs-cli-v2"
-	// "githubOAuthSecretId": "heyyo"
-	Properties   map[string]interface{}
+	// "githubPersonalAccessTokenSecretId": "heyyo"
+	Properties map[string]interface{}
 }
 
-// GitHubOAuthSecretID returns the ID of the secret in the Secrets manager,
+// GitHubPersonalAccessTokenSecretID returns the ID of the secret in the Secrets manager,
 // which stores the GitHub OAuth token if the provider is "GitHub". Otherwise,
 // it returns an error.
-func (s *Source) GitHubOAuthSecretID() (string, error) {
+func (s *Source) GitHubPersonalAccessTokenSecretID() (string, error) {
 	secretID, exists := s.Properties[GithubSecretIdKeyName]
 	if !exists {
 		return "", errors.New("the GitHub token secretID is not configured")
@@ -110,7 +110,7 @@ func (s *Source) GitHubOAuthSecretID() (string, error) {
 
 type ownerAndRepo struct {
 	owner string
-	repo string
+	repo  string
 }
 
 func (s *Source) parseOwnerAndRepo() (*ownerAndRepo, error) {
@@ -123,7 +123,7 @@ func (s *Source) parseOwnerAndRepo() (*ownerAndRepo, error) {
 	}
 	ownerAndRepoStr, ok := ownerAndRepoI.(string)
 	if !ok {
-		return nil, fmt.Errorf("unable to locate the repository from the properties: %+v", ownerAndRepoI)	
+		return nil, fmt.Errorf("unable to locate the repository from the properties: %+v", ownerAndRepoI)
 	}
 
 	result := strings.Split(ownerAndRepoStr, "/")
@@ -132,7 +132,7 @@ func (s *Source) parseOwnerAndRepo() (*ownerAndRepo, error) {
 	}
 	return &ownerAndRepo{
 		owner: result[0],
-		repo: result[1],
+		repo:  result[1],
 	}, nil
 }
 

--- a/internal/pkg/deploy/deploy.go
+++ b/internal/pkg/deploy/deploy.go
@@ -5,6 +5,12 @@
 package deploy
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+	
+	"github.com/aws/aws-sdk-go/aws/arn"
+
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/manifest"
 )
@@ -18,20 +24,128 @@ type CreateEnvironmentInput struct {
 	ToolsAccountPrincipalARN string // The Principal ARN of the tools account.
 }
 
+const (
+	GithubProviderName = "GitHub"
+	GithubSecretIdKeyName = "githubOAuthSecretId"
+)
+
 // CreatePipelineInput represents the fields required to deploy a pipeline.
 type CreatePipelineInput struct {
 	// Name of the project this pipeline belongs to
 	ProjectName string
 	// Name of the pipeline
 	Name   string
+	// The source code provider for this pipeline
 	Source *Source
+	// The stages of the pipeline. The order of stages in this list
+	// will be the order we deploy to
 	Stages []PipelineStage
+	// A list of artifact buckets and corresponding KMS keys that will
+	// be used in this pipeline.
+	ArtifactBuckets []ArtifactBucket
+}
+
+// ArtifactBucket represents an S3 bucket used by the CodePipeline to store
+// intermediate artifacts produced by the pipeline.
+type ArtifactBucket struct {
+	// The ARN of the S3 bucket.
+	BucketArn string
+	// The ARN of the KMS key used to en/decrypt artifacts stored in this bucket.
+	KeyArn string
+}
+
+// Region parses out the region from the ARN of the KMS key associated with
+// the artifact bucket. 
+func (a *ArtifactBucket) Region() (string, error) {
+	// We assume the bucket and the key are in the same AWS region.
+	parsedArn, err := arn.Parse(a.KeyArn)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse region out of key ARN: %s, error: %w",
+		a.BucketArn, err)
+	}
+	return parsedArn.Region, nil
+}
+
+// BucketName parses out the name of the bucket from its ARN.
+func (a *ArtifactBucket) BucketName() (string, error) {
+	parsedArn, err := arn.Parse(a.BucketArn)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the name of the bucket out of bucket ARN: %s, error: %w",
+		a.BucketArn, err)
+	}
+	return parsedArn.Resource, nil
 }
 
 // Source defines the source of the artifacts to be built and deployed.
 type Source struct {
+	// The name of the source code provider. For example, "GitHub"
 	ProviderName string
+	
+	// Contains provider-specific configurations, such as:
+	// "repository": "aws/amazon-ecs-cli-v2"
+	// "githubOAuthSecretId": "heyyo"
 	Properties   map[string]interface{}
+}
+
+// GitHubOAuthSecretID returns the ID of the secret in the Secrets manager,
+// which stores the GitHub OAuth token if the provider is "GitHub". Otherwise,
+// it returns an error.
+func (s *Source) GitHubOAuthSecretID() (string, error) {
+	secretID, exists := s.Properties[GithubSecretIdKeyName]
+	if !exists {
+		return "", errors.New("the GitHub token secretID is not configured")
+	}
+
+	id, ok := secretID.(string)
+	if !ok {
+		return "", fmt.Errorf("unable to locate the GitHub token secretID from %v", secretID)
+	}
+
+	if s.ProviderName != GithubProviderName {
+		return "", fmt.Errorf("failed attempt to retrieve GitHub token from a non-GitHub provider")
+	}
+
+	return id, nil
+}
+
+func (s *Source) parseOwnerAndRepo() (string, string, error) {
+	if s.ProviderName != GithubProviderName {
+		return "", "", fmt.Errorf("invalid provider: %s", s.ProviderName)
+	}
+	ownerAndRepoI, exists := s.Properties["repository"]
+	if !exists {
+		return "", "", fmt.Errorf("unable to locate the repository from the properties: %+v", s.Properties)
+	}
+	ownerAndRepo, ok := ownerAndRepoI.(string)
+	if !ok {
+		return "", "", fmt.Errorf("unable to locate the repository from the properties: %+v", ownerAndRepoI)	
+	}
+
+	result := strings.Split(ownerAndRepo, "/")
+	if len(result) != 2 {
+		return "", "", fmt.Errorf("unable to locate the repository from the properties: %s", ownerAndRepo)
+	}
+	return result[0], result[1], nil
+}
+
+// Repository returns the repository portion. For example,
+// given "aws/amazon-ecs-cli-v2", this function returns "amazon-ecs-cli-v2"
+func (s *Source) Repository() (string, error) {
+	_, repo, err := s.parseOwnerAndRepo()
+	if err != nil {
+		return "", err
+	}
+	return repo, nil
+}
+
+// Owner returns the repository owner portion. For example,
+// given "aws/amazon-ecs-cli-v2", this function returns "aws"
+func (s *Source) Owner() (string, error) {
+	owner, _, err := s.parseOwnerAndRepo()
+	if err != nil {
+		return "", err
+	}
+	return owner, nil
 }
 
 // PipelineStage represents configuration for each deployment stage
@@ -48,10 +162,10 @@ type AssociatedEnvironment struct {
 	// Name of the environment, must be unique within a project.
 	// This is also the name of the pipeline stage.
 	Name string
-	// T region this environment is stored in.
+	// The region this environment is stored in.
 	Region string
-	// AccountId of the account this environment is stored in.
-	AccountId string
+	// AccountID of the account this environment is stored in.
+	AccountID string
 	// Whether or not this environment is a production environment.
 	Prod bool
 }

--- a/internal/pkg/deploy/deploy_test.go
+++ b/internal/pkg/deploy/deploy_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package deploy holds the structures to deploy applications and environments.
+package deploy
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOwnerAndRepo(t *testing.T) {
+	testCases := map[string]struct {
+		src            *Source
+		expectedErrMsg *string
+		expectedOwner  string
+		expectedRepo   string
+	}{
+		"unsupported source provider": {
+			src: &Source{
+				ProviderName: "chicken",
+				Properties:   map[string]interface{}{},
+			},
+			expectedErrMsg: aws.String("invalid provider: chicken"),
+		},
+		"missing repository property": {
+			src: &Source{
+				ProviderName: "GitHub",
+				Properties:   map[string]interface{}{},
+			},
+			expectedErrMsg: aws.String("unable to locate the repository from the properties"),
+		},
+		"invalid repository property": {
+			src: &Source{
+				ProviderName: "GitHub",
+				Properties: map[string]interface{}{
+					"repository": "invalid",
+				},
+			},
+			expectedErrMsg: aws.String("unable to locate the repository from the properties"),
+		},
+		"valid repository property": {
+			src: &Source{
+				ProviderName: "GitHub",
+				Properties: map[string]interface{}{
+					"repository": "chicken/wings",
+				},
+			},
+			expectedErrMsg: nil,
+			expectedOwner:  "chicken",
+			expectedRepo:   "wings",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			oAndR, err := tc.src.parseOwnerAndRepo()
+			if tc.expectedErrMsg != nil {
+				require.Contains(t, err.Error(), *tc.expectedErrMsg)
+			} else {
+				require.NoError(t, err, "expected error")
+				require.Equal(t, tc.expectedOwner, oAndR.owner, "mismatched owner")
+				require.Equal(t, tc.expectedRepo, oAndR.repo, "mismatched repo")
+			}
+		})
+	}
+}

--- a/internal/pkg/manifest/pipeline_test.go
+++ b/internal/pkg/manifest/pipeline_test.go
@@ -102,13 +102,14 @@ source:
   # The name of the provider that is used to store the source artifacts.
   provider: GitHub
   # Additional properties that further specifies the exact location
-  # the artifacts should be sourced from.
+  # the artifacts should be sourced from. For example, the GitHub provider
+  # has the following properties: repository, branch.
   properties:
     branch: master
     repository: aws/amazon-ecs-cli-v2
 
 # The deployment section defines the order the pipeline will deploy
-# to your environments
+# to your environments.
 stages:
     - 
       # The name of the environment to deploy to.

--- a/templates/cicd/pipeline.yml
+++ b/templates/cicd/pipeline.yml
@@ -11,12 +11,13 @@ source:
   # The name of the provider that is used to store the source artifacts.
   provider: {{.Source.ProviderName}}
   # Additional properties that further specifies the exact location
-  # the artifacts should be sourced from.
+  # the artifacts should be sourced from. For example, the GitHub provider
+  # has the following properties: repository, branch.
   properties:{{range $key, $value := .Source.Properties}}
     {{$key}}: {{$value}}{{end}}
 {{$length := len .Stages}}{{if gt $length 0}}
 # The deployment section defines the order the pipeline will deploy
-# to your environments
+# to your environments.
 stages:{{range .Stages}}
     - 
       # The name of the environment to deploy to.

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -12,7 +12,7 @@ Parameters:
   GitHubOAuthSecretId:
     Description: The secretId of the GitHub OAuth token stored in the Secrets Manager
     Type: String
-    Default: {{$.Source.GitHubOAuthSecretID}}
+    Default: {{$.Source.GitHubPersonalAccessTokenSecretID}}
 Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -255,10 +255,10 @@ Resources:
         {{range $stage := .Stages}}
         # {{$stage.Name}} is the same as the name of the environment
         # this pipeline stage deploys to
-        - Name: DeployTo{{$.ProjectName}}-{{$stage.Name}}
+        - Name: DeployTo-{{$.ProjectName}}-{{$stage.Name}}
           Actions:{{range $app := $stage.LocalApplications}}
             # TODO: #220 Add manual approval action if this stage is a prod stage
-            - Name: CreateChangeSet-{{$app}}-{{$stage.Name}}
+            - Name: CreateOrUpdate-{{$app}}-{{$stage.Name}}
               Region: {{$stage.Region}}
               ActionTypeId:
                 Category: Deploy
@@ -268,7 +268,7 @@ Resources:
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
                 ChangeSetName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
-                ActionMode: CHANGE_SET_REPLACE
+                ActionMode: CREATE_UPDATE
                 StackName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::{{$app}}-{{$stage.Name}}.yaml
@@ -288,19 +288,4 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole
-            - Name: DeployChangeSet-{{$app}}-{{$stage.Name}}
-              ActionTypeId:
-                Category: Deploy
-                Owner: AWS
-                Version: 1
-                Provider: CloudFormation
-              Configuration:
-                ChangeSetName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
-                ActionMode: CHANGE_SET_EXECUTE
-                StackName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
-                RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-CFNExecutionRole
-              InputArtifacts:
-                - Name: BuildOutput
-              RunOrder: 3
               RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}{{end}}{{end}}

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -1,0 +1,306 @@
+#  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#      http://aws.amazon.com/apache2.0/
+#  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+#  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+#  limitations under the License.
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CodePipeline for the {{$.ProjectName}}
+Parameters:
+  // TODO: #273 make this source-provider-agnostic
+  GitHubOAuthSecretId:
+    # https://alpha-docs-aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+    Description: The secretId of the GitHub OAuth token stored in the Secrets Manager
+    Type: String
+    Default: {{$.Source.GitHubOAuthSecretID}}
+Resources:
+  BuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      # StackName is <projectName>-<pipelineName>
+      RoleName: !Sub ${AWS::StackName}-CodeBuildRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  BuildProjectPolicy:
+    Type: AWS::IAM::Policy
+    DependsOn: BuildProjectRole
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-CodeBuildPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetBucketPolicy
+              - s3:GetObject
+              - s3:ListBucket
+            Resource:{{range .ArtifactBuckets}}
+              # TODO: This might not be necessary. We may only need the bucket
+              # that is in the same region as the pipeline.
+              # Loop through all the artifact buckets created in the stackset
+              - {{.BucketArn}}
+              - !Join ['', ['{{.BucketArn}}', '/*']]{{end}}
+          -
+            Effect: Allow
+            Action:
+              # TODO: scope this down if possible
+              - kms:*
+            Resource:{{range .ArtifactBuckets}}
+              # TODO: This might not be necessary. We may only need the KMS key
+              # that is in the same region as the pipeline.
+              # Loop through all the KMS keys used to en/decrypt artifacts
+              # across (cross-regional) pipeline stages, with each stage
+              # backed by a (regional) S3 bucket.
+              - {{.KeyArn}}{{end}}
+          -
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      Roles:
+        -
+          !Ref BuildProjectRole
+  BuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Ref AWS::StackName
+      Description: !Ref AWS::StackName
+      # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
+      # created in the same region as this pipeline.
+      EncryptionKey: !ImportValue ArtifactKey
+      ServiceRole: !GetAtt BuildProjectRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        # enable interactions with Docker daemon from within the container
+        # run by the CodeBuild service
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                docker: 18
+            build:
+              commands:
+                # TODO: Fill in the actual build commands
+                - ls
+          artifacts:
+            # TODO: Fill in the paths to the CFN templates that this pipeline
+            # will deploy
+            files: '**/*'
+      TimeoutInMinutes: 60
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-codepipeline-role
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codepipeline.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  PipelineRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-codepipeline-policy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Action:
+              # TODO: Scope down the permissions if possible
+              - codepipeline:*
+              - iam:ListRoles
+              - cloudformation:Describe*
+              - cloudFormation:List*
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+              - cloudformation:CreateStack
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeStacks
+              - cloudformation:UpdateStack
+              - cloudformation:CreateChangeSet
+              - cloudformation:DeleteChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:SetStackPolicy
+              - cloudformation:ValidateTemplate
+              - iam:PassRole
+              - s3:ListAllMyBuckets
+              - s3:GetBucketLocation
+            Resource:
+              - "*"
+          -
+            Effect: Allow
+            Action:
+              - kms:Decrypt
+              - kms:Encrypt
+              - kms:GenerateDataKey
+            Resource:{{range .ArtifactBuckets}}
+              # Loop through all the KMS keys used to en/decrypt artifacts
+              # across (cross-regional) pipeline stages, with each stage
+              # backed by a (regional) S3 bucket.
+              - {{.KeyArn}}{{end}}
+          -
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetBucketPolicy
+              - s3:GetObject
+              - s3:ListBucket
+            Resource:{{range .ArtifactBuckets}}
+              # Loop through all the artifact buckets created in the stackset
+              - {{.BucketArn}}
+              - !Join ['', ['{{.BucketArn}}', '/*']]{{end}}
+          -
+            Effect: Allow
+            Action:
+              - sts:AssumeRole
+            Resource:{{range $stage := .Stages}}
+              - arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}
+      Roles:
+        -
+          !Ref PipelineRole
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    DependsOn:
+      - PipelineRole
+      - PipelineRolePolicy
+    Properties:
+      # Reference: https://github.com/aws-samples/aws-codepipeline-cross-region-continuous-deployment/blob/master/cfn-templates/cross-region-code-pipeline.yaml
+      ArtifactStores:{{range .ArtifactBuckets}}
+        # Loop through all the artifact buckets and the corresponding KMS
+        # keys created in the stackset
+        -
+          Region: {{.Region}}
+          ArtifactStore:
+            Type: S3
+            Location: {{.BucketName}}
+            EncryptionKey:
+              Id: {{.KeyArn}}
+              Type: KMS{{end}}
+      RoleArn: !GetAtt PipelineRole.Arn
+      Name: !Ref AWS::StackName
+      Stages:
+        - Name: Source
+          # defaults to pull for source changes instead of using webhook, same as CDK.
+          Actions:
+            - Name: SourceCodeFor-{{$.ProjectName}}
+              # https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-webhooks-create-cfn.html
+              ActionTypeId:
+                Category: Source
+                # TODO: #273 For CodeCommit, this needs to be AWS. Let's do that later
+                Owner: ThirdParty
+                Version: 1
+                Provider: {{.Source.ProviderName}}
+              Configuration:
+                # TODO: #273 For now this set of configurations is GitHub-specific,
+                # change it to be more generic
+                # https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#PollForSourceChanges-defaults
+                Owner: {{$.Source.Owner}}
+                Repo: {{$.Source.Repository}}
+                Branch: {{index $.Source.Properties "branch"}}
+                # https://alpha-docs-aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+                # Use the *entire* SecretString with version AWSCURRENT
+                OAuthToken: !Sub
+                    - '{{"{{"}}resolve:secretsmanager:${SecretId}{{"}}"}}'
+                    - { SecretId: !Ref GitHubOAuthSecretId }
+              OutputArtifacts:
+                - Name: SCCheckoutArtifact
+              RunOrder: 1
+        -
+          Name: Build
+          Actions:
+          -
+            Name: Build
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref BuildProject
+            RunOrder: 1
+            InputArtifacts:
+              - Name: SCCheckoutArtifact
+            OutputArtifacts:
+              - Name: BuildOutput
+        {{$length := len .Stages}}{{if gt $length 0}}
+        {{range $stage := .Stages}}
+        # {{$stage.Name}} is the same as the name of the environment
+        # this pipeline stage deploys to
+        - Name: DeployTo{{$.ProjectName}}-{{$stage.Name}}
+          Actions:{{range $app := $stage.LocalApplications}}
+            # TODO: #220 Add manual approval action if this stage is a prod stage
+            - Name: CreateChangeSet-{{$app}}-{{$stage.Name}}
+              Region: {{$stage.Region}}
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
+                ChangeSetName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                ActionMode: CHANGE_SET_REPLACE
+                StackName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                Capabilities: CAPABILITY_NAMED_IAM
+                TemplatePath: BuildOutput::{{$app}}-{{$stage.Name}}.yaml
+                # The ARN of the IAM role (in the env accountn) that
+                # AWS CloudFormation assumes when it operates on resources
+                # in a stack in an environment account.
+                # TODO: We need the actual name of the CFN execution role here
+                # (created while an environment AWS account is provisioned
+                # through Archer).
+                RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              # After we complete #220, the manual approval action will have a
+              # RunOrder of 1 such that it can block the deployment if this
+              # is a prod stage
+              RunOrder: 2
+              # The ARN of the environment manager IAM role (in the env
+              # account) that performs the declared action. This is assumed
+              # through the roleArn for the pipeline.
+              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole
+            - Name: DeployChangeSet-{{$app}}-{{$stage.Name}}
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Version: 1
+                Provider: CloudFormation
+              Configuration:
+                ChangeSetName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                ActionMode: CHANGE_SET_EXECUTE
+                StackName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-CFNExecutionRole
+              InputArtifacts:
+                - Name: BuildOutput
+              RunOrder: 3
+              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}{{end}}{{end}}

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -1,16 +1,15 @@
-#  Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
-#  the License. A copy of the License is located at
-#      http://aws.amazon.com/apache2.0/
-#  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-#  CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#     http://aws.amazon.com/apache2.0/
+# or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CodePipeline for the {{$.ProjectName}}
 Parameters:
-  // TODO: #273 make this source-provider-agnostic
+  # TODO: #273 make this source-provider-agnostic
   GitHubOAuthSecretId:
-    # https://alpha-docs-aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
     Description: The secretId of the GitHub OAuth token stored in the Secrets Manager
     Type: String
     Default: {{$.Source.GitHubOAuthSecretID}}
@@ -46,10 +45,10 @@ Resources:
               - s3:GetBucketPolicy
               - s3:GetObject
               - s3:ListBucket
+            # TODO: This might not be necessary. We may only need the bucket
+            # that is in the same region as the pipeline.
+            # Loop through all the artifact buckets created in the stackset
             Resource:{{range .ArtifactBuckets}}
-              # TODO: This might not be necessary. We may only need the bucket
-              # that is in the same region as the pipeline.
-              # Loop through all the artifact buckets created in the stackset
               - {{.BucketArn}}
               - !Join ['', ['{{.BucketArn}}', '/*']]{{end}}
           -
@@ -57,12 +56,12 @@ Resources:
             Action:
               # TODO: scope this down if possible
               - kms:*
+            # TODO: This might not be necessary. We may only need the KMS key
+            # that is in the same region as the pipeline.
+            # Loop through all the KMS keys used to en/decrypt artifacts
+            # across (cross-regional) pipeline stages, with each stage
+            # backed by a (regional) S3 bucket.
             Resource:{{range .ArtifactBuckets}}
-              # TODO: This might not be necessary. We may only need the KMS key
-              # that is in the same region as the pipeline.
-              # Loop through all the KMS keys used to en/decrypt artifacts
-              # across (cross-regional) pipeline stages, with each stage
-              # backed by a (regional) S3 bucket.
               - {{.KeyArn}}{{end}}
           -
             Effect: Allow
@@ -88,12 +87,12 @@ Resources:
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        # enable interactions with Docker daemon from within the container
-        # run by the CodeBuild service
         PrivilegedMode: true
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
+        # TODO: Fill in the actual build commands
+        # TODO: Fill in the paths to the CFN templates that this pipeline will deploy
         BuildSpec: |
           version: 0.2
           phases:
@@ -102,11 +101,8 @@ Resources:
                 docker: 18
             build:
               commands:
-                # TODO: Fill in the actual build commands
                 - ls
           artifacts:
-            # TODO: Fill in the paths to the CFN templates that this pipeline
-            # will deploy
             files: '**/*'
       TimeoutInMinutes: 60
   PipelineRole:
@@ -134,7 +130,6 @@ Resources:
           -
             Effect: Allow
             Action:
-              # TODO: Scope down the permissions if possible
               - codepipeline:*
               - iam:ListRoles
               - cloudformation:Describe*
@@ -163,9 +158,6 @@ Resources:
               - kms:Encrypt
               - kms:GenerateDataKey
             Resource:{{range .ArtifactBuckets}}
-              # Loop through all the KMS keys used to en/decrypt artifacts
-              # across (cross-regional) pipeline stages, with each stage
-              # backed by a (regional) S3 bucket.
               - {{.KeyArn}}{{end}}
           -
             Effect: Allow
@@ -175,7 +167,6 @@ Resources:
               - s3:GetObject
               - s3:ListBucket
             Resource:{{range .ArtifactBuckets}}
-              # Loop through all the artifact buckets created in the stackset
               - {{.BucketArn}}
               - !Join ['', ['{{.BucketArn}}', '/*']]{{end}}
           -
@@ -193,10 +184,8 @@ Resources:
       - PipelineRole
       - PipelineRolePolicy
     Properties:
-      # Reference: https://github.com/aws-samples/aws-codepipeline-cross-region-continuous-deployment/blob/master/cfn-templates/cross-region-code-pipeline.yaml
       ArtifactStores:{{range .ArtifactBuckets}}
-        # Loop through all the artifact buckets and the corresponding KMS
-        # keys created in the stackset
+        
         -
           Region: {{.Region}}
           ArtifactStore:
@@ -209,10 +198,8 @@ Resources:
       Name: !Ref AWS::StackName
       Stages:
         - Name: Source
-          # defaults to pull for source changes instead of using webhook, same as CDK.
           Actions:
             - Name: SourceCodeFor-{{$.ProjectName}}
-              # https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-webhooks-create-cfn.html
               ActionTypeId:
                 Category: Source
                 # TODO: #273 For CodeCommit, this needs to be AWS. Let's do that later
@@ -222,11 +209,10 @@ Resources:
               Configuration:
                 # TODO: #273 For now this set of configurations is GitHub-specific,
                 # change it to be more generic
-                # https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#PollForSourceChanges-defaults
                 Owner: {{$.Source.Owner}}
                 Repo: {{$.Source.Repository}}
                 Branch: {{index $.Source.Properties "branch"}}
-                # https://alpha-docs-aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
+                # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html#dynamic-references-secretsmanager
                 # Use the *entire* SecretString with version AWSCURRENT
                 OAuthToken: !Sub
                     - '{{"{{"}}resolve:secretsmanager:${SecretId}{{"}}"}}'


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR makes it possible to render a deployable CodePipeline in the form of Cloudformation template. For now it’s not hooked up into any archer command yet but the generated template has deployed successfully.

What’s working:
1. A deployable CodePipeline with a Source stage that can fetch code from Github
2. A Build stage that only runs `ls` and outputs everything (i.e. `**/*`) as built artifacts for now.

What’s not working:
1. When attempted to deploy using Cloudformation actions, they failed with `Access Denied (Service: Amazon S3; Status Code: 403; Error Code: AccessDenied`. Need to investigate further.
Update: Turns out this is just because my artifact buckets were manually created and do not have bucket policy to allow cross-account access (from env account back to the tools account, where the bucket is hosted)

2. Quite a few resources had to be manually provisioned for now because we don’t have the logic to create them yet or the resource names have not been finalized. Examples include:
	a. CFN execution role in each environment
	b. A secret in the Secrets Manager that stores the GitHub token
	c. artifact buckets and KMS keys to support cross-regional pipeline (David’s PR)
	d. maybe more……

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Closes #223.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
