### PR TITLE
Fix shell completion

### DIFF
--- a/cmd/archer/main.go
+++ b/cmd/archer/main.go
@@ -57,7 +57,7 @@ func buildRootCmd() *cobra.Command {
 
 	// "Settings" command group.
 	cmd.AddCommand(cli.BuildVersionCmd())
-	cmd.AddCommand(cli.BuildCompletionCmd())
+	cmd.AddCommand(cli.BuildCompletionCmd(cmd))
 
 	// "Release" command group.
 	cmd.AddCommand(cli.BuildPipelineCmd())

--- a/internal/pkg/cli/completion.go
+++ b/internal/pkg/cli/completion.go
@@ -48,7 +48,7 @@ func (opts *CompletionOpts) Execute() error {
 }
 
 // BuildCompletionCmd returns the command to output shell completion code for the specified shell (bash or zsh).
-func BuildCompletionCmd() *cobra.Command {
+func BuildCompletionCmd(rootCmd *cobra.Command) *cobra.Command {
 	opts := &CompletionOpts{}
 	cmd := &cobra.Command{
 		Use:   "completion [shell]",
@@ -66,7 +66,9 @@ The code must be evaluated to provide interactive completion of commands.`,
   /code $ archer completion bash > /usr/local/etc/bash_completion.d
 
   Install bash completion on linux
-  /code $ source <(archer completion bash)`,
+  /code $ source <(archer completion bash)
+  /code $ archer completion bash > archer.sh
+  /code $ sudo mv archer.sh /etc/bash_completion.d/archer`,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Shell = args[0]
@@ -74,7 +76,7 @@ The code must be evaluated to provide interactive completion of commands.`,
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.w = os.Stdout
-			opts.completer = cmd
+			opts.completer = rootCmd
 			return opts.Execute()
 		},
 	}

--- a/internal/pkg/cli/completion.go
+++ b/internal/pkg/cli/completion.go
@@ -69,7 +69,12 @@ The code must be evaluated to provide interactive completion of commands.`,
   /code $ source <(archer completion bash)
   /code $ archer completion bash > archer.sh
   /code $ sudo mv archer.sh /etc/bash_completion.d/archer`,
-		Args: cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("requires a single shell argument (bash or zsh)")
+			}
+			return nil
+		},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.Shell = args[0]
 			return opts.Validate()


### PR DESCRIPTION
Generate a completer for the root command, not for the completion command

Fixes #119

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
