### PR TITLE
Tighten up CloudFormation error handling

### DIFF
--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -412,7 +412,7 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 					"Should export CRNExecutionRole ARN")
 
 				require.True(t,
-					strings.HasSuffix(*output.OutputValue, fmt.Sprintf("role/%s-CFNExecutionRoleARN", envStackName)),
+					strings.HasSuffix(*output.OutputValue, fmt.Sprintf("role/%s-CFNExecutionRole", envStackName)),
 					"CRNExecutionRole ARN value should not be nil.")
 			},
 			"ClusterId": func(output *awsCF.Output) {

--- a/internal/pkg/deploy/cloudformation/errors.go
+++ b/internal/pkg/deploy/cloudformation/errors.go
@@ -23,6 +23,25 @@ func (err *ErrStackAlreadyExists) Unwrap() error {
 	return err.parentErr
 }
 
+// ErrStackNotFound occurs when we can't find a particular CloudFormation stack.
+type ErrStackNotFound struct {
+	stackName string
+}
+
+func (err *ErrStackNotFound) Error() string {
+	return fmt.Sprintf("failed to find a stack named %s", err.stackName)
+}
+
+// ErrStackUpdateInProgress occurs when we try to update a stack that's already being updated.
+type ErrStackUpdateInProgress struct {
+	stackName   string
+	stackStatus string
+}
+
+func (err *ErrStackUpdateInProgress) Error() string {
+	return fmt.Sprintf("stack %s is currently being updated (status %s) and cannot be deployed to", err.stackName, err.stackStatus)
+}
+
 // ErrNotExecutableChangeSet occurs when the change set cannot be executed.
 type ErrNotExecutableChangeSet struct {
 	set *changeSet
@@ -39,7 +58,7 @@ type ErrTemplateNotFound struct {
 }
 
 func (err *ErrTemplateNotFound) Error() string {
-	return fmt.Sprintf("failed to find the cloudformation template at %s", err.templateLocation)
+	return fmt.Sprintf("find the cloudformation template at %s", err.templateLocation)
 }
 
 // Is returns true if the target's template location and parent error are equal to this error's template location and parent error.

--- a/internal/pkg/deploy/cloudformation/stack_status.go
+++ b/internal/pkg/deploy/cloudformation/stack_status.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+// StackStatus stacks
+type StackStatus string
+
+// RequiresCleanup indicates that the stack was created, but failed.
+// It should be deleted.
+func (s StackStatus) RequiresCleanup() bool {
+	return cloudformation.StackStatusRollbackComplete == string(s) ||
+		cloudformation.StackStatusRollbackFailed == string(s)
+}
+
+// InProgress that the stack is currently being updated.
+func (s StackStatus) InProgress() bool {
+	return strings.HasSuffix(string(s), "IN_PROGRESS")
+}


### PR DESCRIPTION
This fixes and enhances some cf error handling:
1. For create, if a stack was failed to have been crated,
   we'll delete it and then create the stack. This means
   if someone creates an env stack, it fails, and the run
   env init again, it'll delete the old failed stack and
   try to create it again. We only do this for stacks
   which failed cration.
2. For both update/create we error out if a stack is
   already being updated.

This doesn't fix the bug where if a stack does already exist
we don't write it to SSM.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
