### PR TITLE
Set up resources in env/project stack for DNS Delegation

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -100,6 +100,7 @@ func (opts *InitEnvOpts) Execute() error {
 		Prod:                     opts.IsProduction,
 		PublicLoadBalancer:       true, // TODO: configure this based on user input or application Type needs?
 		ToolsAccountPrincipalARN: caller.RootUserARN,
+		ProjectDNSName:           project.Domain,
 	}
 
 	if project.RequiresDNSDelegation() {

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -380,7 +380,7 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 
 		// Deploy the environment and wait for it to be complete
 		require.NoError(t, deployer.DeployEnvironment(&environmentToDeploy))
-		// Make sure the environment was deployed succesfully
+		// Make sure the environment was deployed successfully
 
 		_, responses := deployer.StreamEnvironmentCreation(&environmentToDeploy)
 		resp := <-responses
@@ -479,6 +479,11 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 				require.NotNil(t,
 					output.OutputValue,
 					"PublicLoadBalancerDNSName value should not be nil")
+			},
+			"PublicLoadBalancerHostedZone": func(output *awsCF.Output) {
+				require.NotNil(t,
+					output.OutputValue,
+					"PublicLoadBalancerHostedZone value should not be nil")
 			},
 			"HTTPListenerArn": func(output *awsCF.Output) {
 				require.Equal(t,

--- a/internal/pkg/deploy/cloudformation/project_test.go
+++ b/internal/pkg/deploy/cloudformation/project_test.go
@@ -1031,7 +1031,7 @@ func TestDelegateDNSPermissions(t *testing.T) {
 				return &mockCloudFormation{
 					t: t,
 					mockCreateChangeSet: func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
-						require.Equal(t, 5, len(in.Parameters))
+						require.Equal(t, 6, len(in.Parameters))
 						return &cloudformation.CreateChangeSetOutput{
 							StackId: aws.String("stackname"),
 						}, nil
@@ -1096,7 +1096,7 @@ func TestDelegateDNSPermissions(t *testing.T) {
 				return &mockCloudFormation{
 					t: t,
 					mockCreateChangeSet: func(t *testing.T, in *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
-						require.Equal(t, 5, len(in.Parameters))
+						require.Equal(t, 6, len(in.Parameters))
 						return &cloudformation.CreateChangeSetOutput{
 							StackId: aws.String("stackname"),
 						}, nil

--- a/internal/pkg/deploy/cloudformation/stack/project.go
+++ b/internal/pkg/deploy/cloudformation/stack/project.go
@@ -43,16 +43,18 @@ type ProjectStackConfig struct {
 }
 
 const (
-	projectTemplatePath            = "project/project.yml"
-	projectResourcesTemplatePath   = "project/cf.yml"
-	projectAdminRoleParamName      = "AdminRoleName"
-	projectExecutionRoleParamName  = "ExecutionRoleName"
-	projectOutputKMSKey            = "KMSKeyARN"
-	projectOutputS3Bucket          = "PipelineBucket"
-	projectOutputECRRepoPrefix     = "ECRRepo"
-	projectDNSDelegatedAccountsKey = "ProjectDNSDelegatedAccounts"
-	projectDomainNameKey           = "ProjectDomainName"
-	projectNameKey                 = "ProjectName"
+	projectTemplatePath               = "project/project.yml"
+	projectResourcesTemplatePath      = "project/cf.yml"
+	projectAdminRoleParamName         = "AdminRoleName"
+	projectExecutionRoleParamName     = "ExecutionRoleName"
+	projectDNSDelegationRoleParamName = "DNSDelegationRoleName"
+	projectOutputKMSKey               = "KMSKeyARN"
+	projectOutputS3Bucket             = "PipelineBucket"
+	projectOutputECRRepoPrefix        = "ECRRepo"
+	projectDNSDelegatedAccountsKey    = "ProjectDNSDelegatedAccounts"
+	projectDomainNameKey              = "ProjectDomainName"
+	projectNameKey                    = "ProjectName"
+	projectDNSDelegationRoleName      = "DNSDelegationRole"
 )
 
 // ProjectConfigFrom takes a template file and extracts the metadata block,
@@ -136,6 +138,10 @@ func (c *ProjectStackConfig) Parameters() []*cloudformation.Parameter {
 		{
 			ParameterKey:   aws.String(projectNameKey),
 			ParameterValue: aws.String(c.Project),
+		},
+		{
+			ParameterKey:   aws.String(projectDNSDelegationRoleParamName),
+			ParameterValue: aws.String(dnsDelegationRoleName(c.Project)),
 		},
 	}
 }
@@ -250,4 +256,8 @@ func DNSDelegatedAccountsForStack(stack *cloudformation.Stack) []string {
 	}
 
 	return []string{}
+}
+
+func dnsDelegationRoleName(projectName string) string {
+	return fmt.Sprintf("%s-%s", projectName, projectDNSDelegationRoleName)
 }

--- a/internal/pkg/deploy/cloudformation/stack/project_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/project_test.go
@@ -175,6 +175,10 @@ func TestProjectParameters(t *testing.T) {
 			ParameterValue: aws.String("amazon.com"),
 		},
 		{
+			ParameterKey:   aws.String(projectDNSDelegationRoleParamName),
+			ParameterValue: aws.String("testproject-DNSDelegationRole"),
+		},
+		{
 			ParameterKey:   aws.String(projectNameKey),
 			ParameterValue: aws.String("testproject"),
 		},

--- a/internal/pkg/deploy/env.go
+++ b/internal/pkg/deploy/env.go
@@ -16,6 +16,7 @@ type CreateEnvironmentInput struct {
 	Prod                     bool   // Whether or not this environment is a production environment.
 	PublicLoadBalancer       bool   // Whether or not this environment should contain a shared public load balancer between applications.
 	ToolsAccountPrincipalARN string // The Principal ARN of the tools account.
+	ProjectDNSName           string // The DNS name of this project, if it exists
 }
 
 // CreateEnvironmentResponse holds the created environment on successful deployment.

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -38,9 +38,23 @@ Parameters:
   ToolsAccountPrincipalARN:
     Type: String
 
+  ProjectDNSName:
+    Type: String
+    Default: ""
+
+  ProjectDNSDelegationRole:
+    Type: String
+    Default: ""
+
 Conditions:
   CreatePublicLoadBalancer:
     Fn::Equals: [ !Ref IncludePublicLoadBalancer, true ]
+  DelegateDNS:
+    !Not [!Equals [ !Ref ProjectDNSName, "" ]]
+  ExportHTTPSListener: !And
+    - !Condition DelegateDNS
+    - !Condition CreatePublicLoadBalancer
+
 
 Resources:
   VPC:
@@ -192,6 +206,11 @@ Resources:
           FromPort: 80
           IpProtocol: tcp
           ToPort: 80
+        - CidrIp: 0.0.0.0/0
+          Description: Allow from anyone on port 443
+          FromPort: 443
+          IpProtocol: tcp
+          ToPort: 443
       VpcId: !Ref VPC
 
   PublicLoadBalancer:
@@ -227,7 +246,21 @@ Resources:
       LoadBalancerArn: !Ref PublicLoadBalancer
       Port: 80
       Protocol: HTTP
-  
+
+  HTTPSListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    DependsOn: HTTPSCert
+    Condition: DelegateDNS
+    Properties:
+      Certificates:
+        - CertificateArn: !Ref HTTPSCert
+      DefaultActions:
+        - TargetGroupArn: !Ref DefaultHTTPTargetGroup
+          Type: forward
+      LoadBalancerArn: !Ref PublicLoadBalancer
+      Port: 443
+      Protocol: HTTPS
+
   CloudformationExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -250,13 +283,13 @@ Resources:
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-            - 
+            -
               Effect: Allow
               NotAction:
                 - 'organizations:*'
                 - 'account:*'
               Resource: '*'
-            - 
+            -
               Effect: Allow
               Action:
                 - 'organizations:DescribeOrganization'
@@ -437,6 +470,109 @@ Resources:
             ]
             Resource: "*"
 
+  # DNS Delegation Resources
+  CertificateValidationFunction:
+    Type: AWS::Lambda::Function
+    Condition: DelegateDNS
+    Properties:
+      Code:
+        ZipFile: |
+          {{.ACMValidationLambda}}
+      Handler: "index.certificateRequestHandler"
+      Timeout: 600
+      MemorySize: 512
+      Role: !GetAtt 'CustomResourceRole.Arn'
+      Runtime: nodejs10.x
+
+  DNSDelegationFunction:
+    Type: AWS::Lambda::Function
+    Condition: DelegateDNS
+    Properties:
+      Code:
+        ZipFile: |
+          {{.DNSDelegationLambda}}
+      Handler: "index.domainDelegationHandler"
+      Timeout: 600
+      MemorySize: 512
+      Role: !GetAtt 'CustomResourceRole.Arn'
+      Runtime: nodejs10.x
+
+  EnvironmentHostedZone:
+    Type: "AWS::Route53::HostedZone"
+    Condition: DelegateDNS
+    Properties:
+      HostedZoneConfig:
+        Comment: !Sub "HostedZone for environment ${EnvironmentName} - ${EnvironmentName}.${ProjectName}.${ProjectDNSName}"
+      Name: !Sub ${EnvironmentName}.${ProjectName}.${ProjectDNSName}
+
+  CustomResourceRole:
+    Type: AWS::IAM::Role
+    Condition: DelegateDNS
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          -
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: "DNSandACMAccess"
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "acm:ListCertificates"
+                  - "acm:RequestCertificate"
+                  - "acm:DescribeCertificate"
+                  - "acm:GetCertificate"
+                  - "acm:DeleteCertificate"
+                  - "acm:AddTagsToCertificate"
+                  - "route53:ListHostedZonesByName"
+                  - "sts:AssumeRole"
+                  - "logs:*"
+                  - "route53:ChangeResourceRecordSets"
+                  - "route53:ListResourceRecordSets"
+                  - "route53:Get*"
+                  - "route53:Describe*"
+                Resource:
+                  - "*"
+  # Adds records for this environment's hostedzone
+  # into the project's hostedzone. This lets this
+  # environment own the DNS of the it's subdomain.
+  DelegateDNSAction:
+    Condition: DelegateDNS
+    Type: Custom::DNSDelegationFunction
+    DependsOn:
+    - DNSDelegationFunction
+    - EnvironmentHostedZone
+    Properties:
+      ServiceToken: !GetAtt DNSDelegationFunction.Arn
+      DomainName: !Sub ${ProjectName}.${ProjectDNSName}
+      SubdomainName: !Sub ${EnvironmentName}.${ProjectName}.${ProjectDNSName}
+      NameServers: !GetAtt EnvironmentHostedZone.NameServers
+      RootDNSRole: !Ref ProjectDNSDelegationRole
+
+  HTTPSCert:
+    Condition: DelegateDNS
+    Type: Custom::CertificateValidationFunction
+    DependsOn:
+    - CertificateValidationFunction
+    - EnvironmentHostedZone
+    - DelegateDNSAction
+    Properties:
+      ServiceToken: !GetAtt CertificateValidationFunction.Arn
+      DomainName: !Sub ${EnvironmentName}.${ProjectName}.${ProjectDNSName}
+      HostedZoneId: !Ref EnvironmentHostedZone
+      Region: !Ref AWS::Region
+      SubjectAlternativeNames:
+      - !Sub "*.${EnvironmentName}.${ProjectName}.${ProjectDNSName}"
+
 Outputs:
   VpcId:
     Value: !Ref VPC
@@ -458,6 +594,8 @@ Outputs:
   PublicLoadBalancerDNSName:
     Condition: CreatePublicLoadBalancer
     Value: !GetAtt PublicLoadBalancer.DNSName
+    Export:
+      Name: !Sub ${AWS::StackName}-PublicLoadBalancerDNS
 
   PublicLoadBalancerArn:
     Condition: CreatePublicLoadBalancer
@@ -471,11 +609,23 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-PublicLoadBalancerSecurityGroupId
 
+  PublicLoadBalancerHostedZone:
+    Condition: CreatePublicLoadBalancer
+    Value: !GetAtt PublicLoadBalancer.CanonicalHostedZoneID
+    Export:
+      Name: !Sub ${AWS::StackName}-CanonicalHostedZoneID
+
   HTTPListenerArn:
     Condition: CreatePublicLoadBalancer
     Value: !Ref HTTPListener
     Export:
       Name: !Sub ${AWS::StackName}-HTTPListenerArn
+
+  HTTPSListenerArn:
+    Condition: ExportHTTPSListener
+    Value: !Ref HTTPSListener
+    Export:
+      Name: !Sub ${AWS::StackName}-HTTPSListenerArn
 
   DefaultHTTPTargetGroupArn:
     Condition: CreatePublicLoadBalancer
@@ -493,8 +643,23 @@ Outputs:
     Description: The role to be assumed by the ecs-cli to manage environments.
     Export:
       Name: !Sub ${AWS::StackName}-EnvironmentManagerRoleARN
+
   CFNExecutionRoleARN:
     Value: !GetAtt CloudformationExecutionRole.Arn
     Description: The role to be assumed by the Cloudformation service when it deploys application infrastructure.
     Export:
       Name: !Sub ${AWS::StackName}-CFNExecutionRoleARN
+
+  EnvironmentHostedZone:
+    Condition: DelegateDNS
+    Value: !Ref EnvironmentHostedZone
+    Description: The HostedZone for this environment's private DNS.
+    Export:
+      Name: !Sub ${AWS::StackName}-HostedZone
+
+  EnvironmentSubdomain:
+    Condition: DelegateDNS
+    Value: !Sub ${EnvironmentName}.${ProjectName}.${ProjectDNSName}
+    Description: The domain name of this environment.
+    Export:
+      Name: !Sub ${AWS::StackName}-SubDomain

--- a/templates/project/project.yml
+++ b/templates/project/project.yml
@@ -7,6 +7,9 @@ Parameters:
     Type: String
   ExecutionRoleName:
     Type: String
+  DNSDelegationRoleName:
+    Type: String
+    Default: ""
   ProjectDNSDelegatedAccounts:
     Type: CommaDelimitedList
     Default: ""
@@ -99,6 +102,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: DelegateDNS
     Properties:
+      RoleName: !Ref DNSDelegationRoleName
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
This pipes through the DNS name of the project to the env
templates, and wires in the custom resources.

TODO: Add the integration tests for this - but the
existing, non DNS integ tests are running fine.

I manually ran the env setup for a DNS project. 

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
