### PR TITLE
Fix project-resources template for apps with "-" in the name

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/project.go
+++ b/internal/pkg/deploy/cloudformation/stack/project.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"html/template"
 	"sort"
+	"strings"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/aws-sdk-go/aws"
@@ -79,7 +80,13 @@ func (e *ProjectStackConfig) ResourceTemplate(config *ProjectResourcesConfig) (s
 		return "", &ErrTemplateNotFound{templateLocation: projectResourcesTemplatePath, parentErr: err}
 	}
 
-	template, err := template.New("resourcetemplate").Parse(stackSetTemplate)
+	template, err := template.New("resourcetemplate").
+		Funcs(template.FuncMap{
+			"logicalIDSafe": func(logicalID string) string {
+				return strings.ReplaceAll(logicalID, "-", "DASH")
+			},
+		}).
+		Parse(stackSetTemplate)
 	if err != nil {
 		return "", err
 	}

--- a/templates/project/cf.yml
+++ b/templates/project/cf.yml
@@ -1,6 +1,6 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-AWSTemplateFormatVersion: '2010-09-09' {{$accounts := .Accounts}} {{$project := .Project}} {{$apps := .Apps}}
+AWSTemplateFormatVersion: '2010-09-09'{{$accounts := .Accounts}}{{$project := .Project}}{{$apps := .Apps}}
 # Cross-regional resources deployed via a stackset in the tools account
 # to support the CodePipeline for a workspace
 Description: Cross-regional resources to support the CodePipeline for a workspace
@@ -82,7 +82,7 @@ Resources:
     DeletionPolicy: Retain
 
 {{range $app := $apps}}
-  ECRRepo{{$app}}:
+  ECRRepo{{logicalIDSafe $app}}:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: {{$project}}/{{$app}}
@@ -112,7 +112,7 @@ Outputs:
   PipelineBucket:
     Description: Bucket used for CodePipeline to stage resources in.
     Value: !Ref PipelineBuiltArtifactBucket
-{{range $app := $apps}}  ECRRepo{{$app}}:
+{{range $app := $apps}}  ECRRepo{{logicalIDSafe $app}}:
     Description: ECR Repo used to store images of the {{$app}} app.
-    Value: !GetAtt ECRRepo{{$app}}.Arn
+    Value: !GetAtt ECRRepo{{logicalIDSafe $app}}.Arn
 {{end}}


### PR DESCRIPTION
CloudFormation logical IDs can't have dashes in the name. This
change "sanitizes" the logical IDs we generate in the project
resources stack.

We'll replace dashes with the word DASH (since caps aren't
allowed in app/project names - we won't have any collisions with
any real apps, which may have dash in their name).

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
