### PR TITLE
Added Cloudwatch permission to the integ test role

### DIFF
--- a/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/testdata/rendered_pipeline_cfn_template.yml
@@ -22,8 +22,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
               Service:
                 - codebuild.amazonaws.com
@@ -38,8 +37,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - s3:PutObject
               - s3:GetBucketPolicy
@@ -55,8 +53,7 @@ Resources:
               - !Join ['', ['chicken-us-west-2', '/*']]
               - chicken-us-west-1
               - !Join ['', ['chicken-us-west-1', '/*']]
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               # TODO: scope this down if possible
               - kms:*
@@ -69,16 +66,14 @@ Resources:
               - arn:aws:kms:us-east-1:012345678910:key/30131d3f-c30f-4d49-beaa-cf4bfc07f34e
               - arn:aws:kms:us-west-2:012345678910:key/80de5f7f-422d-4dff-8f4d-01f6ec5715bc
               - arn:aws:kms:us-west-1:012345678910:key/75668c57-ec4b-4d0c-b880-8dc3fa78f6d1
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
       Roles:
-        -
-          !Ref BuildProjectRole
+        - !Ref BuildProjectRole
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -114,6 +109,22 @@ Resources:
             Action:
               - sts:AssumeRole
       Path: /
+  IntegTestPolicy:
+    Type: AWS::IAM::Policy
+    DependsOn: IntegTestRole
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-IntegTestPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      Roles:
+        - !Ref IntegTestRole
   IntegTestProjecttestDASHchicken:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -22,8 +22,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
               Service:
                 - codebuild.amazonaws.com
@@ -38,8 +37,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - s3:PutObject
               - s3:GetBucketPolicy
@@ -51,8 +49,7 @@ Resources:
             Resource:{{range .ArtifactBuckets}}
               - {{.BucketName}}
               - !Join ['', ['{{.BucketName}}', '/*']]{{end}}
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               # TODO: scope this down if possible
               - kms:*
@@ -63,16 +60,14 @@ Resources:
             # backed by a (regional) S3 bucket.
             Resource:{{range .ArtifactBuckets}}
               - {{.KeyArn}}{{end}}
-          -
-            Effect: Allow
+          - Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: arn:aws:logs:*:*:*
       Roles:
-        -
-          !Ref BuildProjectRole
+        - !Ref BuildProjectRole
   BuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -107,7 +102,23 @@ Resources:
                 - codebuild.amazonaws.com
             Action:
               - sts:AssumeRole
-      Path: /{{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
+      Path: /
+  IntegTestPolicy:
+    Type: AWS::IAM::Policy
+    DependsOn: IntegTestRole
+    Properties:
+      PolicyName: !Sub ${AWS::StackName}-IntegTestPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:*
+      Roles:
+        - !Ref IntegTestRole{{$length := len .Stages}}{{if gt $length 0}}{{range $stage := .Stages}}
   IntegTestProject{{logicalIDSafe $stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:


### PR DESCRIPTION
<!-- Provide summary of changes -->
The CodeBuild project that runs integration tests in the pipeline need at least the Cloudwatch permissions.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Closes #379.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
