### PR TITLE
Add a ProjectName method to globalOpts

### DIFF
--- a/internal/pkg/cli/app_deploy_test.go
+++ b/internal/pkg/cli/app_deploy_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 )
 
-func TestSourceInputs(t *testing.T) {
-	opts := appDeployOpts{}
-
-	got := opts.sourceInputs()
-
-	require.Equal(t, errNoProjectInWorkspace, got)
-}
-
 func TestSourceProjectApplications(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -68,7 +60,7 @@ func TestSourceProjectApplications(t *testing.T) {
 			tc.setupMocks()
 
 			opts := appDeployOpts{
-				globalOpts: globalOpts{
+				GlobalOpts: &GlobalOpts{
 					projectName: mockProjectName,
 				},
 				projectService: mockProjectService,
@@ -127,7 +119,7 @@ func TestSourceProjectEnvironments(t *testing.T) {
 			tc.setupMocks()
 
 			opts := appDeployOpts{
-				globalOpts: globalOpts{
+				GlobalOpts: &GlobalOpts{
 					projectName: mockProjectName,
 				},
 				projectService: mockProjectService,

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -46,7 +46,7 @@ type PackageAppOpts struct {
 	fs           afero.Fs
 	prompt       prompter
 
-	globalOpts // Embed global options.
+	*GlobalOpts // Embed global options.
 }
 
 // NewPackageAppOpts returns a new PackageAppOpts where the image tag is set to "manual-{short git sha}".
@@ -60,7 +60,7 @@ func NewPackageAppOpts() *PackageAppOpts {
 			paramsWriter: ioutil.Discard,
 			fs:           &afero.Afero{Fs: afero.NewOsFs()},
 			prompt:       prompt.New(),
-			globalOpts:   newGlobalOpts(),
+			GlobalOpts:   NewGlobalOpts(),
 		}
 	}
 	return &PackageAppOpts{
@@ -69,7 +69,7 @@ func NewPackageAppOpts() *PackageAppOpts {
 		paramsWriter: ioutil.Discard,
 		fs:           &afero.Afero{Fs: afero.NewOsFs()},
 		prompt:       prompt.New(),
-		globalOpts:   newGlobalOpts(),
+		GlobalOpts:   NewGlobalOpts(),
 	}
 }
 
@@ -105,7 +105,7 @@ func (opts *PackageAppOpts) Ask() error {
 
 // Validate returns an error if the values provided by the user are invalid.
 func (opts *PackageAppOpts) Validate() error {
-	if opts.projectName == "" {
+	if opts.ProjectName() == "" {
 		return errNoProjectInWorkspace
 	}
 	if opts.Tag == "" {
@@ -121,7 +121,7 @@ func (opts *PackageAppOpts) Validate() error {
 		}
 	}
 	if opts.EnvName != "" {
-		if _, err := opts.envStore.GetEnvironment(opts.projectName, opts.EnvName); err != nil {
+		if _, err := opts.envStore.GetEnvironment(opts.ProjectName(), opts.EnvName); err != nil {
 			return err
 		}
 	}
@@ -130,7 +130,7 @@ func (opts *PackageAppOpts) Validate() error {
 
 // Execute prints the CloudFormation template of the application for the environment.
 func (opts *PackageAppOpts) Execute() error {
-	env, err := opts.envStore.GetEnvironment(opts.projectName, opts.EnvName)
+	env, err := opts.envStore.GetEnvironment(opts.ProjectName(), opts.EnvName)
 	if err != nil {
 		return err
 	}
@@ -230,9 +230,9 @@ func contains(s string, items []string) bool {
 }
 
 func (opts *PackageAppOpts) listEnvNames() ([]string, error) {
-	envs, err := opts.envStore.ListEnvironments(opts.projectName)
+	envs, err := opts.envStore.ListEnvironments(opts.ProjectName())
 	if err != nil {
-		return nil, fmt.Errorf("list environments for project %s: %w", opts.projectName, err)
+		return nil, fmt.Errorf("list environments for project %s: %w", opts.ProjectName(), err)
 	}
 	var names []string
 	for _, env := range envs {

--- a/internal/pkg/cli/app_package_test.go
+++ b/internal/pkg/cli/app_package_test.go
@@ -169,11 +169,12 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			tc.expectPrompt(mockPrompt)
 
 			opts := &PackageAppOpts{
-				AppName:  tc.inAppName,
-				EnvName:  tc.inEnvName,
-				ws:       mockWorkspace,
-				envStore: mockEnvStore,
-				prompt:   mockPrompt,
+				AppName:    tc.inAppName,
+				EnvName:    tc.inEnvName,
+				ws:         mockWorkspace,
+				envStore:   mockEnvStore,
+				prompt:     mockPrompt,
+				GlobalOpts: &GlobalOpts{},
 			}
 
 			// WHEN
@@ -293,7 +294,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 				ws:       mockWorkspace,
 				envStore: mockEnvStore,
 
-				globalOpts: globalOpts{projectName: tc.inProjectName},
+				GlobalOpts: &GlobalOpts{projectName: tc.inProjectName},
 			}
 
 			// WHEN
@@ -476,7 +477,7 @@ count: 1`), nil)
 				paramsWriter: paramsBuf,
 				fs:           mockFS,
 
-				globalOpts: globalOpts{projectName: tc.inProjectName},
+				GlobalOpts: &GlobalOpts{projectName: tc.inProjectName},
 			}
 
 			// WHEN

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -16,15 +16,26 @@ func init() {
 	bindProjectName()
 }
 
-// globalOpts holds fields that are used across multiple commands.
-type globalOpts struct {
+// GlobalOpts holds fields that are used across multiple commands.
+type GlobalOpts struct {
 	projectName string
 }
 
-func newGlobalOpts() globalOpts {
-	return globalOpts{
+// NewGlobalOpts returns a GlobalOpts with the project name retrieved from viper.
+func NewGlobalOpts() *GlobalOpts {
+	return &GlobalOpts{
 		projectName: viper.GetString(projectFlag),
 	}
+}
+
+// ProjectName returns the project name.
+// If the name is empty, it caches it after querying viper.
+func (o *GlobalOpts) ProjectName() string {
+	if o.projectName != "" {
+		return o.projectName
+	}
+	o.projectName = viper.GetString(projectFlag)
+	return o.projectName
 }
 
 // actionCommand is the interface that every command that creates a resource implements.

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -55,7 +55,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 			addEnv := &InitEnvOpts{
 				EnvName:    tc.inputEnv,
 				prompt:     mockPrompter,
-				globalOpts: globalOpts{projectName: tc.inputProject},
+				GlobalOpts: &GlobalOpts{projectName: tc.inputProject},
 			}
 			tc.setupMocks()
 
@@ -99,7 +99,7 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 			// GIVEN
 			opts := &InitEnvOpts{
 				EnvName:    tc.inEnvName,
-				globalOpts: globalOpts{projectName: tc.inProjectName},
+				GlobalOpts: &GlobalOpts{projectName: tc.inProjectName},
 			}
 
 			// WHEN
@@ -352,7 +352,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				envDeployer:   mockEnvDeployer,
 				identity:      mockIdentity,
 				prog:          mockProgress,
-				globalOpts:    globalOpts{projectName: tc.inProjectName},
+				GlobalOpts:    &GlobalOpts{projectName: tc.inProjectName},
 			}
 
 			// WHEN

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -89,6 +89,7 @@ func NewInitOpts() (*InitOpts, error) {
 		prog:          spin,
 		prompt:        prompt,
 		identity:      id,
+		GlobalOpts:    NewGlobalOpts(),
 	}
 	return &InitOpts{
 		initProject: initProject,

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -41,12 +41,12 @@ type InitPipelineOpts struct {
 	// Caches environments
 	projectEnvs []string
 
-	globalOpts
+	*GlobalOpts
 }
 
 func NewInitPipelineOpts() *InitPipelineOpts {
 	return &InitPipelineOpts{
-		globalOpts: newGlobalOpts(),
+		GlobalOpts: NewGlobalOpts(),
 		prompt:     prompt.New(),
 	}
 }
@@ -86,7 +86,7 @@ func (opts *InitPipelineOpts) Ask() error {
 // Validate returns an error if the flag values passed by the user are invalid.
 func (opts *InitPipelineOpts) Validate() error {
 	// TODO
-	if opts.projectName == "" {
+	if opts.ProjectName() == "" {
 		return errNoProjectInWorkspace
 	}
 
@@ -249,9 +249,9 @@ func (opts *InitPipelineOpts) getEnvNames() ([]string, error) {
 		return nil, fmt.Errorf("couldn't connect to environment datastore: %w", err)
 	}
 
-	envs, err := store.ListEnvironments(opts.projectName)
+	envs, err := store.ListEnvironments(opts.ProjectName())
 	if err != nil {
-		return nil, fmt.Errorf("could not list environments for project %s: %w", opts.projectName, err)
+		return nil, fmt.Errorf("could not list environments for project %s: %w", opts.ProjectName(), err)
 	}
 
 	if len(envs) == 0 {


### PR DESCRIPTION
Commands should access the project name by querying the ProjectName.
If the ProjectName is empty in globalOpts, then it queries viper.

Fixes #295 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
