### PR TITLE
Replace ChangeSet suffix with UUID

### DIFF
--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
@@ -355,9 +356,12 @@ func (opts appDeployOpts) deployApp() error {
 
 	template, err := opts.getAppDeployTemplate()
 
-	// TODO move stack
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return fmt.Errorf("failed to generate random id for changeSet: %w", err)
+	}
 	stackName := fmt.Sprintf("%s-%s-%s", opts.ProjectName(), opts.targetEnvironment.Name, opts.app)
-	changeSetName := fmt.Sprintf("%s-%s", stackName, opts.imageTag)
+	changeSetName := fmt.Sprintf("%s-%s", stackName, id)
 
 	opts.spinner.Start(
 		fmt.Sprintf("Deploying %s to %s.",


### PR DESCRIPTION
This change lets us recover from empty stack updates.
Right now, if we generate a changeset, we suffix it
with the image tag.

If this is empty, the changeset is kept in CF.
If we make a change that doesn't affect the tag,
we'll fail to deploy.

We should clean up those failed changesets, but for now,
to get this working, changing the ID to be a UUID.

addresses #460

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
