### PR TITLE
Re-set accidentally removed COMMIT_ID variable in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,6 +33,7 @@ phases:
       - cp ./bin/local/archer-amd64 ./bin/local/archer-linux-$COMMIT_VERSION
       - mv ./bin/local/archer-amd64 ./bin/local/archer-linux-$VERSION
       - echo "Creating manifest file..."
+      - COMMIT_ID=`git rev-parse HEAD`
       - MANIFESTFILE="$COMMIT_ID.manifest"
       - echo ./bin/local/archer-windows-$COMMIT_VERSION.exe >> $MANIFESTFILE
       - echo ./bin/local/archer-windows-$VERSION.exe >> $MANIFESTFILE


### PR DESCRIPTION
Error in squashing commits in #276 resulted in the accidental removal of a crucial variable used in the title of the manifest file. This caused the deployment of the binaries generated on merge of #276 to fail, as the manifest generated by build stage was titled ".manifest" and the release stage expected "$COMMIT_ID.manifest" to exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
