### PR TITLE
Make app deploy flag and examples consistent

### DIFF
--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -40,7 +40,7 @@ func BuildAppDeployCommand() *cobra.Command {
 		Long: `Deploy an application to an environment.`,
 		Example: `
   Deploy an application named "frontend" to a "test" environment.
-  $ archer app deploy --name frontend --env test`,
+  /code $ archer app deploy --name frontend --env test`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := input.init(); err != nil {
 				return err
@@ -64,7 +64,7 @@ func BuildAppDeployCommand() *cobra.Command {
 		// },
 	}
 
-	cmd.Flags().StringVarP(&input.app, "app", "a", "", "application name")
+	cmd.Flags().StringVarP(&input.app, "name", "n", "", "application name")
 	cmd.Flags().StringVarP(&input.env, "env", "e", "", "environment name")
 	cmd.Flags().StringVarP(&input.imageTag, "tag", "t", "", "image tag")
 

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -261,7 +261,7 @@ func (opts *InitAppOpts) RecommendedActions() []string {
 	return []string{
 		fmt.Sprintf("Update your manifest %s to change the defaults.", color.HighlightResource(opts.manifestPath)),
 		fmt.Sprintf("Run %s to deploy your application to a %s environment.",
-			color.HighlightCode(fmt.Sprintf("archer app deploy --name %s --env %s --project %s", opts.AppName, defaultEnvironmentName, viper.GetString(projectFlag))),
+			color.HighlightCode(fmt.Sprintf("archer app deploy --name %s --env %s", opts.AppName, defaultEnvironmentName)),
 			defaultEnvironmentName),
 	}
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
* Change `app` flag in `app deploy` sub-command to `name`
* Remove `project` flag from the `init` workflow `app deploy` example 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
