### PR TITLE
DNS delegation part 1

### DIFF
--- a/internal/pkg/archer/project.go
+++ b/internal/pkg/archer/project.go
@@ -11,6 +11,11 @@ type Project struct {
 	Version   string `json:"version"` // The version of the project layout in the underlying datastore (e.g. SSM).
 }
 
+// RequiresDNSDelegation returns true if we have to set up DNS Delegation resources
+func (p *Project) RequiresDNSDelegation() bool {
+	return p.Domain != ""
+}
+
 // ProjectRegionalResources represent project resources that are regional.
 type ProjectRegionalResources struct {
 	Region         string            // The region these resources are in.

--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -25,6 +25,7 @@ type projectDeployer interface {
 	DeployProject(in *deploy.CreateProjectInput) error
 	AddAppToProject(project *archer.Project, appName string) error
 	AddEnvToProject(project *archer.Project, env *archer.Environment) error
+	DelegateDNSPermissions(project *archer.Project, accountID string) error
 }
 
 type projectResourcesGetter interface {

--- a/internal/pkg/cli/mocks/mock_deploy.go
+++ b/internal/pkg/cli/mocks/mock_deploy.go
@@ -5,10 +5,11 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	archer "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	deploy "github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockenvironmentDeployer is a mock of environmentDeployer interface
@@ -36,6 +37,7 @@ func (m *MockenvironmentDeployer) EXPECT() *MockenvironmentDeployerMockRecorder 
 
 // DeployEnvironment mocks base method
 func (m *MockenvironmentDeployer) DeployEnvironment(env *deploy.CreateEnvironmentInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployEnvironment", env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +45,13 @@ func (m *MockenvironmentDeployer) DeployEnvironment(env *deploy.CreateEnvironmen
 
 // DeployEnvironment indicates an expected call of DeployEnvironment
 func (mr *MockenvironmentDeployerMockRecorder) DeployEnvironment(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployEnvironment", reflect.TypeOf((*MockenvironmentDeployer)(nil).DeployEnvironment), env)
 }
 
 // StreamEnvironmentCreation mocks base method
 func (m *MockenvironmentDeployer) StreamEnvironmentCreation(env *deploy.CreateEnvironmentInput) (<-chan []deploy.ResourceEvent, <-chan deploy.CreateEnvironmentResponse) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StreamEnvironmentCreation", env)
 	ret0, _ := ret[0].(<-chan []deploy.ResourceEvent)
 	ret1, _ := ret[1].(<-chan deploy.CreateEnvironmentResponse)
@@ -56,6 +60,7 @@ func (m *MockenvironmentDeployer) StreamEnvironmentCreation(env *deploy.CreateEn
 
 // StreamEnvironmentCreation indicates an expected call of StreamEnvironmentCreation
 func (mr *MockenvironmentDeployerMockRecorder) StreamEnvironmentCreation(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamEnvironmentCreation", reflect.TypeOf((*MockenvironmentDeployer)(nil).StreamEnvironmentCreation), env)
 }
 
@@ -84,6 +89,7 @@ func (m *MockpipelineDeployer) EXPECT() *MockpipelineDeployerMockRecorder {
 
 // DeployPipeline mocks base method
 func (m *MockpipelineDeployer) DeployPipeline(env *deploy.CreatePipelineInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployPipeline", env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -91,11 +97,13 @@ func (m *MockpipelineDeployer) DeployPipeline(env *deploy.CreatePipelineInput) e
 
 // DeployPipeline indicates an expected call of DeployPipeline
 func (mr *MockpipelineDeployerMockRecorder) DeployPipeline(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployPipeline", reflect.TypeOf((*MockpipelineDeployer)(nil).DeployPipeline), env)
 }
 
 // AddPipelineResourcesToProject mocks base method
 func (m *MockpipelineDeployer) AddPipelineResourcesToProject(project *archer.Project, region string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPipelineResourcesToProject", project, region)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -103,11 +111,13 @@ func (m *MockpipelineDeployer) AddPipelineResourcesToProject(project *archer.Pro
 
 // AddPipelineResourcesToProject indicates an expected call of AddPipelineResourcesToProject
 func (mr *MockpipelineDeployerMockRecorder) AddPipelineResourcesToProject(project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPipelineResourcesToProject", reflect.TypeOf((*MockpipelineDeployer)(nil).AddPipelineResourcesToProject), project, region)
 }
 
 // GetProjectResourcesByRegion mocks base method
 func (m *MockpipelineDeployer) GetProjectResourcesByRegion(project *archer.Project, region string) (*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProjectResourcesByRegion", project, region)
 	ret0, _ := ret[0].(*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -116,11 +126,13 @@ func (m *MockpipelineDeployer) GetProjectResourcesByRegion(project *archer.Proje
 
 // GetProjectResourcesByRegion indicates an expected call of GetProjectResourcesByRegion
 func (mr *MockpipelineDeployerMockRecorder) GetProjectResourcesByRegion(project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectResourcesByRegion", reflect.TypeOf((*MockpipelineDeployer)(nil).GetProjectResourcesByRegion), project, region)
 }
 
 // GetRegionalProjectResources mocks base method
 func (m *MockpipelineDeployer) GetRegionalProjectResources(project *archer.Project) ([]*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionalProjectResources", project)
 	ret0, _ := ret[0].([]*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -129,6 +141,7 @@ func (m *MockpipelineDeployer) GetRegionalProjectResources(project *archer.Proje
 
 // GetRegionalProjectResources indicates an expected call of GetRegionalProjectResources
 func (mr *MockpipelineDeployerMockRecorder) GetRegionalProjectResources(project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalProjectResources", reflect.TypeOf((*MockpipelineDeployer)(nil).GetRegionalProjectResources), project)
 }
 
@@ -157,6 +170,7 @@ func (m *MockprojectDeployer) EXPECT() *MockprojectDeployerMockRecorder {
 
 // DeployProject mocks base method
 func (m *MockprojectDeployer) DeployProject(in *deploy.CreateProjectInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployProject", in)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -164,11 +178,13 @@ func (m *MockprojectDeployer) DeployProject(in *deploy.CreateProjectInput) error
 
 // DeployProject indicates an expected call of DeployProject
 func (mr *MockprojectDeployerMockRecorder) DeployProject(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployProject", reflect.TypeOf((*MockprojectDeployer)(nil).DeployProject), in)
 }
 
 // AddAppToProject mocks base method
 func (m *MockprojectDeployer) AddAppToProject(project *archer.Project, appName string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddAppToProject", project, appName)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -176,11 +192,13 @@ func (m *MockprojectDeployer) AddAppToProject(project *archer.Project, appName s
 
 // AddAppToProject indicates an expected call of AddAppToProject
 func (mr *MockprojectDeployerMockRecorder) AddAppToProject(project, appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAppToProject", reflect.TypeOf((*MockprojectDeployer)(nil).AddAppToProject), project, appName)
 }
 
 // AddEnvToProject mocks base method
 func (m *MockprojectDeployer) AddEnvToProject(project *archer.Project, env *archer.Environment) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddEnvToProject", project, env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -188,7 +206,22 @@ func (m *MockprojectDeployer) AddEnvToProject(project *archer.Project, env *arch
 
 // AddEnvToProject indicates an expected call of AddEnvToProject
 func (mr *MockprojectDeployerMockRecorder) AddEnvToProject(project, env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEnvToProject", reflect.TypeOf((*MockprojectDeployer)(nil).AddEnvToProject), project, env)
+}
+
+// DelegateDNSPermissions mocks base method
+func (m *MockprojectDeployer) DelegateDNSPermissions(project *archer.Project, accountID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelegateDNSPermissions", project, accountID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DelegateDNSPermissions indicates an expected call of DelegateDNSPermissions
+func (mr *MockprojectDeployerMockRecorder) DelegateDNSPermissions(project, accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateDNSPermissions", reflect.TypeOf((*MockprojectDeployer)(nil).DelegateDNSPermissions), project, accountID)
 }
 
 // MockprojectResourcesGetter is a mock of projectResourcesGetter interface
@@ -216,6 +249,7 @@ func (m *MockprojectResourcesGetter) EXPECT() *MockprojectResourcesGetterMockRec
 
 // GetProjectResourcesByRegion mocks base method
 func (m *MockprojectResourcesGetter) GetProjectResourcesByRegion(project *archer.Project, region string) (*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProjectResourcesByRegion", project, region)
 	ret0, _ := ret[0].(*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -224,11 +258,13 @@ func (m *MockprojectResourcesGetter) GetProjectResourcesByRegion(project *archer
 
 // GetProjectResourcesByRegion indicates an expected call of GetProjectResourcesByRegion
 func (mr *MockprojectResourcesGetterMockRecorder) GetProjectResourcesByRegion(project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectResourcesByRegion", reflect.TypeOf((*MockprojectResourcesGetter)(nil).GetProjectResourcesByRegion), project, region)
 }
 
 // GetRegionalProjectResources mocks base method
 func (m *MockprojectResourcesGetter) GetRegionalProjectResources(project *archer.Project) ([]*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionalProjectResources", project)
 	ret0, _ := ret[0].([]*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -237,6 +273,7 @@ func (m *MockprojectResourcesGetter) GetRegionalProjectResources(project *archer
 
 // GetRegionalProjectResources indicates an expected call of GetRegionalProjectResources
 func (mr *MockprojectResourcesGetterMockRecorder) GetRegionalProjectResources(project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalProjectResources", reflect.TypeOf((*MockprojectResourcesGetter)(nil).GetRegionalProjectResources), project)
 }
 
@@ -265,6 +302,7 @@ func (m *Mockdeployer) EXPECT() *MockdeployerMockRecorder {
 
 // DeployEnvironment mocks base method
 func (m *Mockdeployer) DeployEnvironment(env *deploy.CreateEnvironmentInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployEnvironment", env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -272,11 +310,13 @@ func (m *Mockdeployer) DeployEnvironment(env *deploy.CreateEnvironmentInput) err
 
 // DeployEnvironment indicates an expected call of DeployEnvironment
 func (mr *MockdeployerMockRecorder) DeployEnvironment(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployEnvironment", reflect.TypeOf((*Mockdeployer)(nil).DeployEnvironment), env)
 }
 
 // StreamEnvironmentCreation mocks base method
 func (m *Mockdeployer) StreamEnvironmentCreation(env *deploy.CreateEnvironmentInput) (<-chan []deploy.ResourceEvent, <-chan deploy.CreateEnvironmentResponse) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StreamEnvironmentCreation", env)
 	ret0, _ := ret[0].(<-chan []deploy.ResourceEvent)
 	ret1, _ := ret[1].(<-chan deploy.CreateEnvironmentResponse)
@@ -285,11 +325,13 @@ func (m *Mockdeployer) StreamEnvironmentCreation(env *deploy.CreateEnvironmentIn
 
 // StreamEnvironmentCreation indicates an expected call of StreamEnvironmentCreation
 func (mr *MockdeployerMockRecorder) StreamEnvironmentCreation(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamEnvironmentCreation", reflect.TypeOf((*Mockdeployer)(nil).StreamEnvironmentCreation), env)
 }
 
 // DeployProject mocks base method
 func (m *Mockdeployer) DeployProject(in *deploy.CreateProjectInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployProject", in)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -297,11 +339,13 @@ func (m *Mockdeployer) DeployProject(in *deploy.CreateProjectInput) error {
 
 // DeployProject indicates an expected call of DeployProject
 func (mr *MockdeployerMockRecorder) DeployProject(in interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployProject", reflect.TypeOf((*Mockdeployer)(nil).DeployProject), in)
 }
 
 // AddAppToProject mocks base method
 func (m *Mockdeployer) AddAppToProject(project *archer.Project, appName string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddAppToProject", project, appName)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -309,11 +353,27 @@ func (m *Mockdeployer) AddAppToProject(project *archer.Project, appName string) 
 
 // AddAppToProject indicates an expected call of AddAppToProject
 func (mr *MockdeployerMockRecorder) AddAppToProject(project, appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAppToProject", reflect.TypeOf((*Mockdeployer)(nil).AddAppToProject), project, appName)
+}
+
+// DelegateDNSPermissions mocks base method
+func (m *Mockdeployer) DelegateDNSPermissions(project *archer.Project, accountID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelegateDNSPermissions", project, accountID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DelegateDNSPermissions indicates an expected call of DelegateDNSPermissions
+func (mr *MockdeployerMockRecorder) DelegateDNSPermissions(project, accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateDNSPermissions", reflect.TypeOf((*Mockdeployer)(nil).DelegateDNSPermissions), project, accountID)
 }
 
 // AddEnvToProject mocks base method
 func (m *Mockdeployer) AddEnvToProject(project *archer.Project, env *archer.Environment) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddEnvToProject", project, env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -321,11 +381,13 @@ func (m *Mockdeployer) AddEnvToProject(project *archer.Project, env *archer.Envi
 
 // AddEnvToProject indicates an expected call of AddEnvToProject
 func (mr *MockdeployerMockRecorder) AddEnvToProject(project, env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEnvToProject", reflect.TypeOf((*Mockdeployer)(nil).AddEnvToProject), project, env)
 }
 
 // DeployPipeline mocks base method
 func (m *Mockdeployer) DeployPipeline(env *deploy.CreatePipelineInput) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeployPipeline", env)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -333,11 +395,13 @@ func (m *Mockdeployer) DeployPipeline(env *deploy.CreatePipelineInput) error {
 
 // DeployPipeline indicates an expected call of DeployPipeline
 func (mr *MockdeployerMockRecorder) DeployPipeline(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployPipeline", reflect.TypeOf((*Mockdeployer)(nil).DeployPipeline), env)
 }
 
 // AddPipelineResourcesToProject mocks base method
 func (m *Mockdeployer) AddPipelineResourcesToProject(project *archer.Project, region string) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPipelineResourcesToProject", project, region)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -345,11 +409,13 @@ func (m *Mockdeployer) AddPipelineResourcesToProject(project *archer.Project, re
 
 // AddPipelineResourcesToProject indicates an expected call of AddPipelineResourcesToProject
 func (mr *MockdeployerMockRecorder) AddPipelineResourcesToProject(project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPipelineResourcesToProject", reflect.TypeOf((*Mockdeployer)(nil).AddPipelineResourcesToProject), project, region)
 }
 
 // GetProjectResourcesByRegion mocks base method
 func (m *Mockdeployer) GetProjectResourcesByRegion(project *archer.Project, region string) (*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProjectResourcesByRegion", project, region)
 	ret0, _ := ret[0].(*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -358,11 +424,13 @@ func (m *Mockdeployer) GetProjectResourcesByRegion(project *archer.Project, regi
 
 // GetProjectResourcesByRegion indicates an expected call of GetProjectResourcesByRegion
 func (mr *MockdeployerMockRecorder) GetProjectResourcesByRegion(project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectResourcesByRegion", reflect.TypeOf((*Mockdeployer)(nil).GetProjectResourcesByRegion), project, region)
 }
 
 // GetRegionalProjectResources mocks base method
 func (m *Mockdeployer) GetRegionalProjectResources(project *archer.Project) ([]*archer.ProjectRegionalResources, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionalProjectResources", project)
 	ret0, _ := ret[0].([]*archer.ProjectRegionalResources)
 	ret1, _ := ret[1].(error)
@@ -371,5 +439,6 @@ func (m *Mockdeployer) GetRegionalProjectResources(project *archer.Project) ([]*
 
 // GetRegionalProjectResources indicates an expected call of GetRegionalProjectResources
 func (mr *MockdeployerMockRecorder) GetRegionalProjectResources(project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalProjectResources", reflect.TypeOf((*Mockdeployer)(nil).GetRegionalProjectResources), project)
 }

--- a/internal/pkg/cli/mocks/mock_projectservice.go
+++ b/internal/pkg/cli/mocks/mock_projectservice.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	archer "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	ecr "github.com/aws/amazon-ecs-cli-v2/internal/pkg/build/ecr"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -163,4 +164,122 @@ func (m *MockprojectService) CreateApplication(app *archer.Application) error {
 func (mr *MockprojectServiceMockRecorder) CreateApplication(app interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockprojectService)(nil).CreateApplication), app)
+}
+
+// MockecrService is a mock of ecrService interface
+type MockecrService struct {
+	ctrl     *gomock.Controller
+	recorder *MockecrServiceMockRecorder
+}
+
+// MockecrServiceMockRecorder is the mock recorder for MockecrService
+type MockecrServiceMockRecorder struct {
+	mock *MockecrService
+}
+
+// NewMockecrService creates a new mock instance
+func NewMockecrService(ctrl *gomock.Controller) *MockecrService {
+	mock := &MockecrService{ctrl: ctrl}
+	mock.recorder = &MockecrServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockecrService) EXPECT() *MockecrServiceMockRecorder {
+	return m.recorder
+}
+
+// GetRepository mocks base method
+func (m *MockecrService) GetRepository(name string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRepository", name)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRepository indicates an expected call of GetRepository
+func (mr *MockecrServiceMockRecorder) GetRepository(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepository", reflect.TypeOf((*MockecrService)(nil).GetRepository), name)
+}
+
+// GetECRAuth mocks base method
+func (m *MockecrService) GetECRAuth() (ecr.Auth, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetECRAuth")
+	ret0, _ := ret[0].(ecr.Auth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetECRAuth indicates an expected call of GetECRAuth
+func (mr *MockecrServiceMockRecorder) GetECRAuth() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetECRAuth", reflect.TypeOf((*MockecrService)(nil).GetECRAuth))
+}
+
+// MockdockerService is a mock of dockerService interface
+type MockdockerService struct {
+	ctrl     *gomock.Controller
+	recorder *MockdockerServiceMockRecorder
+}
+
+// MockdockerServiceMockRecorder is the mock recorder for MockdockerService
+type MockdockerServiceMockRecorder struct {
+	mock *MockdockerService
+}
+
+// NewMockdockerService creates a new mock instance
+func NewMockdockerService(ctrl *gomock.Controller) *MockdockerService {
+	mock := &MockdockerService{ctrl: ctrl}
+	mock.recorder = &MockdockerServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdockerService) EXPECT() *MockdockerServiceMockRecorder {
+	return m.recorder
+}
+
+// Build mocks base method
+func (m *MockdockerService) Build(uri, tag, path string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Build", uri, tag, path)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Build indicates an expected call of Build
+func (mr *MockdockerServiceMockRecorder) Build(uri, tag, path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Build", reflect.TypeOf((*MockdockerService)(nil).Build), uri, tag, path)
+}
+
+// Login mocks base method
+func (m *MockdockerService) Login(uri string, auth ecr.Auth) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Login", uri, auth)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Login indicates an expected call of Login
+func (mr *MockdockerServiceMockRecorder) Login(uri, auth interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockdockerService)(nil).Login), uri, auth)
+}
+
+// Push mocks base method
+func (m *MockdockerService) Push(uri, tag string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Push", uri, tag)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Push indicates an expected call of Push
+func (mr *MockdockerServiceMockRecorder) Push(uri, tag interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*MockdockerService)(nil).Push), uri, tag)
 }

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -139,8 +139,9 @@ func (opts *InitProjectOpts) Execute() error {
 	}
 	opts.prog.Start(fmt.Sprintf(fmtDeployProjectStart, color.HighlightUserInput(opts.ProjectName)))
 	err = opts.deployer.DeployProject(&deploy.CreateProjectInput{
-		Project:   opts.ProjectName,
-		AccountID: caller.Account,
+		Project:    opts.ProjectName,
+		AccountID:  caller.Account,
+		DomainName: opts.DomainName,
 	})
 	if err != nil {
 		opts.prog.Stop(log.Serrorf(fmtDeployProjectFailed, color.HighlightUserInput(opts.ProjectName)))

--- a/internal/pkg/cli/project_init_test.go
+++ b/internal/pkg/cli/project_init_test.go
@@ -209,8 +209,9 @@ func TestInitProjectOpts_Execute(t *testing.T) {
 				mockProgress.EXPECT().Start(fmt.Sprintf(fmtDeployProjectStart, "project"))
 				mockDeployer.EXPECT().
 					DeployProject(&deploy.CreateProjectInput{
-						Project:   "project",
-						AccountID: "12345",
+						Project:    "project",
+						AccountID:  "12345",
+						DomainName: "amazon.com",
 					}).Return(nil)
 				mockProgress.EXPECT().Stop(log.Ssuccessf(fmtDeployProjectComplete, "project"))
 			},

--- a/internal/pkg/deploy/cloudformation/changeset.go
+++ b/internal/pkg/deploy/cloudformation/changeset.go
@@ -132,9 +132,9 @@ func withParameters(params []*cloudformation.Parameter) createChangeSetOpt {
 	}
 }
 
-func withCreateChangeSetType() createChangeSetOpt {
+func withChangeSetType(csType string) createChangeSetOpt {
 	return func(in *cloudformation.CreateChangeSetInput) {
-		in.ChangeSetType = aws.String(cloudformation.ChangeSetTypeCreate)
+		in.ChangeSetType = aws.String(csType)
 	}
 }
 

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -165,14 +165,21 @@ func (cf CloudFormation) describeStackWithClient(describeStackInput *cloudformat
 
 	return describeStackOutput.Stacks[0], nil
 }
+func (cf CloudFormation) create(stackConfig stackConfiguration) error {
+	return cf.deploy(stackConfig, cloudformation.ChangeSetTypeCreate)
+}
 
-func (cf CloudFormation) deploy(stackConfig stackConfiguration) error {
+func (cf CloudFormation) update(stackConfig stackConfiguration) error {
+	return cf.deploy(stackConfig, cloudformation.ChangeSetTypeUpdate)
+}
+
+func (cf CloudFormation) deploy(stackConfig stackConfiguration, createOrUpdate string) error {
 	template, err := stackConfig.Template()
 	if err != nil {
 		return fmt.Errorf("template creation: %w", err)
 	}
 
-	in, err := createChangeSetInput(stackConfig.StackName(), template, withCreateChangeSetType(), withTags(stackConfig.Tags()), withParameters(stackConfig.Parameters()))
+	in, err := createChangeSetInput(stackConfig.StackName(), template, withChangeSetType(createOrUpdate), withTags(stackConfig.Tags()), withParameters(stackConfig.Parameters()))
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/deploy/cloudformation/cloudformation_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_test.go
@@ -355,7 +355,7 @@ func TestDeploy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.cf.deploy(tc.input)
+			got := tc.cf.deploy(tc.input, cloudformation.ChangeSetTypeCreate)
 
 			if tc.want != nil {
 				require.EqualError(t, got, tc.want.Error())

--- a/internal/pkg/deploy/cloudformation/env.go
+++ b/internal/pkg/deploy/cloudformation/env.go
@@ -16,7 +16,7 @@ import (
 // If the change set to create the stack cannot be executed, returns a ErrNotExecutableChangeSet.
 // Otherwise, returns a wrapped error.
 func (cf CloudFormation) DeployEnvironment(env *deploy.CreateEnvironmentInput) error {
-	return cf.deploy(stack.NewEnvStackConfig(env, cf.box))
+	return cf.create(stack.NewEnvStackConfig(env, cf.box))
 }
 
 // StreamEnvironmentCreation streams resource update events while a deployment is taking place.

--- a/internal/pkg/deploy/cloudformation/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/pipeline.go
@@ -17,5 +17,5 @@ import (
 func (cf CloudFormation) DeployPipeline(in *deploy.CreatePipelineInput) error {
 	pipelineConfig := stack.NewPipelineStackConfig(in)
 
-	return cf.deploy(pipelineConfig)
+	return cf.create(pipelineConfig)
 }

--- a/internal/pkg/deploy/cloudformation/project.go
+++ b/internal/pkg/deploy/cloudformation/project.go
@@ -27,7 +27,7 @@ func (cf CloudFormation) DeployProject(in *deploy.CreateProjectInput) error {
 
 	// First deploy the project roles needed by StackSets. These roles
 	// allow the stack set to set up our regional stacks.
-	if err := cf.deploy(projectConfig); err == nil {
+	if err := cf.create(projectConfig); err == nil {
 		_, err := cf.waitForStackCreation(projectConfig)
 		if err != nil {
 			return err

--- a/internal/pkg/deploy/project.go
+++ b/internal/pkg/deploy/project.go
@@ -5,8 +5,12 @@
 // This file defines project deployment resources.
 package deploy
 
+//TODO rename this DeployProjectInput
+
 // CreateProjectInput holds the fields required to create a project stack set.
 type CreateProjectInput struct {
-	Project   string // Name of the project that needs to be created.
-	AccountID string // AWS account ID to administrate the project.
+	Project               string   // Name of the project that needs to be created.
+	AccountID             string   // AWS account ID to administrate the project.
+	DNSDelegationAccounts []string // Accounts to grant DNS access to for this project
+	DomainName            string   // DNS Name used for this project
 }

--- a/templates/project/project.yml
+++ b/templates/project/project.yml
@@ -7,6 +7,16 @@ Parameters:
     Type: String
   ExecutionRoleName:
     Type: String
+  ProjectDNSDelegatedAccounts:
+    Type: CommaDelimitedList
+    Default: ""
+  ProjectDomainName:
+    Type: String
+    Default: ""
+Conditions:
+  DelegateDNS:
+    !Not [!Equals [ !Ref ProjectDomainName, "" ]]
+
 Resources:
   AdministrationRole:
     Type: AWS::IAM::Role
@@ -81,6 +91,41 @@ Resources:
                   - ecr:GetRepositoryPolicy
                   - ecr:GetLifecyclePolicy
                 Resource: "*"
+  DNSDelegationRole:
+    Type: AWS::IAM::Role
+    Condition: DelegateDNS
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:  !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action:
+              - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              AWS: !Split
+                - ','
+                - !Sub
+                    - 'arn:aws:iam::${inner}:root'
+                    - inner: !Join
+                      - ':root,arn:aws:iam::'
+                      - Ref: "ProjectDNSDelegatedAccounts"
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: DNSDelegationPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+              - Sid: HostedZoneChangeRecord
+                Effect: Allow
+                Action:
+                  - route53:*
+                Resource: "*"
+
 Outputs:
   ExecutionRoleARN:
     Description: ExecutionRole used by this project to set up ECR Repos, KMS Keys and S3 buckets


### PR DESCRIPTION
    Attach environment principal to DNS Delegation Policy

    This change makes it so we can do cross-account DNS delegation. It
    grants the environment permission to update the project's hosted zone.

    TODO: the project.yml template is not complete, it just adds a role.

    But this change adds the infrastructure to add an environment to a
    project's DNSDelegation role.