### PR TITLE
Reduce wait time for CF polling from 30s -> 3s

### DIFF
--- a/internal/pkg/deploy/cloudformation/app_test.go
+++ b/internal/pkg/deploy/cloudformation/app_test.go
@@ -20,13 +20,13 @@ func TestDeployApp(t *testing.T) {
 	mockError := errors.New("mockError")
 
 	testCases := map[string]struct {
-		mockCreateStack                      func(t *testing.T, in *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error)
-		mockWaitUntilStackCreateComplete     func(t *testing.T, in *cloudformation.DescribeStacksInput) error
-		mockCreateChangeSet                  func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error)
-		mockWaitUntilChangeSetCreateComplete func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error
-		mockExecuteChangeSet                 func(t *testing.T, in *cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error)
-		mockWaitUntilStackUpdateComplete     func(t *testing.T, in *cloudformation.DescribeStacksInput) error
-		mockDescribeChangeSet                func(t *testing.T, in *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error)
+		mockCreateStack                                 func(t *testing.T, in *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error)
+		mockWaitUntilStackCreateCompleteWithContext     func(t *testing.T, in *cloudformation.DescribeStacksInput) error
+		mockCreateChangeSet                             func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error)
+		mockWaitUntilChangeSetCreateCompleteWithContext func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error
+		mockExecuteChangeSet                            func(t *testing.T, in *cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error)
+		mockWaitUntilStackUpdateCompleteWithContext     func(t *testing.T, in *cloudformation.DescribeStacksInput) error
+		mockDescribeChangeSet                           func(t *testing.T, in *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error)
 
 		wantErr error
 	}{
@@ -40,7 +40,7 @@ func TestDeployApp(t *testing.T) {
 
 				return &cloudformation.CreateStackOutput{}, nil
 			},
-			mockWaitUntilStackCreateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+			mockWaitUntilStackCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 				t.Helper()
 
 				require.Equal(t, mockStackName, *in.StackName)
@@ -69,7 +69,7 @@ func TestDeployApp(t *testing.T) {
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
-			mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+			mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 				t.Helper()
 
 				require.Equal(t, mockChangeSetName, *in.ChangeSetName)
@@ -85,7 +85,7 @@ func TestDeployApp(t *testing.T) {
 
 				return &cloudformation.ExecuteChangeSetOutput{}, nil
 			},
-			mockWaitUntilStackUpdateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+			mockWaitUntilStackUpdateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 				t.Helper()
 
 				require.Equal(t, mockStackName, *in.StackName)
@@ -114,7 +114,7 @@ func TestDeployApp(t *testing.T) {
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
-			mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+			mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 				t.Helper()
 
 				require.Equal(t, mockChangeSetName, *in.ChangeSetName)
@@ -154,7 +154,7 @@ func TestDeployApp(t *testing.T) {
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
-			mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+			mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 				t.Helper()
 
 				require.Equal(t, mockChangeSetName, *in.ChangeSetName)
@@ -180,13 +180,13 @@ func TestDeployApp(t *testing.T) {
 				client: mockCloudFormation{
 					t: t,
 
-					mockCreateStack:                      tc.mockCreateStack,
-					mockWaitUntilStackCreateComplete:     tc.mockWaitUntilStackCreateComplete,
-					mockCreateChangeSet:                  tc.mockCreateChangeSet,
-					mockWaitUntilChangeSetCreateComplete: tc.mockWaitUntilChangeSetCreateComplete,
-					mockExecuteChangeSet:                 tc.mockExecuteChangeSet,
-					mockWaitUntilStackUpdateComplete:     tc.mockWaitUntilStackUpdateComplete,
-					mockDescribeChangeSet:                tc.mockDescribeChangeSet,
+					mockCreateStack: tc.mockCreateStack,
+					mockWaitUntilStackCreateCompleteWithContext:     tc.mockWaitUntilStackCreateCompleteWithContext,
+					mockCreateChangeSet:                             tc.mockCreateChangeSet,
+					mockWaitUntilChangeSetCreateCompleteWithContext: tc.mockWaitUntilChangeSetCreateCompleteWithContext,
+					mockExecuteChangeSet:                            tc.mockExecuteChangeSet,
+					mockWaitUntilStackUpdateCompleteWithContext:     tc.mockWaitUntilStackUpdateCompleteWithContext,
+					mockDescribeChangeSet:                           tc.mockDescribeChangeSet,
 				},
 			}
 

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -1,5 +1,4 @@
 // +build integration
-
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -408,7 +407,7 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 			},
 			"CFNExecutionRoleARN": func(output *awsCF.Output) {
 				require.Equal(t,
-					fmt.Sprintf("%s-CRNExecutionRoleARN", envStackName),
+					fmt.Sprintf("%s-CFNExecutionRoleARN", envStackName),
 					*output.ExportName,
 					"Should export CRNExecutionRole ARN")
 

--- a/internal/pkg/deploy/cloudformation/env_test.go
+++ b/internal/pkg/deploy/cloudformation/env_test.go
@@ -23,9 +23,9 @@ func TestStreamEnvironmentCreation(t *testing.T) {
 	testCases := map[string]struct {
 		in *deploy.CreateEnvironmentInput
 
-		mockWaitUntilStackCreateComplete func(t *testing.T, in *cloudformation.DescribeStacksInput) error
-		mockDescribeStacks               func(t *testing.T, in *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
-		mockDescribeStackEvents          func(t *testing.T, in *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error)
+		mockWaitUntilStackCreateCompleteWithContext func(t *testing.T, in *cloudformation.DescribeStacksInput) error
+		mockDescribeStacks                          func(t *testing.T, in *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+		mockDescribeStackEvents                     func(t *testing.T, in *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error)
 
 		wantedEvents []deploy.ResourceEvent
 		wantedResult deploy.CreateEnvironmentResponse
@@ -36,7 +36,7 @@ func TestStreamEnvironmentCreation(t *testing.T) {
 				Name:    "test",
 			},
 
-			mockWaitUntilStackCreateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+			mockWaitUntilStackCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 				require.Equal(t, "phonetool-test", *in.StackName, "stack names should be equal to each other")
 				return errors.New("wait until error")
 			},
@@ -75,7 +75,7 @@ func TestStreamEnvironmentCreation(t *testing.T) {
 				Name:    "test",
 			},
 
-			mockWaitUntilStackCreateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+			mockWaitUntilStackCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 				require.Equal(t, "phonetool-test", *in.StackName, "stack names should be equal to each other")
 				return errors.New("wait until error")
 			},
@@ -96,7 +96,7 @@ func TestStreamEnvironmentCreation(t *testing.T) {
 				Name:    "test",
 			},
 
-			mockWaitUntilStackCreateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+			mockWaitUntilStackCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 				require.Equal(t, "phonetool-test", *in.StackName, "stack names should be equal to each other")
 				return nil
 			},
@@ -151,10 +151,10 @@ func TestStreamEnvironmentCreation(t *testing.T) {
 			// GIVEN
 			cf := CloudFormation{
 				client: &mockCloudFormation{
-					t:                                t,
-					mockDescribeStackEvents:          tc.mockDescribeStackEvents,
-					mockDescribeStacks:               tc.mockDescribeStacks,
-					mockWaitUntilStackCreateComplete: tc.mockWaitUntilStackCreateComplete,
+					t:                       t,
+					mockDescribeStackEvents: tc.mockDescribeStackEvents,
+					mockDescribeStacks:      tc.mockDescribeStacks,
+					mockWaitUntilStackCreateCompleteWithContext: tc.mockWaitUntilStackCreateCompleteWithContext,
 				},
 				box: emptyEnvBox(),
 			}

--- a/internal/pkg/deploy/cloudformation/project.go
+++ b/internal/pkg/deploy/cloudformation/project.go
@@ -4,6 +4,7 @@
 package cloudformation
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -93,7 +94,7 @@ func (cf CloudFormation) DelegateDNSPermissions(project *archer.Project, account
 		return fmt.Errorf("updating project to allow DNS delegation: %w", err)
 	}
 
-	return cf.client.WaitUntilStackUpdateComplete(&describeStack)
+	return cf.client.WaitUntilStackUpdateCompleteWithContext(context.Background(), &describeStack, cf.waiters...)
 }
 
 // GetProjectResourcesByRegion fetches all the regional resources for a particular region.

--- a/internal/pkg/deploy/cloudformation/project_test.go
+++ b/internal/pkg/deploy/cloudformation/project_test.go
@@ -1041,10 +1041,10 @@ func TestDelegateDNSPermissions(t *testing.T) {
 							ExecutionStatus: aws.String(cloudformation.ExecutionStatusAvailable),
 						}, nil
 					},
-					mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+					mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 						return nil
 					},
-					mockWaitUntilStackUpdateComplete: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
+					mockWaitUntilStackUpdateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeStacksInput) error {
 						return nil
 					},
 				}
@@ -1106,7 +1106,7 @@ func TestDelegateDNSPermissions(t *testing.T) {
 							ExecutionStatus: aws.String(cloudformation.ExecutionStatusAvailable),
 						}, nil
 					},
-					mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+					mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 						return nil
 					},
 				}
@@ -1141,11 +1141,11 @@ func getMockSuccessfulDeployCFClient(t *testing.T, stackName string) *mockCloudF
 				StackId: aws.String(stackName),
 			}, nil
 		},
-		mockWaitUntilChangeSetCreateComplete: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
+		mockWaitUntilChangeSetCreateCompleteWithContext: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) error {
 
 			return nil
 		},
-		mockWaitUntilStackCreateComplete: func(t *testing.T, input *cloudformation.DescribeStacksInput) error {
+		mockWaitUntilStackCreateCompleteWithContext: func(t *testing.T, input *cloudformation.DescribeStacksInput) error {
 			return nil
 		},
 		mockDescribeChangeSet: func(t *testing.T, in *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error) {


### PR DESCRIPTION
If we pass in our own waiters, we can specify
the wait time that CF waits before checking
the status of creating stacks, updating them, etc.

This helps a lot, especially since we use changesets
and changeset creation is usually much faster than 30s.

a full project init w/ envs went from 8m 40s -> 7m 20s

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
