### PR TITLE
Add implementation for Project Resources

### DIFF
--- a/internal/pkg/aws/ecr/ecr.go
+++ b/internal/pkg/aws/ecr/ecr.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ecr contains utility functions for dealing with ECR repos
+package ecr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/arn"
+)
+
+const (
+	urlFmtString      = "%s.dkr.ecr.%s.amazonaws.com/%s"
+	arnResourcePrefix = "repository/"
+)
+
+// URIFromARN converts an ECR Repo ARN to a Repository URI
+func URIFromARN(repositoryARN string) (string, error) {
+	repoARN, err := arn.Parse(repositoryARN)
+	if err != nil {
+		return "", fmt.Errorf("parsing repository ARN %s: %w", repositoryARN, err)
+	}
+	// Repo ARNs look like arn:aws:ecr:region:012345678910:repository/test
+	// so we have to strip the repository out.
+	repoName := strings.TrimPrefix(repoARN.Resource, arnResourcePrefix)
+	return fmt.Sprintf(urlFmtString,
+		repoARN.AccountID,
+		repoARN.Region,
+		repoName), nil
+}

--- a/internal/pkg/aws/ecr/erc_test.go
+++ b/internal/pkg/aws/ecr/erc_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ecr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestURIFromARN(t *testing.T) {
+
+	testCases := map[string]struct {
+		givenARN  string
+		wantedURI string
+		wantErr   error
+	}{
+		"valid arn": {
+			givenARN:  "arn:aws:ecr:us-west-2:0123456789:repository/myrepo",
+			wantedURI: "0123456789.dkr.ecr.us-west-2.amazonaws.com/myrepo",
+		},
+		"valid arn with namespace": {
+			givenARN:  "arn:aws:ecr:us-west-2:0123456789:repository/myproject/myapp",
+			wantedURI: "0123456789.dkr.ecr.us-west-2.amazonaws.com/myproject/myapp",
+		},
+		"separate region": {
+			givenARN:  "arn:aws:ecr:us-east-1:0123456789:repository/myproject/myapp",
+			wantedURI: "0123456789.dkr.ecr.us-east-1.amazonaws.com/myproject/myapp",
+		},
+		"invalid ARN": {
+			givenARN: "myproject/myapp",
+			wantErr:  fmt.Errorf("parsing repository ARN myproject/myapp: arn: invalid prefix"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			uri, err := URIFromARN(tc.givenARN)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tc.wantErr.Error())
+			} else {
+				require.Equal(t, tc.wantedURI, uri)
+			}
+		})
+	}
+}

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -382,7 +382,7 @@ func TestWaitForStackCreation(t *testing.T) {
 		"error if no stacks returned": {
 			cf:    getMockWaitStackCreateCFClient(t, stackConfig.StackName(), false, true),
 			input: stackConfig,
-			want:  fmt.Errorf("failed to find a stack named %s after it was created", stackConfig.StackName()),
+			want:  fmt.Errorf("failed to find a stack named %s", stackConfig.StackName()),
 		},
 		"happy path": {
 			cf:    getMockWaitStackCreateCFClient(t, stackConfig.StackName(), false, false),

--- a/internal/pkg/deploy/cloudformation/stack/template_functions.go
+++ b/internal/pkg/deploy/cloudformation/stack/template_functions.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package stack
+
+import "strings"
+
+const (
+	dashReplacement = "DASH"
+)
+
+var templateFunctions = map[string]interface{}{
+	"logicalIDSafe": logicalIDSafe,
+}
+
+// logicalIDSafe takes a CloudFormation logical ID, and
+// sanitizes it by removing "-" characters (not allowed)
+// and replacing them with "DASH" (allowed by CloudFormation but
+// not permitted in ecs-cli generated resource names).
+func logicalIDSafe(logicalID string) string {
+	return strings.ReplaceAll(logicalID, "-", dashReplacement)
+}
+
+// safeLogicalIDToOriginal takes a "sanitized" logical ID
+// and converts it back to its original form, with dashes.
+func safeLogicalIDToOriginal(safeLogicalID string) string {
+	return strings.ReplaceAll(safeLogicalID, dashReplacement, "-")
+}


### PR DESCRIPTION
This adds the ability to get project resources by
reading the output of project resource cloudformation stacks.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
