### PR TITLE
Increase delete wait time for ACM certs

### DIFF
--- a/cf-custom-resources/lib/dns-cert-validator.js
+++ b/cf-custom-resources/lib/dns-cert-validator.js
@@ -154,11 +154,8 @@ const deleteCertificate = async function (arn, region, hostedZoneId) {
             inUseByResources = Certificate.InUseBy || [];
             dnsValidationRecord = Certificate.DomainValidationOptions || [];
             if (inUseByResources.length) {
-                // Exponential backoff with jitter based on 200ms base
-                // component of backoff fixed to ensure minimum total wait time on
-                // slow targets.
-                const base = Math.pow(2, attempt);
-                await sleep(random() * base * 50 + base * 150);
+                // Deleting resources can be quite slow - so just sleep 30 seconds between checks.
+                await sleep(30000);
             } else {
                 break
             }


### PR DESCRIPTION
I've noticed them taking around ~4 mins to
have all its resources removed from it.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
