### PR TITLE
Trim /Dockerfile from manifest image path value

### DIFF
--- a/internal/pkg/cli/app_deploy_test.go
+++ b/internal/pkg/cli/app_deploy_test.go
@@ -343,3 +343,98 @@ func TestDeployApp(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAppDockerfilePath(t *testing.T) {
+	var mockWorkspace *mocks.MockWorkspace
+
+	mockError := errors.New("mockError")
+	mockManifestList := []string{
+		"appA",
+		"appB",
+	}
+	mockManifest := []byte(`name: appA
+type: 'Load Balanced Web App'
+image:
+  build: appA/Dockerfile
+`)
+
+	tests := map[string]struct {
+		inputApp   string
+		setupMocks func(controller *gomock.Controller)
+
+		wantPath string
+		wantErr  error
+	}{
+		"should wrap error returned from workspaceService ListManifestFiles()": {
+			setupMocks: func(controller *gomock.Controller) {
+				mockWorkspace = mocks.NewMockWorkspace(controller)
+
+				mockWorkspace.EXPECT().ListManifestFiles().Times(1).Return(nil, mockError)
+			},
+			wantPath: "",
+			wantErr:  fmt.Errorf("list local manifest files: %w", mockError),
+		},
+		"should return error if list of manifest files returned from workspaceService is empty": {
+			setupMocks: func(controller *gomock.Controller) {
+				mockWorkspace = mocks.NewMockWorkspace(controller)
+
+				mockWorkspace.EXPECT().ListManifestFiles().Times(1).Return([]string{}, nil)
+			},
+			wantPath: "",
+			wantErr:  errNoLocalManifestsFound,
+		},
+		"should return error if unable to match input app with local manifests": {
+			inputApp: "appC",
+			setupMocks: func(controller *gomock.Controller) {
+				mockWorkspace = mocks.NewMockWorkspace(controller)
+
+				mockWorkspace.EXPECT().ListManifestFiles().Times(1).Return(mockManifestList, nil)
+			},
+			wantPath: "",
+			wantErr:  fmt.Errorf("couldn't find local manifest %s", "appC"),
+		},
+		"should return error if workspaceService ReadFile returns error": {
+			inputApp: "appA",
+			setupMocks: func(controller *gomock.Controller) {
+				mockWorkspace = mocks.NewMockWorkspace(controller)
+
+				gomock.InOrder(
+					mockWorkspace.EXPECT().ListManifestFiles().Times(1).Return(mockManifestList, nil),
+					mockWorkspace.EXPECT().ReadFile("appA").Times(1).Return(nil, mockError),
+				)
+			},
+			wantPath: "",
+			wantErr:  fmt.Errorf("read manifest file %s: %w", "appA", mockError),
+		},
+		"should trim the manifest DockerfilePath if it contains /Dockerfile": {
+			inputApp: "appA",
+			setupMocks: func(controller *gomock.Controller) {
+				mockWorkspace = mocks.NewMockWorkspace(controller)
+
+				gomock.InOrder(
+					mockWorkspace.EXPECT().ListManifestFiles().Times(1).Return(mockManifestList, nil),
+					mockWorkspace.EXPECT().ReadFile("appA").Times(1).Return(mockManifest, nil),
+				)
+			},
+			wantPath: "appA",
+			wantErr:  nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			test.setupMocks(ctrl)
+			opts := appDeployOpts{
+				app:              test.inputApp,
+				workspaceService: mockWorkspace,
+			}
+
+			gotPath, gotErr := opts.getAppDockerfilePath()
+
+			require.Equal(t, test.wantPath, gotPath)
+			require.Equal(t, test.wantErr, gotErr)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
* Updated `app deploy` workflow to trim `/Dockerfile` from manifest docker image path values
* Improved error messages and added test coverage for `getAppDockerfilePath` function

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #490 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
