### PR TITLE
Workspace can return a list of unmarshalled app manifests

### DIFF
--- a/internal/pkg/archer/manifest.go
+++ b/internal/pkg/archer/manifest.go
@@ -7,4 +7,5 @@ package archer
 type Manifest interface {
 	Marshal() ([]byte, error)
 	DockerfilePath() string
+	AppName() string
 }

--- a/internal/pkg/archer/workspace.go
+++ b/internal/pkg/archer/workspace.go
@@ -14,7 +14,7 @@ type Workspace interface {
 	ManifestIO
 	Create(projectName string) error
 	Summary() (*WorkspaceSummary, error)
-	AppNames() ([]string, error)
+	Apps() ([]Manifest, error)
 }
 
 // ManifestIO can read, write and list local manifest files.

--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -167,18 +167,23 @@ func (opts *appDeployOpts) sourceProjectData() error {
 }
 
 func (opts *appDeployOpts) sourceProjectApplications() error {
-	appNames, err := opts.workspaceService.AppNames()
+	apps, err := opts.workspaceService.Apps()
 
 	if err != nil {
-		return fmt.Errorf("get app names: %w", err)
+		return fmt.Errorf("get apps: %w", err)
 	}
 
-	if len(appNames) == 0 {
+	if len(apps) == 0 {
 		// TODO: recommend follow up command - app init?
 		return errors.New("no applications found")
 	}
 
-	opts.localProjectAppNames = appNames
+	names := make([]string, 0, len(apps))
+	for _, app := range apps {
+		names = append(names, app.AppName())
+	}
+
+	opts.localProjectAppNames = names
 
 	return nil
 }

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -155,9 +155,13 @@ func (opts *PackageAppOpts) Execute() error {
 }
 
 func (opts *PackageAppOpts) listAppNames() ([]string, error) {
-	names, err := opts.ws.AppNames()
+	apps, err := opts.ws.Apps()
 	if err != nil {
 		return nil, fmt.Errorf("list applications in workspace: %w", err)
+	}
+	names := make([]string, 0, len(apps))
+	for _, app := range apps {
+		names = append(names, app.AppName())
 	}
 	return names, nil
 }

--- a/internal/pkg/cli/app_package_test.go
+++ b/internal/pkg/cli/app_package_test.go
@@ -36,7 +36,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 	}{
 		"wrap list apps error": {
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return(nil, errors.New("some error"))
+				m.EXPECT().Apps().Return(nil, errors.New("some error"))
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -49,7 +49,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		},
 		"empty workspace error": {
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return([]string{}, nil)
+				m.EXPECT().Apps().Return([]archer.Manifest{}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -63,7 +63,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		"wrap list envs error": {
 			inAppName: "frontend",
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return(nil, errors.New("some ssm error"))
@@ -78,7 +78,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		"empty environments error": {
 			inAppName: "frontend",
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return(nil, nil)
@@ -92,7 +92,17 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		},
 		"prompt for all options": {
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil)
+				m.EXPECT().Apps().Return([]archer.Manifest{
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "frontend",
+						},
+					},
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "backend",
+						},
+					}}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return([]*archer.Environment{
@@ -116,7 +126,17 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inEnvName: "test",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil)
+				m.EXPECT().Apps().Return([]archer.Manifest{
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "frontend",
+						},
+					},
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "backend",
+						},
+					}}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -132,7 +152,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inAppName: "frontend",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return([]*archer.Environment{
@@ -156,7 +176,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inEnvName: "test",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -224,7 +244,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 	}{
 		"invalid workspace": {
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
@@ -235,7 +255,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 		"invalid image tag": {
 			inProjectName: "phonetool",
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
@@ -248,7 +268,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inTag:         "manual-1234",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return(nil, errors.New("some error"))
+				m.EXPECT().Apps().Return(nil, errors.New("some error"))
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
@@ -262,7 +282,13 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inTag:         "manual-1234",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return([]string{"backend"}, nil)
+				m.EXPECT().Apps().Return([]archer.Manifest{
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "backend",
+						},
+					},
+				}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
@@ -276,7 +302,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inTag:         "manual-1234",
 
 			expectWS: func(m *mocks.MockWorkspace) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().Apps().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment("phonetool", "test").Return(nil, &store.ErrNoSuchEnvironment{

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -68,9 +68,14 @@ func (opts *UpdatePipelineOpts) Validate() error {
 
 func (opts *UpdatePipelineOpts) convertStages(manifestStages []manifest.PipelineStage) ([]deploy.PipelineStage, error) {
 	var stages []deploy.PipelineStage
-	apps, err := opts.ws.AppNames()
+	apps, err := opts.ws.Apps()
 	if err != nil {
 		return nil, err
+	}
+	// TODO: Will fast follow with another PR to actually support #443
+	appNames := make([]string, 0, len(apps))
+	for _, app := range apps {
+		appNames = append(appNames, app.AppName())
 	}
 
 	for _, stage := range manifestStages {
@@ -80,7 +85,7 @@ func (opts *UpdatePipelineOpts) convertStages(manifestStages []manifest.Pipeline
 		}
 
 		pipelineStage := deploy.PipelineStage{
-			LocalApplications: apps,
+			LocalApplications: appNames,
 			AssociatedEnvironment: &deploy.AssociatedEnvironment{
 				Name:      stage.Name,
 				Region:    env.Region,

--- a/internal/pkg/cli/pipeline_update_test.go
+++ b/internal/pkg/cli/pipeline_update_test.go
@@ -34,7 +34,17 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 			},
 			inProjectName: "badgoose",
 			mockWorkspace: func(m *archermocks.MockWorkspace) {
-				m.EXPECT().AppNames().Return([]string{"frontend, backend"}, nil).Times(1)
+				m.EXPECT().Apps().Return([]archer.Manifest{
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "frontend",
+						},
+					},
+					&manifest.LBFargateManifest{
+						AppManifest: manifest.AppManifest{
+							Name: "backend",
+						},
+					}}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				mockEnv := &archer.Environment{
@@ -56,7 +66,7 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 						AccountID: "123456789012",
 						Prod:      false,
 					},
-					LocalApplications: []string{"frontend, backend"},
+					LocalApplications: []string{"frontend", "backend"},
 				},
 			},
 			expectedError: nil,

--- a/internal/pkg/manifest/app_manifest.go
+++ b/internal/pkg/manifest/app_manifest.go
@@ -25,6 +25,11 @@ type AppManifest struct {
 	Type string `yaml:"type"` // must be one of the supported manifest types.
 }
 
+// AppName returns the name of the application
+func (a *AppManifest) AppName() string {
+	return a.Name
+}
+
 // AppImage represents the application's container image.
 type AppImage struct {
 	Build string `yaml:"build"` // Path to the Dockerfile.

--- a/internal/pkg/manifest/lb_fargate_manifest.go
+++ b/internal/pkg/manifest/lb_fargate_manifest.go
@@ -105,11 +105,6 @@ func (m LBFargateManifest) DockerfilePath() string {
 	return m.Image.Build
 }
 
-// AppName returns the name of the application
-func (m LBFargateManifest) AppName() string {
-	return m.Name
-}
-
 // EnvConf returns the application configuration with environment overrides.
 // If the environment passed in does not have any overrides then we return the default values.
 func (m *LBFargateManifest) EnvConf(envName string) LBFargateConfig {

--- a/internal/pkg/manifest/lb_fargate_manifest.go
+++ b/internal/pkg/manifest/lb_fargate_manifest.go
@@ -105,6 +105,11 @@ func (m LBFargateManifest) DockerfilePath() string {
 	return m.Image.Build
 }
 
+// AppName returns the name of the application
+func (m LBFargateManifest) AppName() string {
+	return m.Name
+}
+
 // EnvConf returns the application configuration with environment overrides.
 // If the environment passed in does not have any overrides then we return the default values.
 func (m *LBFargateManifest) EnvConf(envName string) LBFargateConfig {

--- a/mocks/mock_workspace.go
+++ b/mocks/mock_workspace.go
@@ -121,19 +121,19 @@ func (mr *MockWorkspaceMockRecorder) Summary() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockWorkspace)(nil).Summary))
 }
 
-// AppNames mocks base method
-func (m *MockWorkspace) AppNames() ([]string, error) {
+// Apps mocks base method
+func (m *MockWorkspace) Apps() ([]archer.Manifest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppNames")
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "Apps")
+	ret0, _ := ret[0].([]archer.Manifest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AppNames indicates an expected call of AppNames
-func (mr *MockWorkspaceMockRecorder) AppNames() *gomock.Call {
+// Apps indicates an expected call of Apps
+func (mr *MockWorkspaceMockRecorder) Apps() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNames", reflect.TypeOf((*MockWorkspace)(nil).AppNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apps", reflect.TypeOf((*MockWorkspace)(nil).Apps))
 }
 
 // MockManifestIO is a mock of ManifestIO interface


### PR DESCRIPTION
<!-- Provide summary of changes -->
There are multiple places where we need a list of unserialized app manifests. Now you can finally do that :)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Resolves #452.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
