### PR TITLE
Check ShouldDeploy flag before deploying app

### DIFF
--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -187,6 +187,10 @@ func (opts *InitOpts) deployEnv() error {
 }
 
 func (opts *InitOpts) deployApp() error {
+	if !opts.ShouldDeploy {
+		return nil
+	}
+
 	if err := opts.appDeployer.init(); err != nil {
 		return err
 	}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -119,6 +119,21 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.initEnv.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 			},
 		},
+		"should not deploy the app if shouldDeploy is false": {
+			inPromptForShouldDeploy: true,
+			inShouldDeploy:          false,
+			expect: func(opts *InitOpts) {
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Validate().Return(nil)
+				opts.initProject.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
+				opts.initApp.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
+
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm("Would you like to deploy a staging environment?", gomock.Any()).
+					Return(false, nil)
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add check against `ShouldDeploy` flag in `deployApp` function.

Sample output:
```
→ ./bin/local/archer init
Note: It's best to run this command in the root of your workspace.
Welcome to the ECS CLI! We're going to walk you through some questions 
to help you get set up with a project on ECS. A project is a collection of 
containerized applications (or micro-services) that operate together.

Looks like you don't have any existing projects. Let's create one!
? What would you like to call your project? myproj
? Which type of infrastructure pattern best represents your application? Load Balanced Web App
? What do you want to call this Load Balanced Web App? myapp
? Which Dockerfile would you like to use for myapp app? myapp/Dockerfile
Ok great, we'll set up a Load Balanced Web App named myapp in project myproj.
✔ Success! Created the infrastructure to manage container repositories under project myproj.

✔ Success! Wrote the manifest for myapp app at 'ecs-project/myapp-app.yml'
Your manifest contains configurations like your container size and ports.

✔ Success! Created ECR repositories for application myapp.
2019/11/20 13:17:00 Created Application with version 1
All right, you're all set for local development.
? Would you like to deploy a staging environment? No

No problem, you can deploy your application later:
- Run `archer env init --name test --project myproj` to create your staging environment.
- Update your manifest ecs-project/myapp-app.yml to change the defaults.
- Run `archer app deploy --name myapp --env test` to deploy your application to a test environment.
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
#428 #431 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
