### PR TITLE
Add HTTPS to lb_fargate_app template & x-account deploys

### DIFF
--- a/internal/pkg/cli/app_package_test.go
+++ b/internal/pkg/cli/app_package_test.go
@@ -530,6 +530,46 @@ count: 1`), nil)
 				}, nil)
 			},
 		},
+		"print CFN template with HTTPS": {
+			inProjectName: "phonetool",
+			inEnvName:     "test",
+			inAppName:     "frontend",
+			inTagName:     "latest",
+
+			expectStore: func(m *climocks.MockprojectService) {
+				m.EXPECT().GetEnvironment("phonetool", "test").Return(&archer.Environment{
+					Project:   "phonetool",
+					Name:      "test",
+					AccountID: "1111",
+					Region:    "us-west-2",
+				}, nil)
+				m.EXPECT().GetProject("phonetool").Return(&archer.Project{
+					Name:      "phonetool",
+					AccountID: "1234",
+					Domain:    "ecs.aws",
+				}, nil)
+			},
+			expectWorkspace: func(m *mocks.MockWorkspace) {
+				m.EXPECT().AppManifestFileName("frontend").Return("frontend-app.yml")
+				m.EXPECT().ReadFile("frontend-app.yml").Return([]byte(`name: frontend
+type: Load Balanced Web App
+image:
+  build: frontend/Dockerfile
+  port: 80
+http:
+  path: '*'
+cpu: 256
+memory: 512
+count: 1`), nil)
+			},
+			expectDeployer: func(m *climocks.MockprojectResourcesGetter) {
+				m.EXPECT().GetProjectResourcesByRegion(gomock.Any(), gomock.Any()).Return(&archer.ProjectRegionalResources{
+					RepositoryURLs: map[string]string{
+						"frontend": "some url",
+					},
+				}, nil)
+			},
+		},
 		"with output directory": {
 			inProjectName: "phonetool",
 			inEnvName:     "test",

--- a/internal/pkg/deploy/cloudformation/app.go
+++ b/internal/pkg/deploy/cloudformation/app.go
@@ -14,7 +14,7 @@ import (
 
 // DeployApp wraps the application deployment flow and handles orchestration of
 // creating a stack versus updating a stack.
-func (cf CloudFormation) DeployApp(template, stackName, changeSetName string, tags map[string]string) error {
+func (cf CloudFormation) DeployApp(template, stackName, changeSetName, cfExecutionRole string, tags map[string]string) error {
 	var cfnTags []*cloudformation.Tag
 	for k, v := range tags {
 		cfnTags = append(cfnTags, &cloudformation.Tag{
@@ -28,6 +28,7 @@ func (cf CloudFormation) DeployApp(template, stackName, changeSetName string, ta
 		TemplateBody: aws.String(template),
 		Capabilities: aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam}),
 		Tags:         cfnTags,
+		RoleARN:      aws.String(cfExecutionRole),
 	})
 
 	// If CreateStack does not return an error we'll wait for StackCreateComplete status.
@@ -61,6 +62,7 @@ func (cf CloudFormation) DeployApp(template, stackName, changeSetName string, ta
 		Capabilities:  aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam}),
 		ChangeSetType: aws.String(cloudformation.ChangeSetTypeUpdate),
 		Tags:          cfnTags,
+		RoleARN:       aws.String(cfExecutionRole),
 	})
 
 	if err != nil {

--- a/internal/pkg/deploy/cloudformation/app_test.go
+++ b/internal/pkg/deploy/cloudformation/app_test.go
@@ -17,6 +17,7 @@ func TestDeployApp(t *testing.T) {
 	mockTemplate := "mockTemplate"
 	mockStackName := "mockStackName"
 	mockChangeSetName := "mockChangeSetName"
+	mockExecutionRole := "mockExecutionRole"
 	mockError := errors.New("mockError")
 
 	testCases := map[string]struct {
@@ -37,6 +38,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockStackName, *in.StackName)
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return &cloudformation.CreateStackOutput{}, nil
 			},
@@ -55,6 +57,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockStackName, *in.StackName)
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return nil, awserr.New(cloudformation.ErrCodeAlreadyExistsException, "", nil)
 			},
@@ -66,6 +69,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
 				require.Equal(t, cloudformation.ChangeSetTypeUpdate, *in.ChangeSetType)
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
@@ -100,6 +104,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockStackName, *in.StackName)
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return nil, awserr.New(cloudformation.ErrCodeAlreadyExistsException, "", nil)
 			},
@@ -111,6 +116,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
 				require.Equal(t, cloudformation.ChangeSetTypeUpdate, *in.ChangeSetType)
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
@@ -140,6 +146,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockStackName, *in.StackName)
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return nil, awserr.New(cloudformation.ErrCodeAlreadyExistsException, "", nil)
 			},
@@ -151,6 +158,7 @@ func TestDeployApp(t *testing.T) {
 				require.Equal(t, mockTemplate, *in.TemplateBody)
 				require.Equal(t, cloudformation.CapabilityCapabilityIam, *in.Capabilities[0])
 				require.Equal(t, cloudformation.ChangeSetTypeUpdate, *in.ChangeSetType)
+				require.Equal(t, mockExecutionRole, *in.RoleARN)
 
 				return &cloudformation.CreateChangeSetOutput{}, nil
 			},
@@ -190,7 +198,7 @@ func TestDeployApp(t *testing.T) {
 				},
 			}
 
-			gotErr := cf.DeployApp(mockTemplate, mockStackName, mockChangeSetName, nil)
+			gotErr := cf.DeployApp(mockTemplate, mockStackName, mockChangeSetName, mockExecutionRole, nil)
 
 			require.Equal(t, tc.wantErr, gotErr)
 		})

--- a/internal/pkg/deploy/cloudformation/stack/testdata/rendered_pipeline_cfn_template.yml
+++ b/internal/pkg/deploy/cloudformation/stack/testdata/rendered_pipeline_cfn_template.yml
@@ -372,9 +372,9 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-frontend-test-chicken
+                ChangeSetName: chickenProject-test-chicken-frontend
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-frontend-test-chicken
+                StackName: chickenProject-test-chicken-frontend
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::infrastructure/frontend.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/frontend-test-chicken.params.json
@@ -398,9 +398,9 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-backend-test-chicken
+                ChangeSetName: chickenProject-test-chicken-backend
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-backend-test-chicken
+                StackName: chickenProject-test-chicken-backend
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::infrastructure/backend.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/backend-test-chicken.params.json
@@ -444,9 +444,9 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-frontend-prod-can-fly
+                ChangeSetName: chickenProject-prod-can-fly-frontend
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-frontend-prod-can-fly
+                StackName: chickenProject-prod-can-fly-frontend
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::infrastructure/frontend.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/frontend-prod-can-fly.params.json
@@ -470,9 +470,9 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: chickenProject-backend-prod-can-fly
+                ChangeSetName: chickenProject-prod-can-fly-backend
                 ActionMode: CREATE_UPDATE
-                StackName: chickenProject-backend-prod-can-fly
+                StackName: chickenProject-prod-can-fly-backend
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::infrastructure/backend.stack.yml
                 TemplateConfiguration: BuildOutput::infrastructure/backend-prod-can-fly.params.json

--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -325,9 +325,9 @@ Resources:
                 Provider: CloudFormation
               Configuration:
                 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/continuous-delivery-codepipeline-action-reference.html
-                ChangeSetName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                ChangeSetName: {{$.ProjectName}}-{{$stage.Name}}-{{$app}}
                 ActionMode: CREATE_UPDATE
-                StackName: {{$.ProjectName}}-{{$app}}-{{$stage.Name}}
+                StackName: {{$.ProjectName}}-{{$stage.Name}}-{{$app}}
                 Capabilities: CAPABILITY_NAMED_IAM
                 TemplatePath: BuildOutput::infrastructure/{{$stage.AppTemplatePath $app}}
                 TemplateConfiguration: BuildOutput::infrastructure/{{$stage.AppTemplateConfigurationPath $app}}

--- a/templates/lb-fargate-service/cf.yml
+++ b/templates/lb-fargate-service/cf.yml
@@ -33,6 +33,16 @@ Parameters:
   TaskCount:
     Type: Number
     Default: {{.App.Count}}
+  HTTPSEnabled:
+    Type: String
+    AllowedValues: [true, false]
+    Default: '{{.HTTPSEnabled}}'
+Conditions:
+  HTTPLoadBalancer:
+    !Not
+      - !Condition HTTPSLoadBalancer
+  HTTPSLoadBalancer:
+    !Equals [!Ref HTTPSEnabled, true]
 Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -117,8 +127,6 @@ Resources:
               !Sub "${ProjectName}-${EnvName}-PublicLoadBalancerSecurityGroupId"
   Service:
     Type: AWS::ECS::Service
-    DependsOn:
-      - ListenerRule
     Properties:
       Cluster:
         Fn::ImportValue:
@@ -150,7 +158,6 @@ Resources:
         - ContainerName: !Ref AppName
           ContainerPort: !Ref ContainerPort
           TargetGroupArn: !Ref TargetGroup
-
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -167,9 +174,33 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Sub "${ProjectName}-${EnvName}-VpcId"
-
-  ListenerRule:
+  LoadBalancerDNSAlias:
+    Type: AWS::Route53::RecordSetGroup
+    Condition: HTTPSLoadBalancer
+    Properties:
+      HostedZoneId:
+        Fn::ImportValue:
+          !Sub "${ProjectName}-${EnvName}-HostedZone"
+      Comment: !Sub "LoadBalancer alias for app ${AppName}"
+      RecordSets:
+      - Name:
+          !Join
+            - '.'
+            - - !Ref AppName
+              - Fn::ImportValue:
+                  !Sub "${ProjectName}-${EnvName}-SubDomain"
+              - ""
+        Type: A
+        AliasTarget:
+          HostedZoneId:
+            Fn::ImportValue:
+              !Sub "${ProjectName}-${EnvName}-CanonicalHostedZoneID"
+          DNSName:
+            Fn::ImportValue:
+              !Sub "${ProjectName}-${EnvName}-PublicLoadBalancerDNS"
+  HTTPListenerRule:
     Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: HTTPLoadBalancer
     Properties:
       Actions:
         - TargetGroupArn: !Ref TargetGroup
@@ -182,4 +213,24 @@ Resources:
       ListenerArn:
         Fn::ImportValue:
           !Sub "${ProjectName}-${EnvName}-HTTPListenerArn"
+      Priority: !Ref RulePriority
+  HTTPSListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: HTTPSLoadBalancer
+    Properties:
+      Actions:
+        - TargetGroupArn: !Ref TargetGroup
+          Type: forward
+      Conditions:
+        - Field: 'host-header'
+          HostHeaderConfig:
+            Values:
+              - Fn::Join:
+                - '.'
+                - - !Ref AppName
+                  - Fn::ImportValue:
+                      !Sub "${ProjectName}-${EnvName}-SubDomain"
+      ListenerArn:
+        Fn::ImportValue:
+          !Sub "${ProjectName}-${EnvName}-HTTPSListenerArn"
       Priority: !Ref RulePriority

--- a/templates/lb-fargate-service/params.json
+++ b/templates/lb-fargate-service/params.json
@@ -9,7 +9,8 @@
     "RulePath": "{{.App.Path}}",
     "TaskCPU": "{{.App.CPU}}",
     "TaskMemory": "{{.App.Memory}}",
-    "TaskCount": "{{.App.Count}}"
+    "TaskCount": "{{.App.Count}}",
+    "HTTPSEnabled": "{{.HTTPSEnabled}}"
   },
   "Tags": {
     "ecs-project": "{{.Env.Project}}",


### PR DESCRIPTION
This change updates the lb fargate app to create an https
listner if the project is configured for https.

It also enables cross account deployments and brings
the app stack name in line with the codepipeline's apps
(project-env-app).

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
