### PR TITLE
Added manual approval step

### DIFF
--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -253,13 +253,9 @@ Resources:
               - Name: SCCheckoutArtifact
             OutputArtifacts:
               - Name: BuildOutput
-        
-        
-        # test is the same as the name of the environment
-        # this pipeline stage deploys to
+
         - Name: DeployTo-chickenProject-test
           Actions:
-            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-frontend-test
               Region: us-west-2
               ActionTypeId:
@@ -281,15 +277,11 @@ Resources:
                 RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              # After we complete #220, the manual approval action will have a
-              # RunOrder of 1 such that it can block the deployment if this
-              # is a prod stage
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-test
               Region: us-west-2
               ActionTypeId:
@@ -311,19 +303,20 @@ Resources:
                 RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              # After we complete #220, the manual approval action will have a
-              # RunOrder of 1 such that it can block the deployment if this
-              # is a prod stage
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-        # prod is the same as the name of the environment
-        # this pipeline stage deploys to
         - Name: DeployTo-chickenProject-prod
           Actions:
-            # TODO: #220 Add manual approval action if this stage is a prod stage
+            - Name: ApprovePromotionTo-prod
+              ActionTypeId:
+                Category: Approval
+                Owner: AWS
+                Provider: Manual
+                Version: 1
+              RunOrder: 1
             - Name: CreateOrUpdate-frontend-prod
               Region: us-east-1
               ActionTypeId:
@@ -345,15 +338,11 @@ Resources:
                 RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              # After we complete #220, the manual approval action will have a
-              # RunOrder of 1 such that it can block the deployment if this
-              # is a prod stage
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
-            # TODO: #220 Add manual approval action if this stage is a prod stage
             - Name: CreateOrUpdate-backend-prod
               Region: us-east-1
               ActionTypeId:
@@ -375,9 +364,6 @@ Resources:
                 RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              # After we complete #220, the manual approval action will have a
-              # RunOrder of 1 such that it can block the deployment if this
-              # is a prod stage
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -224,13 +224,16 @@ Resources:
               - Name: SCCheckoutArtifact
             OutputArtifacts:
               - Name: BuildOutput
-        {{$length := len .Stages}}{{if gt $length 0}}
-        {{range $stage := .Stages}}
-        # {{$stage.Name}} is the same as the name of the environment
-        # this pipeline stage deploys to
+{{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
         - Name: DeployTo-{{$.ProjectName}}-{{$stage.Name}}
-          Actions:{{range $app := $stage.LocalApplications}}
-            # TODO: #220 Add manual approval action if this stage is a prod stage
+          Actions:{{if $stage.Prod}}
+            - Name: ApprovePromotionTo-{{$stage.Name}}
+              ActionTypeId:
+                Category: Approval
+                Owner: AWS
+                Provider: Manual
+                Version: 1
+              RunOrder: 1{{end}}{{range $app := $stage.LocalApplications}}
             - Name: CreateOrUpdate-{{$app}}-{{$stage.Name}}
               Region: {{$stage.Region}}
               ActionTypeId:
@@ -252,9 +255,6 @@ Resources:
                 RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
-              # After we complete #220, the manual approval action will have a
-              # RunOrder of 1 such that it can block the deployment if this
-              # is a prod stage
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed


### PR DESCRIPTION
<!-- Provide summary of changes -->
The manual approval step was added before any application can be deployed in the production stage because the RunOrder of the approval step is the smallest compared to all apps (which all use 2).

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Closes #220.

After deployment, the pipeline looks like this with an approval step that blocks all deployment to the prod stage but not the other stages:
![Screen Shot 2019-11-12 at 4 56 59 PM](https://user-images.githubusercontent.com/3822365/68723460-77573700-056d-11ea-995c-79ebc50c9f3f.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
