### PR TITLE
Validate that archer resource names are lowercase

### DIFF
--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -141,7 +141,7 @@ func TestAppInitOpts_Validate(t *testing.T) {
 		},
 		"invalid app name": {
 			inAppName: "1234",
-			wantedErr: errors.New("application name 1234 is invalid: value must be start with letter and container only letters, numbers, and hyphens"),
+			wantedErr: errors.New(fmt.Sprintf("application name 1234 is invalid: %s", errValueBadFormat)),
 		},
 		"invalid dockerfile path": {
 			inDockerfilePath: "./hello/Dockerfile",

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -81,7 +81,7 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 			inEnvName:     "123env",
 			inProjectName: "phonetool",
 
-			wantedErr: "environment name 123env is invalid: value must be start with letter and container only letters, numbers, and hyphens",
+			wantedErr: fmt.Sprintf("environment name 123env is invalid: %s", errValueBadFormat),
 		},
 		"new workspace": {
 			inEnvName:     "test-pdx",

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -15,7 +15,7 @@ import (
 var (
 	errValueEmpty      = errors.New("value must not be empty")
 	errValueTooLong    = errors.New("value must not exceed 255 characters")
-	errValueBadFormat  = errors.New("value must be start with letter and container only lower-case letters, numbers, and hyphens")
+	errValueBadFormat  = errors.New("value must start with a letter and contain only lower-case letters, numbers, and hyphens")
 	errValueNotAString = errors.New("value must be a string")
 )
 

--- a/internal/pkg/cli/validate.go
+++ b/internal/pkg/cli/validate.go
@@ -15,7 +15,7 @@ import (
 var (
 	errValueEmpty      = errors.New("value must not be empty")
 	errValueTooLong    = errors.New("value must not exceed 255 characters")
-	errValueBadFormat  = errors.New("value must be start with letter and container only letters, numbers, and hyphens")
+	errValueBadFormat  = errors.New("value must be start with letter and container only lower-case letters, numbers, and hyphens")
 	errValueNotAString = errors.New("value must be a string")
 )
 
@@ -76,7 +76,7 @@ func basicNameValidation(val interface{}) error {
 }
 
 func isCorrectFormat(s string) bool {
-	valid, err := regexp.MatchString(`^[a-zA-Z][a-zA-Z0-9\-]+$`, s)
+	valid, err := regexp.MatchString(`^[a-z][a-z0-9\-]+$`, s)
 	if err != nil {
 		return false // bubble up error?
 	}

--- a/internal/pkg/cli/validate_test.go
+++ b/internal/pkg/cli/validate_test.go
@@ -45,6 +45,10 @@ var basicNameTestCases = map[string]testCase{
 		input: "123chicken",
 		want:  errValueBadFormat,
 	},
+	"contains upper-case letters": {
+		input: "badGoose",
+		want:  errValueBadFormat,
+	},
 }
 
 func TestValidateProjectName(t *testing.T) {
@@ -100,31 +104,35 @@ func TestValidateEnvironmentName(t *testing.T) {
 func TestIsCorrectFormat(t *testing.T) {
 	testCases := map[string]struct {
 		input string
-		want  bool
+		isLegit bool
 	}{
 		"numbers only input": {
 			input: "1234",
-			want:  false,
+			isLegit:  false,
 		},
-		"alphabetic input only": {
-			input: "abcDaZ",
-			want:  true,
+		"lower-case alphabetic input only": {
+			input: "badgoose",
+			isLegit:  true,
 		},
 		"alphanumeric string input": {
-			input: "abC123",
-			want:  true,
+			input: "abc123",
+			isLegit:  true,
 		},
 		"contains hyphen": {
 			input: "bad-goose",
-			want:  true,
+			isLegit:  true,
 		},
 		"non-alphanumeric string input": {
 			input: "bad-goose!",
-			want:  false,
+			isLegit:  false,
 		},
 		"starts with non-letter": {
 			input: "1bad-goose",
-			want:  false,
+			isLegit:  false,
+		},
+		"contains capital letter": {
+			input: "badGoose",
+			isLegit:  false,
 		},
 	}
 
@@ -132,7 +140,7 @@ func TestIsCorrectFormat(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := isCorrectFormat(tc.input)
 
-			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.isLegit, got)
 		})
 	}
 }


### PR DESCRIPTION
ECR repositories do not accept upper case characters due to Reasons™️.
This catches the error so it doesn't fail when deploying with CFN.

Fixes #185.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
