### PR TITLE
Ignore empty changesets

### DIFF
--- a/internal/pkg/deploy/cloudformation/changeset.go
+++ b/internal/pkg/deploy/cloudformation/changeset.go
@@ -103,6 +103,16 @@ func (set *changeSet) execute() error {
 	return nil
 }
 
+func (set *changeSet) delete() error {
+	if _, err := set.c.DeleteChangeSet(&cloudformation.DeleteChangeSetInput{
+		ChangeSetName: aws.String(set.name),
+		StackName:     aws.String(set.stackID),
+	}); err != nil {
+		return fmt.Errorf("failed to delete changeSet %s: %w", set, err)
+	}
+	return nil
+}
+
 // createChangeSetOpt is a functional option to add additional settings to a CreateChangeSetInput.
 type createChangeSetOpt func(in *cloudformation.CreateChangeSetInput)
 


### PR DESCRIPTION
This change makes it so we don't fail
if there are no changes to a stack.

It also cleans up empty changesets so they
don't clutter a customer's account.

I yoinked some of the code directly from @sonofachamp :D
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
