### PR TITLE
Remove unused validation and flags in pipeline init

### DIFF
--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -24,7 +24,6 @@ const (
 	githubRepoFlag        = "github-repo"
 	githubAccessTokenFlag = "github-access-token"
 	githubBranchFlag      = "github-branch"
-	enableCDFlag          = "enable-cd"
 	envsFlag              = "environments"
 	domainNameFlag        = "domain"
 	pipelineFileFlag      = "file"
@@ -67,10 +66,8 @@ const (
 	githubAccessTokenFlagDescription = "GitHub personal access token for your repository."
 	githubBranchFlagDescription      = "Branch name of your Github repository"
 	deployPipelineFlagDescription    = "Deploys the pipeline."
-	enableCDFlagDescription          = "Enables automatic deployment to production environment."
 	pipelineEnvsFlagDescription      = "Environments to add to the pipeline."
 	domainNameFlagDescription        = "Optional. Your existing custom domain name."
 	pipelineFileFlagDescription      = "Name of YAML file used to update the pipeline."
-	deployFlagDescription            = "Trigger a deployment of your application(s) to any new stage in your pipeline."
 	appLocalFlagDescription          = "Only show applications in the current directory."
 )

--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -48,10 +48,7 @@ type InitPipelineOpts struct {
 	GitHubRepo        string
 	GitHubAccessToken string
 	GitHubBranch      string
-	EnableCD          bool
-	Deploy            bool
 	PipelineFilename  string
-	// TODO add git branch
 	// TODO add pipeline file (to write to different file than pipeline.yml?)
 
 	// Interfaces to interact with dependencies.
@@ -475,9 +472,6 @@ func BuildPipelineInitCmd() *cobra.Command {
 			if err := opts.Ask(); err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil { // validate flags
-				return err
-			}
 			return opts.Execute()
 		}),
 		PostRunE: func(cmd *cobra.Command, args []string) error {
@@ -492,8 +486,6 @@ func BuildPipelineInitCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.GitHubRepo, githubRepoFlag, githubRepoFlagShort, "", githubRepoFlagDescription)
 	cmd.Flags().StringVarP(&opts.GitHubAccessToken, githubAccessTokenFlag, githubAccessTokenFlagShort, "", githubAccessTokenFlagDescription)
 	cmd.Flags().StringVarP(&opts.GitHubBranch, githubBranchFlag, githubBranchFlagShort, "", githubBranchFlagDescription)
-	cmd.Flags().BoolVar(&opts.Deploy, deployFlag, false, deployPipelineFlagDescription)
-	cmd.Flags().BoolVar(&opts.EnableCD, enableCDFlag, false, enableCDFlagDescription)
 	cmd.Flags().StringSliceVarP(&opts.Environments, envsFlag, envsFlagShort, []string{}, pipelineEnvsFlagDescription)
 
 	return cmd


### PR DESCRIPTION
<!-- Provide summary of changes -->
Remove unused validation and flags (enablecd and deploy) in pipeline init.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
