### PR TITLE
Defaults to use the buildspec.yml

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
@@ -82,9 +82,9 @@ func mockCreatePipelineInput() *deploy.CreatePipelineInput {
 		Source: &deploy.Source{
 			ProviderName: "GitHub",
 			Properties: map[string]interface{}{
-				"repository":                 "hencrice/amazon-ecs-cli-v2",
-				"branch":                     "master",
-				"access_token_secret":        "testGitHubSecret",
+				"repository":          "hencrice/amazon-ecs-cli-v2",
+				"branch":              "master",
+				"access_token_secret": "testGitHubSecret",
 			},
 		},
 		Stages: []deploy.PipelineStage{

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -97,19 +97,6 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
-        # TODO: Fill in the actual build commands
-        # TODO: Fill in the paths to the CFN templates that this pipeline will deploy
-        BuildSpec: |
-          version: 0.2
-          phases:
-            install:
-              runtime-versions:
-                docker: 18
-            build:
-              commands:
-                - ls
-          artifacts:
-            files: '**/*'
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -97,6 +97,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
+        BuildSpec: ecs-project/buildspec.yml
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -91,19 +91,6 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
-        # TODO: Fill in the actual build commands
-        # TODO: Fill in the paths to the CFN templates that this pipeline will deploy
-        BuildSpec: |
-          version: 0.2
-          phases:
-            install:
-              runtime-versions:
-                docker: 18
-            build:
-              commands:
-                - ls
-          artifacts:
-            files: '**/*'
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -91,6 +91,7 @@ Resources:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
       Source:
         Type: CODEPIPELINE
+        BuildSpec: ecs-project/buildspec.yml
       TimeoutInMinutes: 60
   PipelineRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
<!-- Provide summary of changes -->
By removing the field "BuildSpec", CodeBuild will default to use the file named "buildspec.yml" that is checked into the source code. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #324.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
