### PR TITLE
Add app deploy to init

### DIFF
--- a/internal/pkg/cli/deploy.go
+++ b/internal/pkg/cli/deploy.go
@@ -38,3 +38,9 @@ type deployer interface {
 	projectDeployer
 	pipelineDeployer
 }
+
+type appDeployer interface {
+	init() error
+	sourceInputs() error
+	deployApp() error
+}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type mockAppDeployer struct{}
+
+func (mad mockAppDeployer) init() error {
+	return nil
+}
+
+func (mad mockAppDeployer) sourceInputs() error {
+	return nil
+}
+
+func (mad mockAppDeployer) deployApp() error {
+	return nil
+}
+
 func TestInitOpts_Run(t *testing.T) {
 	testCases := map[string]struct {
 		inShouldDeploy          bool
@@ -89,6 +103,22 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.initEnv.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 			},
 		},
+		"app deploy happy path": {
+			inPromptForShouldDeploy: true,
+			inShouldDeploy:          true,
+			expect: func(opts *InitOpts) {
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
+
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm("Would you like to deploy a staging environment?", gomock.Any()).
+					Return(true, nil)
+				opts.initEnv.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -106,6 +136,7 @@ func TestInitOpts_Run(t *testing.T) {
 				initProject: climocks.NewMockactionCommand(ctrl),
 				initApp:     climocks.NewMockactionCommand(ctrl),
 				initEnv:     climocks.NewMockactionCommand(ctrl),
+				appDeployer: mockAppDeployer{},
 
 				prompt: climocks.NewMockprompter(ctrl),
 

--- a/internal/pkg/cli/mocks/mock_deploy.go
+++ b/internal/pkg/cli/mocks/mock_deploy.go
@@ -5,11 +5,10 @@
 package mocks
 
 import (
-	reflect "reflect"
-
 	archer "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	deploy "github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockenvironmentDeployer is a mock of environmentDeployer interface
@@ -357,20 +356,6 @@ func (mr *MockdeployerMockRecorder) AddAppToProject(project, appName interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAppToProject", reflect.TypeOf((*Mockdeployer)(nil).AddAppToProject), project, appName)
 }
 
-// DelegateDNSPermissions mocks base method
-func (m *Mockdeployer) DelegateDNSPermissions(project *archer.Project, accountID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DelegateDNSPermissions", project, accountID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DelegateDNSPermissions indicates an expected call of DelegateDNSPermissions
-func (mr *MockdeployerMockRecorder) DelegateDNSPermissions(project, accountID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateDNSPermissions", reflect.TypeOf((*Mockdeployer)(nil).DelegateDNSPermissions), project, accountID)
-}
-
 // AddEnvToProject mocks base method
 func (m *Mockdeployer) AddEnvToProject(project *archer.Project, env *archer.Environment) error {
 	m.ctrl.T.Helper()
@@ -383,6 +368,20 @@ func (m *Mockdeployer) AddEnvToProject(project *archer.Project, env *archer.Envi
 func (mr *MockdeployerMockRecorder) AddEnvToProject(project, env interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEnvToProject", reflect.TypeOf((*Mockdeployer)(nil).AddEnvToProject), project, env)
+}
+
+// DelegateDNSPermissions mocks base method
+func (m *Mockdeployer) DelegateDNSPermissions(project *archer.Project, accountID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelegateDNSPermissions", project, accountID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DelegateDNSPermissions indicates an expected call of DelegateDNSPermissions
+func (mr *MockdeployerMockRecorder) DelegateDNSPermissions(project, accountID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelegateDNSPermissions", reflect.TypeOf((*Mockdeployer)(nil).DelegateDNSPermissions), project, accountID)
 }
 
 // DeployPipeline mocks base method
@@ -441,4 +440,69 @@ func (m *Mockdeployer) GetRegionalProjectResources(project *archer.Project) ([]*
 func (mr *MockdeployerMockRecorder) GetRegionalProjectResources(project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionalProjectResources", reflect.TypeOf((*Mockdeployer)(nil).GetRegionalProjectResources), project)
+}
+
+// MockappDeployer is a mock of appDeployer interface
+type MockappDeployer struct {
+	ctrl     *gomock.Controller
+	recorder *MockappDeployerMockRecorder
+}
+
+// MockappDeployerMockRecorder is the mock recorder for MockappDeployer
+type MockappDeployerMockRecorder struct {
+	mock *MockappDeployer
+}
+
+// NewMockappDeployer creates a new mock instance
+func NewMockappDeployer(ctrl *gomock.Controller) *MockappDeployer {
+	mock := &MockappDeployer{ctrl: ctrl}
+	mock.recorder = &MockappDeployerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockappDeployer) EXPECT() *MockappDeployerMockRecorder {
+	return m.recorder
+}
+
+// init mocks base method
+func (m *MockappDeployer) init() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "init")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// init indicates an expected call of init
+func (mr *MockappDeployerMockRecorder) init() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "init", reflect.TypeOf((*MockappDeployer)(nil).init))
+}
+
+// sourceInputs mocks base method
+func (m *MockappDeployer) sourceInputs() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "sourceInputs")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// sourceInputs indicates an expected call of sourceInputs
+func (mr *MockappDeployerMockRecorder) sourceInputs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "sourceInputs", reflect.TypeOf((*MockappDeployer)(nil).sourceInputs))
+}
+
+// deployApp mocks base method
+func (m *MockappDeployer) deployApp() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "deployApp")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// deployApp indicates an expected call of deployApp
+func (mr *MockappDeployerMockRecorder) deployApp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deployApp", reflect.TypeOf((*MockappDeployer)(nil).deployApp))
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Sample output:
```
→ ./bin/local/archer init
Note: It's best to run this command in the root of your workspace.
Welcome to the ECS CLI! We're going to walk you through some questions 
to help you get set up with a project on ECS. A project is a collection of 
containerized applications (or micro-services) that operate together.

Looks like you don't have any existing projects. Let's create one!
? What would you like to call your project? myproj
? Which type of infrastructure pattern best represents your application? Load Balanced Web App
? What do you want to call this Load Balanced Web App? myapp
? Which Dockerfile would you like to use for myapp app? myapp/Dockerfile
Ok great, we'll set up a Load Balanced Web App named myapp in project myproj.
✔ Success! Created the infrastructure to manage container repositories under project myproj.

✔ Success! Wrote the manifest for myapp app at 'ecs-project/myapp-app.yml'
Your manifest contains configurations like your container size and ports.

✔ Success! Created ECR repositories for application myapp.
2019/11/18 15:58:38 Created Application with version 1
All right, you're all set for local development.
? Would you like to deploy a staging environment? Yes
✔ Success! Created the infrastructure for the test environment.
- Virtual private cloud on 2 availability zones to hold your services     [Complete]
  - Internet gateway to connect the network to the internet               [Complete]
  - Public subnets for internet facing services                           [Complete]
  - Private subnets for services that can't be reached from the internet  [Complete]
  - NAT gateway for private services to send requests to the internet     [Complete]
  - Routing tables for services to talk with each other                   [Complete]
- ECS Cluster to hold your services                                       [Complete]
- Application load balancer to distribute traffic                         [Complete]
✔ Success! Linked account <accountID> and region us-west-2 project myproj.
2019/11/18 16:04:15 Created environment with version 1
✔ Success! Created environment test in region us-west-2 under project myproj.
Only found one app, defaulting to: myapp
Sending build context to Docker daemon  57.34kB
Step 1/2 : FROM nginx
 ---> e445ab08b2be
Step 2/2 : COPY index.html /usr/share/nginx/html
 ---> Using cache
 ---> 711d8eb7377b
Successfully built 711d8eb7377b
Successfully tagged <accountID>.dkr.ecr.us-west-2.amazonaws.com/myproj/myapp:05b1631
WARNING! Your password will be stored unencrypted in <path>/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
The push refers to repository [<accountID>.dkr.ecr.us-west-2.amazonaws.com/myproj/myapp]
c2c3319ed52b: Pushed 
fe6a7a3b3f27: Pushed 
d0673244f7d4: Pushed 
d8a33133e477: Pushed 
05b1631: digest: sha256:86ebd369638102b284c87cf8837d9f8b2241d5c8d467ea4589beff7fd5ebde55 size: 1155
Done!
✔ Success! Deployed myapp:05b1631 to test.
```

**NOTE:** I was fighting `gomock` to generate a mock `appDeployer` and it basically wants everything to be exported which seems unnecessary, so for now I opted to create a simple inline `mockAppDeployer` that makes testing the happy path scenario easy.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
#297 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
