### PR TITLE
Rename ReadManifestFile and WriteManifestFile to Read/WriteFile

### DIFF
--- a/cf-custom-resources/package-lock.json
+++ b/cf-custom-resources/package-lock.json
@@ -3134,9 +3134,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
-      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -5995,9 +5995,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.8",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
-      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/internal/pkg/archer/workspace.go
+++ b/internal/pkg/archer/workspace.go
@@ -19,8 +19,13 @@ type Workspace interface {
 
 // ManifestIO can read, write and list local manifest files.
 type ManifestIO interface {
-	WriteManifest(manifestBlob []byte, filename string) (string, error)
-	ReadManifestFile(manifestFileName string) ([]byte, error)
+	WorkspaceFileReadWriter
 	ListManifestFiles() ([]string, error)
 	AppManifestFileName(appName string) string
+}
+
+// WorkspaceFileReadWriter is the interface to read and write files to the project directory in the workspace.
+type WorkspaceFileReadWriter interface {
+	WriteFile(blob []byte, filename string) (string, error)
+	ReadFile(filename string) ([]byte, error)
 }

--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -428,7 +428,7 @@ func (opts appDeployOpts) getAppDockerfilePath() (string, error) {
 		return "", errors.New("couldn't match manifest file name")
 	}
 
-	manifestBytes, err := opts.workspaceService.ReadManifestFile(targetManifestFile)
+	manifestBytes, err := opts.workspaceService.ReadFile(targetManifestFile)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -135,7 +135,7 @@ func (opts *InitAppOpts) createManifest() (string, error) {
 		return "", fmt.Errorf("marshal manifest: %w", err)
 	}
 	filename := opts.manifestWriter.AppManifestFileName(opts.AppName)
-	manifestPath, err := opts.manifestWriter.WriteManifest(manifestBytes, filename)
+	manifestPath, err := opts.manifestWriter.WriteFile(manifestBytes, filename)
 	if err != nil {
 		return "", fmt.Errorf("write manifest for app %s: %w", opts.AppName, err)
 	}

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -92,9 +92,9 @@ func TestAppInitOpts_Ask(t *testing.T) {
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
 
-				fs:         &afero.Afero{Fs: afero.NewMemMapFs()},
+				fs: &afero.Afero{Fs: afero.NewMemMapFs()},
 				GlobalOpts: &GlobalOpts{
-					prompt:     mockPrompt,
+					prompt: mockPrompt,
 				},
 			}
 			tc.mockFileSystem(opts.fs)
@@ -200,7 +200,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil)
 			},
 			mockAppStore: func(m *mocks.MockApplicationStore) {
 				m.EXPECT().GetApplication("project", "frontend").Return(nil, &store.ErrNoSuchApplication{})
@@ -240,7 +240,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil)
 			},
 			mockAppStore: func(m *mocks.MockApplicationStore) {
 				m.EXPECT().GetApplication("project", "frontend").Return(nil, &store.ErrNoSuchApplication{})
@@ -261,7 +261,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil)
 			},
 			mockAppStore: func(m *mocks.MockApplicationStore) {
 				m.EXPECT().GetApplication("project", "frontend").Return(nil, &store.ErrNoSuchApplication{})
@@ -290,7 +290,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile).Times(0)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil).Times(0)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil).Times(0)
 			},
 			mockProgress:     func(m *climocks.Mockprogress) {},
 			mockProjGetter:   func(m *mocks.MockProjectGetter) {},
@@ -313,7 +313,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile).Times(0)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil).Times(0)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil).Times(0)
 			},
 			mockProgress:     func(m *climocks.Mockprogress) {},
 			mockProjGetter:   func(m *mocks.MockProjectGetter) {},
@@ -335,7 +335,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockManifestWriter: func(m *mocks.MockManifestIO) {
 				manifestFile := "/frontend-app.yml"
 				m.EXPECT().AppManifestFileName("frontend").Return(manifestFile)
-				m.EXPECT().WriteManifest(gomock.Any(), manifestFile).Return("/frontend", nil)
+				m.EXPECT().WriteFile(gomock.Any(), manifestFile).Return("/frontend", nil)
 			},
 			mockProgress: func(m *climocks.Mockprogress) {
 				m.EXPECT().Start(gomock.Any())

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -169,7 +169,7 @@ type cfnTemplates struct {
 
 // getTemplates returns the CloudFormation stack's template and its parameters.
 func (opts *PackageAppOpts) getTemplates(env *archer.Environment) (*cfnTemplates, error) {
-	raw, err := opts.ws.ReadManifestFile(opts.ws.AppManifestFileName(opts.AppName))
+	raw, err := opts.ws.ReadFile(opts.ws.AppManifestFileName(opts.AppName))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/app_package_test.go
+++ b/internal/pkg/cli/app_package_test.go
@@ -353,7 +353,7 @@ func TestPackageAppOpts_Execute(t *testing.T) {
 				})
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
-				m.EXPECT().ReadManifestFile(gomock.Any()).Times(0)
+				m.EXPECT().ReadFile(gomock.Any()).Times(0)
 			},
 			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {},
 
@@ -375,7 +375,7 @@ func TestPackageAppOpts_Execute(t *testing.T) {
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return(nil, &workspace.ErrManifestNotFound{
+				m.EXPECT().ReadFile("frontend-app.yml").Return(nil, &workspace.ErrManifestNotFound{
 					ManifestName: "frontend-app.yml",
 				})
 			},
@@ -398,7 +398,7 @@ func TestPackageAppOpts_Execute(t *testing.T) {
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte("somecontent"), nil)
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte("somecontent"), nil)
 			},
 			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {},
 
@@ -418,7 +418,7 @@ func TestPackageAppOpts_Execute(t *testing.T) {
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte(`name: frontend
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
 type: Load Balanced Web App`), nil)
 			},
 			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {},
@@ -444,7 +444,7 @@ type: Load Balanced Web App`), nil)
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte(`name: frontend
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
 type: Load Balanced Web App`), nil)
 			},
 			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {
@@ -474,7 +474,7 @@ type: Load Balanced Web App`), nil)
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte(`name: frontend
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
 type: Load Balanced Web App`), nil)
 			},
 			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {
@@ -511,7 +511,7 @@ type: Load Balanced Web App`), nil)
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte(`name: frontend
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
 type: Load Balanced Web App
 image:
   build: frontend/Dockerfile
@@ -551,7 +551,7 @@ count: 1`), nil)
 			},
 			expectWorkspace: func(m *mocks.MockWorkspace) {
 				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
-				m.EXPECT().ReadManifestFile("frontend-app.yml").Return([]byte(`name: frontend
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
 type: Load Balanced Web App
 image:
   build: frontend/Dockerfile

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
+	"github.com/gobuffalo/packd"
 
 	"github.com/spf13/cobra"
 )
@@ -42,6 +43,7 @@ type InitPipelineOpts struct {
 	// Interfaces to interact with dependencies.
 	manifestWriter archer.ManifestIO
 	secretsmanager archer.SecretsManager
+	box            packd.Box
 
 	// Outputs stored on successful actions.
 	manifestPath string
@@ -193,12 +195,16 @@ func (opts *InitPipelineOpts) createPipelineManifest() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal manifest: %w", err)
 	}
-	manifestPath, err := opts.manifestWriter.WriteManifest(manifestBytes, pipelineDefaultFilename)
+	manifestPath, err := opts.manifestWriter.WriteFile(manifestBytes, pipelineDefaultFilename)
 	if err != nil {
 		return "", fmt.Errorf("write manifest for app %s: %w", pipelineDefaultFilename, err)
 	}
 
 	return manifestPath, nil
+}
+
+func (opts *InitPipelineOpts) createBuildspec() (string, error) {
+	return "", nil
 }
 
 func (opts *InitPipelineOpts) selectEnvironments(addMore bool) error {

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -213,7 +213,7 @@ A project is a collection of containerized applications (or micro-services) that
 			return opts.Execute()
 		},
 		PostRun: func(cmd *cobra.Command, args []string) {
-			log.Successf("The directory %s will hold application manifests for project %s.\n", color.HighlightResource(workspace.ManifestDirectoryName), color.HighlightUserInput(opts.ProjectName))
+			log.Successf("The directory %s will hold application manifests for project %s.\n", color.HighlightResource(workspace.ProjectDirectoryName), color.HighlightUserInput(opts.ProjectName))
 			log.Infoln()
 			log.Infoln("Recommended follow-up actions:")
 			for _, followUp := range opts.RecommendedActions() {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -186,7 +186,7 @@ func TestReadManifest(t *testing.T) {
 				workingDir: tc.workingDir,
 				fsUtils:    &afero.Afero{Fs: appFS},
 			}
-			content, err := ws.ReadManifestFile(tc.manifestFile)
+			content, err := ws.ReadFile(tc.manifestFile)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedContent, string(content))
@@ -235,11 +235,11 @@ func TestWriteManifest(t *testing.T) {
 				workingDir: tc.workingDir,
 				fsUtils:    &afero.Afero{Fs: appFS},
 			}
-			manifestPath, err := ws.WriteManifest([]byte(tc.expectedContent), tc.manifestFile)
+			manifestPath, err := ws.WriteFile([]byte(tc.expectedContent), tc.manifestFile)
 			require.Equal(t, tc.expectedPath, manifestPath)
 			if tc.expectedError == nil {
 				require.NoError(t, err)
-				readContent, err := ws.ReadManifestFile(tc.manifestFile)
+				readContent, err := ws.ReadFile(tc.manifestFile)
 				require.NoError(t, err)
 				require.Equal(t, tc.expectedContent, string(readContent))
 			} else {

--- a/mocks/mock_workspace.go
+++ b/mocks/mock_workspace.go
@@ -33,34 +33,34 @@ func (m *MockWorkspace) EXPECT() *MockWorkspaceMockRecorder {
 	return m.recorder
 }
 
-// WriteManifest mocks base method
-func (m *MockWorkspace) WriteManifest(manifestBlob []byte, filename string) (string, error) {
+// WriteFile mocks base method
+func (m *MockWorkspace) WriteFile(blob []byte, filename string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteManifest", manifestBlob, filename)
+	ret := m.ctrl.Call(m, "WriteFile", blob, filename)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WriteManifest indicates an expected call of WriteManifest
-func (mr *MockWorkspaceMockRecorder) WriteManifest(manifestBlob, filename interface{}) *gomock.Call {
+// WriteFile indicates an expected call of WriteFile
+func (mr *MockWorkspaceMockRecorder) WriteFile(blob, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteManifest", reflect.TypeOf((*MockWorkspace)(nil).WriteManifest), manifestBlob, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockWorkspace)(nil).WriteFile), blob, filename)
 }
 
-// ReadManifestFile mocks base method
-func (m *MockWorkspace) ReadManifestFile(manifestFileName string) ([]byte, error) {
+// ReadFile mocks base method
+func (m *MockWorkspace) ReadFile(filename string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadManifestFile", manifestFileName)
+	ret := m.ctrl.Call(m, "ReadFile", filename)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadManifestFile indicates an expected call of ReadManifestFile
-func (mr *MockWorkspaceMockRecorder) ReadManifestFile(manifestFileName interface{}) *gomock.Call {
+// ReadFile indicates an expected call of ReadFile
+func (mr *MockWorkspaceMockRecorder) ReadFile(filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadManifestFile", reflect.TypeOf((*MockWorkspace)(nil).ReadManifestFile), manifestFileName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockWorkspace)(nil).ReadFile), filename)
 }
 
 // ListManifestFiles mocks base method
@@ -159,34 +159,34 @@ func (m *MockManifestIO) EXPECT() *MockManifestIOMockRecorder {
 	return m.recorder
 }
 
-// WriteManifest mocks base method
-func (m *MockManifestIO) WriteManifest(manifestBlob []byte, filename string) (string, error) {
+// WriteFile mocks base method
+func (m *MockManifestIO) WriteFile(blob []byte, filename string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteManifest", manifestBlob, filename)
+	ret := m.ctrl.Call(m, "WriteFile", blob, filename)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WriteManifest indicates an expected call of WriteManifest
-func (mr *MockManifestIOMockRecorder) WriteManifest(manifestBlob, filename interface{}) *gomock.Call {
+// WriteFile indicates an expected call of WriteFile
+func (mr *MockManifestIOMockRecorder) WriteFile(blob, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteManifest", reflect.TypeOf((*MockManifestIO)(nil).WriteManifest), manifestBlob, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockManifestIO)(nil).WriteFile), blob, filename)
 }
 
-// ReadManifestFile mocks base method
-func (m *MockManifestIO) ReadManifestFile(manifestFileName string) ([]byte, error) {
+// ReadFile mocks base method
+func (m *MockManifestIO) ReadFile(filename string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadManifestFile", manifestFileName)
+	ret := m.ctrl.Call(m, "ReadFile", filename)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadManifestFile indicates an expected call of ReadManifestFile
-func (mr *MockManifestIOMockRecorder) ReadManifestFile(manifestFileName interface{}) *gomock.Call {
+// ReadFile indicates an expected call of ReadFile
+func (mr *MockManifestIOMockRecorder) ReadFile(filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadManifestFile", reflect.TypeOf((*MockManifestIO)(nil).ReadManifestFile), manifestFileName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockManifestIO)(nil).ReadFile), filename)
 }
 
 // ListManifestFiles mocks base method
@@ -216,4 +216,57 @@ func (m *MockManifestIO) AppManifestFileName(appName string) string {
 func (mr *MockManifestIOMockRecorder) AppManifestFileName(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppManifestFileName", reflect.TypeOf((*MockManifestIO)(nil).AppManifestFileName), appName)
+}
+
+// MockWorkspaceFileReadWriter is a mock of WorkspaceFileReadWriter interface
+type MockWorkspaceFileReadWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockWorkspaceFileReadWriterMockRecorder
+}
+
+// MockWorkspaceFileReadWriterMockRecorder is the mock recorder for MockWorkspaceFileReadWriter
+type MockWorkspaceFileReadWriterMockRecorder struct {
+	mock *MockWorkspaceFileReadWriter
+}
+
+// NewMockWorkspaceFileReadWriter creates a new mock instance
+func NewMockWorkspaceFileReadWriter(ctrl *gomock.Controller) *MockWorkspaceFileReadWriter {
+	mock := &MockWorkspaceFileReadWriter{ctrl: ctrl}
+	mock.recorder = &MockWorkspaceFileReadWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockWorkspaceFileReadWriter) EXPECT() *MockWorkspaceFileReadWriterMockRecorder {
+	return m.recorder
+}
+
+// WriteFile mocks base method
+func (m *MockWorkspaceFileReadWriter) WriteFile(blob []byte, filename string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteFile", blob, filename)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteFile indicates an expected call of WriteFile
+func (mr *MockWorkspaceFileReadWriterMockRecorder) WriteFile(blob, filename interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteFile", reflect.TypeOf((*MockWorkspaceFileReadWriter)(nil).WriteFile), blob, filename)
+}
+
+// ReadFile mocks base method
+func (m *MockWorkspaceFileReadWriter) ReadFile(filename string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadFile", filename)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadFile indicates an expected call of ReadFile
+func (mr *MockWorkspaceFileReadWriterMockRecorder) ReadFile(filename interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFile", reflect.TypeOf((*MockWorkspaceFileReadWriter)(nil).ReadFile), filename)
 }


### PR DESCRIPTION
These methods are generic enough so that we can write and read files that are under the "ecs-project" directory. This PR renames them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
