### PR TITLE
Remove roleName

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline.go
@@ -27,8 +27,6 @@ func NewPipelineStackConfig(in *deploy.CreatePipelineInput) *pipelineStackConfig
 	}
 }
 
-// TODO https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html
-// Role names limited to 64 chars bc UGH
 func (p *pipelineStackConfig) StackName() string {
 	return p.ProjectName + "-" + p.Name
 }

--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -17,8 +17,6 @@ Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role
     Properties:
-      # StackName is <projectName>-<pipelineName>
-      RoleName: !Sub ${AWS::StackName}-CodeBuildRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -102,7 +100,6 @@ Resources:
   IntegTestRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-IntegTestRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -159,7 +156,6 @@ Resources:
   PipelineRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-CodepipelineRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -17,8 +17,6 @@ Resources:
   BuildProjectRole:
     Type: AWS::IAM::Role
     Properties:
-      # StackName is <projectName>-<pipelineName>
-      RoleName: !Sub ${AWS::StackName}-CodeBuildRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -96,7 +94,6 @@ Resources:
   IntegTestRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-IntegTestRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -132,7 +129,6 @@ Resources:
   PipelineRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub ${AWS::StackName}-CodepipelineRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
This allows CFN to set a role name for us, which is fine since these
names are not referred to outside the template. This bypasses the need
to check that the role name satisfies the 64-character limit.

See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
