### PR TITLE
Increase HealthCheckGracePeriodSeconds to 1 min

### DIFF
--- a/templates/lb-fargate-service/cf.yml
+++ b/templates/lb-fargate-service/cf.yml
@@ -150,7 +150,7 @@ Resources:
         MaximumPercent: 200
       DesiredCount: !Ref TaskCount
       # This may need to be adjusted if the container takes a while to start up
-      HealthCheckGracePeriodSeconds: 30
+      HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:


### PR DESCRIPTION
Applications that are slow to startup (> 30secs) kept failing the healthchecks. Increasing the grace period to 1min increases the odd that apps will be running by then.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
