### PR TITLE
Fix unit test failures when ecs-project folder is in context

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -291,7 +291,9 @@ func (opts *InitAppOpts) RecommendedActions() []string {
 
 // BuildAppInitCmd build the command for creating a new application.
 func BuildAppInitCmd() *cobra.Command {
-	opts := &InitAppOpts{}
+	opts := &InitAppOpts{
+		GlobalOpts: NewGlobalOpts(),
+	}
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Creates a new application in a project.",
@@ -323,7 +325,6 @@ This command is also run as part of "ecs-preview init".`,
 			opts.projDeployer = cloudformation.New(sess)
 
 			opts.prog = termprogress.NewSpinner()
-			opts.GlobalOpts = NewGlobalOpts()
 			return opts.Validate()
 		}),
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -15,11 +15,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func init() {
-	// Store the local project's name in viper.
-	bindProjectName()
-}
-
 // GlobalOpts holds fields that are used across multiple commands.
 type GlobalOpts struct {
 	projectName string
@@ -28,6 +23,8 @@ type GlobalOpts struct {
 
 // NewGlobalOpts returns a GlobalOpts with the project name retrieved from viper.
 func NewGlobalOpts() *GlobalOpts {
+	bindProjectName()
+
 	return &GlobalOpts{
 		projectName: viper.GetString(projectFlag),
 		prompt:      prompt.New(),


### PR DESCRIPTION
Addresses #332 where unit tests will fail if there is an ecs-project folder with a .ecs-workspace file which contains a project name.
The unit tests were picking that value up via the cli package init func which in turn causes unit tests that rely on an empty project name to fail.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
