### PR TITLE
Add recommended follow-up actions to app delete

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -66,6 +66,13 @@ func BuildAppDeleteCmd() *cobra.Command {
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			return opts.deleteApp()
 		}),
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			log.Infoln("Recommended follow-up actions:")
+			for _, followup := range opts.RecommendedActions() {
+				log.Infof("- %s\n", followup)
+			}
+			return nil
+		},
 	}
 
 	cmd.Flags().BoolVar(&opts.skipConfirmation, yesFlag, false, yesFlagDescription)
@@ -304,4 +311,13 @@ func (opts deleteAppOpts) deleteWorkspaceFile() error {
 	}
 
 	return nil
+}
+
+// RecommendedActions returns follow-up actions the user can take after successfully executing the command.
+func (opts *deleteAppOpts) RecommendedActions() []string {
+	// TODO: Add recommendation to do `pipeline delete` when it is available
+	return []string{
+		fmt.Sprintf("Run %s to update the corresponding pipeline if exists.",
+			color.HighlightCode(fmt.Sprintf("ecs-preview pipeline update"))),
+	}
 }

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -317,7 +317,7 @@ func (opts deleteAppOpts) deleteWorkspaceFile() error {
 func (opts *deleteAppOpts) RecommendedActions() []string {
 	// TODO: Add recommendation to do `pipeline delete` when it is available
 	return []string{
-		fmt.Sprintf("Run %s to update the corresponding pipeline if exists.",
+		fmt.Sprintf("Run %s to update the corresponding pipeline if it exists.",
 			color.HighlightCode(fmt.Sprintf("ecs-preview pipeline update"))),
 	}
 }


### PR DESCRIPTION
Add recommended follow-up actions to app delete to prompt pipeline update. Fix #487 usability problem.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
