### PR TITLE
Cross reference the KMS key in CodePipeline

### DIFF
--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -86,7 +86,7 @@ Resources:
       Description: !Ref AWS::StackName
       # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
       # created in the same region as this pipeline.
-      EncryptionKey: !ImportValue ArtifactKey
+      EncryptionKey: !ImportValue chickenProject-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
         Type: CODEPIPELINE

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -80,7 +80,7 @@ Resources:
       Description: !Ref AWS::StackName
       # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
       # created in the same region as this pipeline.
-      EncryptionKey: !ImportValue ArtifactKey
+      EncryptionKey: !ImportValue {{$.ProjectName}}-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:
         Type: CODEPIPELINE

--- a/templates/project/cf.yml
+++ b/templates/project/cf.yml
@@ -109,6 +109,8 @@ Outputs:
   KMSKeyARN:
     Description: KMS Key used by CodePipeline for encrypting artifacts.
     Value: !GetAtt KMSKey.Arn
+    Export:
+      Name: {{$project}}-ArtifactKey
   PipelineBucket:
     Description: Bucket used for CodePipeline to stage resources in.
     Value: !Ref PipelineBuiltArtifactBucket


### PR DESCRIPTION
<!-- Provide summary of changes -->
The artifact bucket and corresponding encryption key used by the CodePipeline are created via the stackset. Since CodePipeline is provisioned in a separate CF stack, we need to create a cross-stack reference.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Closes #331.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
