### PR TITLE
Add user agent to all aws-sdk calls

### DIFF
--- a/internal/pkg/aws/handlers/user_agent_handler.go
+++ b/internal/pkg/aws/handlers/user_agent_handler.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/version"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+const UserAgentHeader = "User-Agent"
+
+// UserAgentHandler returns a http request handler that sets a custom user agent to all aws requests.
+func UserAgentHandler() request.NamedHandler {
+	return request.NamedHandler{
+		Name: "UserAgentHandler",
+		Fn: func(r *request.Request) {
+			userAgent := r.HTTPRequest.Header.Get(UserAgentHeader)
+			r.HTTPRequest.Header.Set(UserAgentHeader,
+				fmt.Sprintf("aws-ecs-cli-v2/%s %s (%s) %s", version.Version, version.Platform, runtime.GOOS, userAgent))
+		},
+	}
+}

--- a/internal/pkg/aws/session/session.go
+++ b/internal/pkg/aws/session/session.go
@@ -7,6 +7,7 @@ package session
 import (
 	"fmt"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/handlers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -14,30 +15,39 @@ import (
 
 // Default returns a session configured against the "default" AWS profile.
 func Default() (*session.Session, error) {
-	return session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
 		},
 		SharedConfigState: session.SharedConfigEnable,
 	})
+	sess.Handlers.Build.PushBackNamed(handlers.UserAgentHandler())
+
+	return sess, err
 }
 
 // DefaultWithRegion returns a session configured against the "default" AWS profile and the input region.
 func DefaultWithRegion(region string) (*session.Session, error) {
-	return session.NewSession(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})
+	sess.Handlers.Build.PushBackNamed(handlers.UserAgentHandler())
+
+	return sess, err
 }
 
 // FromProfile returns a session configured against the input profile name.
 func FromProfile(name string) (*session.Session, error) {
-	return session.NewSessionWithOptions(session.Options{
+	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
 		},
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           name,
 	})
+	sess.Handlers.Build.PushBackNamed(handlers.UserAgentHandler())
+
+	return sess, err
 }
 
 // FromRole returns a session configured against the input role and region.
@@ -49,9 +59,12 @@ func FromRole(roleARN string, region string) (*session.Session, error) {
 	}
 
 	creds := stscreds.NewCredentials(defaultSession, roleARN)
-	return session.NewSession(&aws.Config{
+	sess, err := session.NewSession(&aws.Config{
 		CredentialsChainVerboseErrors: aws.Bool(true),
 		Credentials:                   creds,
 		Region:                        &region,
 	})
+	sess.Handlers.Build.PushBackNamed(handlers.UserAgentHandler())
+
+	return sess, err
 }


### PR DESCRIPTION
Add User-Agent to all AWS SDK calls.

Fixes: https://github.com/aws/amazon-ecs-cli-v2/issues/255

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
