### PR TITLE
Added approval step after deploying to each stage

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline.go
@@ -37,7 +37,9 @@ func (p *pipelineStackConfig) Template() (string, error) {
 		return "", &ErrTemplateNotFound{templateLocation: pipelineCfnTemplatePath, parentErr: err}
 	}
 
-	tpl, err := template.New("pipelineCfn").Parse(content)
+	tpl, err := template.New("pipelineCfn").
+		Funcs(templateFunctions).
+		Parse(content)
 	if err != nil {
 		return "", fmt.Errorf("parse CloudFormation template for project %s, pipeline %s, error: %w",
 			p.ProjectName, p.Name, err)

--- a/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
@@ -89,11 +89,11 @@ func mockCreatePipelineInput() *deploy.CreatePipelineInput {
 		},
 		Stages: []deploy.PipelineStage{
 			{
-				AssociatedEnvironment: mockAssociatedEnv("test", "us-west-2", false),
+				AssociatedEnvironment: mockAssociatedEnv("test-chicken", "us-west-2", false),
 				LocalApplications:     []string{"frontend", "backend"},
 			},
 			{
-				AssociatedEnvironment: mockAssociatedEnv("prod", "us-east-1", true),
+				AssociatedEnvironment: mockAssociatedEnv("prod-can-fly", "us-east-1", true),
 				LocalApplications:     []string{"frontend", "backend"},
 			},
 		},

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -114,11 +114,11 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /
-  IntegTestProjecttest:
+  IntegTestProjecttestDASHchicken:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Sub ${AWS::StackName}-IntegTest-test
-      Description: !Sub Integration tests for ${AWS::StackName}-test
+      Name: !Sub ${AWS::StackName}-IntegTest-test-chicken
+      Description: !Sub Integration tests for ${AWS::StackName}-test-chicken
       ServiceRole: !GetAtt IntegTestRole.Arn
       Artifacts:
         Type: CODEPIPELINE
@@ -130,16 +130,16 @@ Resources:
         EnvironmentVariables:
           - Name: PIPELINE_STAGE
             Type: PLAINTEXT
-            Value: test
+            Value: test-chicken
       Source:
         Type: CODEPIPELINE
         BuildSpec: ecs-project/buildspec_integ.yml
       TimeoutInMinutes: 480
-  IntegTestProjectprod:
+  IntegTestProjectprodDASHcanDASHfly:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Sub ${AWS::StackName}-IntegTest-prod
-      Description: !Sub Integration tests for ${AWS::StackName}-prod
+      Name: !Sub ${AWS::StackName}-IntegTest-prod-can-fly
+      Description: !Sub Integration tests for ${AWS::StackName}-prod-can-fly
       ServiceRole: !GetAtt IntegTestRole.Arn
       Artifacts:
         Type: CODEPIPELINE
@@ -151,7 +151,7 @@ Resources:
         EnvironmentVariables:
           - Name: PIPELINE_STAGE
             Type: PLAINTEXT
-            Value: prod
+            Value: prod-can-fly
       Source:
         Type: CODEPIPELINE
         BuildSpec: ecs-project/buildspec_integ.yml
@@ -231,8 +231,8 @@ Resources:
             Action:
               - sts:AssumeRole
             Resource:
-              - arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-              - arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
+              - arn:aws:iam::109876543210:role/chickenProject-test-chicken-EnvManagerRole
+              - arn:aws:iam::109876543210:role/chickenProject-prod-can-fly-EnvManagerRole
       Roles:
         -
           !Ref PipelineRole
@@ -309,9 +309,9 @@ Resources:
             OutputArtifacts:
               - Name: BuildOutput
 
-        - Name: DeployTo-test
+        - Name: DeployTo-test-chicken
           Actions:
-            - Name: CreateOrUpdate-frontend-test
+            - Name: CreateOrUpdate-frontend-test-chicken
               Region: us-west-2
               ActionTypeId:
                 Category: Deploy
@@ -320,24 +320,24 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-frontend-test
+                ChangeSetName: chickenProject-frontend-test-chicken
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-frontend-test
+                StackName: chickenProject-frontend-test-chicken
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend.stack.yml
-                TemplateConfiguration: BuildOutput::frontend-test.params.json
+                TemplateConfiguration: BuildOutput::frontend-test-chicken.params.json
                 # The ARN of the IAM role (in the env accountn) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.
-                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-chicken-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-            - Name: CreateOrUpdate-backend-test
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-chicken-EnvManagerRole
+            - Name: CreateOrUpdate-backend-test-chicken
               Region: us-west-2
               ActionTypeId:
                 Category: Deploy
@@ -346,46 +346,44 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-backend-test
+                ChangeSetName: chickenProject-backend-test-chicken
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-backend-test
+                StackName: chickenProject-backend-test-chicken
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend.stack.yml
-                TemplateConfiguration: BuildOutput::backend-test.params.json
+                TemplateConfiguration: BuildOutput::backend-test-chicken.params.json
                 # The ARN of the IAM role (in the env accountn) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.
-                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-chicken-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-        - Name: Validate-test
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-chicken-EnvManagerRole
+            - Name: Approve-test-chicken
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref IntegTestProjecttestDASHchicken
+              RunOrder: 3
+              InputArtifacts:
+                - Name: SCCheckoutArtifact
+        - Name: DeployTo-prod-can-fly
           Actions:
-          - Name: IntegTests
-            ActionTypeId:
-              Category: Build
-              Owner: AWS
-              Version: 1
-              Provider: CodeBuild
-            Configuration:
-              ProjectName: !Ref IntegTestProjecttest
-            RunOrder: 1
-            InputArtifacts:
-              - Name: SCCheckoutArtifact
-        - Name: DeployTo-prod
-          Actions:
-            - Name: ApprovePromotionTo-prod
+            - Name: ApprovePromotionTo-prod-can-fly
               ActionTypeId:
                 Category: Approval
                 Owner: AWS
                 Provider: Manual
                 Version: 1
               RunOrder: 1
-            - Name: CreateOrUpdate-frontend-prod
+            - Name: CreateOrUpdate-frontend-prod-can-fly
               Region: us-east-1
               ActionTypeId:
                 Category: Deploy
@@ -394,24 +392,24 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-frontend-prod
+                ChangeSetName: chickenProject-frontend-prod-can-fly
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-frontend-prod
+                StackName: chickenProject-frontend-prod-can-fly
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::frontend.stack.yml
-                TemplateConfiguration: BuildOutput::frontend-prod.params.json
+                TemplateConfiguration: BuildOutput::frontend-prod-can-fly.params.json
                 # The ARN of the IAM role (in the env accountn) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.
-                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-can-fly-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
-            - Name: CreateOrUpdate-backend-prod
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-can-fly-EnvManagerRole
+            - Name: CreateOrUpdate-backend-prod-can-fly
               Region: us-east-1
               ActionTypeId:
                 Category: Deploy
@@ -420,33 +418,31 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-backend-prod
+                ChangeSetName: chickenProject-backend-prod-can-fly
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-backend-prod
+                StackName: chickenProject-backend-prod-can-fly
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::backend.stack.yml
-                TemplateConfiguration: BuildOutput::backend-prod.params.json
+                TemplateConfiguration: BuildOutput::backend-prod-can-fly.params.json
                 # The ARN of the IAM role (in the env accountn) that
                 # AWS CloudFormation assumes when it operates on resources
                 # in a stack in an environment account.
-                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-CFNExecutionRole
+                RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-can-fly-CFNExecutionRole
               InputArtifacts:
                 - Name: BuildOutput
               RunOrder: 2
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
-        - Name: Validate-prod
-          Actions:
-          - Name: IntegTests
-            ActionTypeId:
-              Category: Build
-              Owner: AWS
-              Version: 1
-              Provider: CodeBuild
-            Configuration:
-              ProjectName: !Ref IntegTestProjectprod
-            RunOrder: 1
-            InputArtifacts:
-              - Name: SCCheckoutArtifact
+              RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-can-fly-EnvManagerRole
+            - Name: Approve-prod-can-fly
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref IntegTestProjectprodDASHcanDASHfly
+              RunOrder: 3
+              InputArtifacts:
+                - Name: SCCheckoutArtifact

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -82,8 +82,8 @@ Resources:
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Ref AWS::StackName
-      Description: !Ref AWS::StackName
+      Name: !Sub ${AWS::StackName}-BuildProject
+      Description: !Sub Build for ${AWS::StackName}
       # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
       # created in the same region as this pipeline.
       EncryptionKey: !ImportValue chickenProject-ArtifactKey
@@ -99,10 +99,67 @@ Resources:
         Type: CODEPIPELINE
         BuildSpec: ecs-project/buildspec.yml
       TimeoutInMinutes: 60
+  IntegTestRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-IntegTestRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+  IntegTestProjecttest:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${AWS::StackName}-IntegTest-test
+      Description: !Sub Integration tests for ${AWS::StackName}-test
+      ServiceRole: !GetAtt IntegTestRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        EnvironmentVariables:
+          - Name: PIPELINE_STAGE
+            Type: PLAINTEXT
+            Value: test
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: ecs-project/buildspec_integ.yml
+      TimeoutInMinutes: 480
+  IntegTestProjectprod:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${AWS::StackName}-IntegTest-prod
+      Description: !Sub Integration tests for ${AWS::StackName}-prod
+      ServiceRole: !GetAtt IntegTestRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        EnvironmentVariables:
+          - Name: PIPELINE_STAGE
+            Type: PLAINTEXT
+            Value: prod
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: ecs-project/buildspec_integ.yml
+      TimeoutInMinutes: 480
   PipelineRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-codepipeline-role
+      RoleName: !Sub ${AWS::StackName}-CodepipelineRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -117,7 +174,7 @@ Resources:
   PipelineRolePolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub ${AWS::StackName}-codepipeline-policy
+      PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -236,11 +293,9 @@ Resources:
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
               RunOrder: 1
-        -
-          Name: Build
+        - Name: Build
           Actions:
-          -
-            Name: Build
+          - Name: Build
             ActionTypeId:
               Category: Build
               Owner: AWS
@@ -254,7 +309,7 @@ Resources:
             OutputArtifacts:
               - Name: BuildOutput
 
-        - Name: DeployTo-chickenProject-test
+        - Name: DeployTo-test
           Actions:
             - Name: CreateOrUpdate-frontend-test
               Region: us-west-2
@@ -308,7 +363,20 @@ Resources:
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::109876543210:role/chickenProject-test-EnvManagerRole
-        - Name: DeployTo-chickenProject-prod
+        - Name: Validate-test
+          Actions:
+          - Name: IntegTests
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref IntegTestProjecttest
+            RunOrder: 1
+            InputArtifacts:
+              - Name: SCCheckoutArtifact
+        - Name: DeployTo-prod
           Actions:
             - Name: ApprovePromotionTo-prod
               ActionTypeId:
@@ -369,3 +437,16 @@ Resources:
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::109876543210:role/chickenProject-prod-EnvManagerRole
+        - Name: Validate-prod
+          Actions:
+          - Name: IntegTests
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref IntegTestProjectprod
+            RunOrder: 1
+            InputArtifacts:
+              - Name: SCCheckoutArtifact

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -108,7 +108,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /{{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
-  IntegTestProject{{$stage.Name}}:
+  IntegTestProject{{logicalIDSafe $stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:
       Name: !Sub ${AWS::StackName}-IntegTest-{{$stage.Name}}
@@ -294,16 +294,14 @@ Resources:
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
               RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}
-        - Name: Validate-{{$stage.Name}}
-          Actions:
-          - Name: IntegTests
-            ActionTypeId:
-              Category: Build
-              Owner: AWS
-              Version: 1
-              Provider: CodeBuild
-            Configuration:
-              ProjectName: !Ref IntegTestProject{{$stage.Name}}
-            RunOrder: 1
-            InputArtifacts:
-              - Name: SCCheckoutArtifact{{end}}{{end}}
+            - Name: Approve-{{$stage.Name}}
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref IntegTestProject{{logicalIDSafe $stage.Name}}
+              RunOrder: 3
+              InputArtifacts:
+                - Name: SCCheckoutArtifact{{end}}{{end}}

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -76,8 +76,8 @@ Resources:
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: !Ref AWS::StackName
-      Description: !Ref AWS::StackName
+      Name: !Sub ${AWS::StackName}-BuildProject
+      Description: !Sub Build for ${AWS::StackName}
       # ArtifactKey is the KMS key ID or ARN that is used with the artifact bucket
       # created in the same region as this pipeline.
       EncryptionKey: !ImportValue {{$.ProjectName}}-ArtifactKey
@@ -93,10 +93,46 @@ Resources:
         Type: CODEPIPELINE
         BuildSpec: ecs-project/buildspec.yml
       TimeoutInMinutes: 60
+  IntegTestRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${AWS::StackName}-IntegTestRole
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /{{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
+  IntegTestProject{{$stage.Name}}:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${AWS::StackName}-IntegTest-{{$stage.Name}}
+      Description: !Sub Integration tests for ${AWS::StackName}-{{$stage.Name}}
+      ServiceRole: !GetAtt IntegTestRole.Arn
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        PrivilegedMode: true
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:1.0
+        EnvironmentVariables:
+          - Name: PIPELINE_STAGE
+            Type: PLAINTEXT
+            Value: {{$stage.Name}}
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: ecs-project/buildspec_integ.yml
+      TimeoutInMinutes: 480{{end}}{{end}}
   PipelineRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-codepipeline-role
+      RoleName: !Sub ${AWS::StackName}-CodepipelineRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -111,7 +147,7 @@ Resources:
   PipelineRolePolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub ${AWS::StackName}-codepipeline-policy
+      PolicyName: !Sub ${AWS::StackName}-CodepipelinePolicy
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -207,11 +243,9 @@ Resources:
               OutputArtifacts:
                 - Name: SCCheckoutArtifact
               RunOrder: 1
-        -
-          Name: Build
+        - Name: Build
           Actions:
-          -
-            Name: Build
+          - Name: Build
             ActionTypeId:
               Category: Build
               Owner: AWS
@@ -225,7 +259,7 @@ Resources:
             OutputArtifacts:
               - Name: BuildOutput
 {{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
-        - Name: DeployTo-{{$.ProjectName}}-{{$stage.Name}}
+        - Name: DeployTo-{{$stage.Name}}
           Actions:{{if $stage.Prod}}
             - Name: ApprovePromotionTo-{{$stage.Name}}
               ActionTypeId:
@@ -259,4 +293,17 @@ Resources:
               # The ARN of the environment manager IAM role (in the env
               # account) that performs the declared action. This is assumed
               # through the roleArn for the pipeline.
-              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}{{end}}{{end}}
+              RoleArn: arn:aws:iam::{{$stage.AccountID}}:role/{{$.ProjectName}}-{{$stage.Name}}-EnvManagerRole{{end}}
+        - Name: Validate-{{$stage.Name}}
+          Actions:
+          - Name: IntegTests
+            ActionTypeId:
+              Category: Build
+              Owner: AWS
+              Version: 1
+              Provider: CodeBuild
+            Configuration:
+              ProjectName: !Ref IntegTestProject{{$stage.Name}}
+            RunOrder: 1
+            InputArtifacts:
+              - Name: SCCheckoutArtifact{{end}}{{end}}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Enable customers to run their buildspec_integ.yml after deploying to each stage. The CodeBuild project is provided with the name of the stage that it is validating against. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Closes #340.

![Screen Shot 2019-11-13 at 11 29 36 AM](https://user-images.githubusercontent.com/3822365/68797568-afac5300-0609-11ea-9027-2843cbaed4d4.png)

![Screen Shot 2019-11-13 at 11 35 47 AM](https://user-images.githubusercontent.com/3822365/68797608-c18df600-0609-11ea-9303-4181defa0c1e.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
