### PR TITLE
Change -d validation to check Dockerfile for "app init"

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -83,11 +83,11 @@ func (opts *InitAppOpts) Validate() error {
 		}
 	}
 	if opts.DockerfilePath != "" {
-		if _, err := opts.fs.Stat(opts.DockerfilePath); err != nil {
-			return err
-		}
 		if !strings.HasSuffix(opts.DockerfilePath, "/Dockerfile") {
 			return fmt.Errorf("a valid Dockerfile path is required")
+		}
+		if _, err := opts.fs.Stat(opts.DockerfilePath); err != nil {
+			return err
 		}
 	}
 	if opts.ProjectName() == "" {

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -83,8 +83,11 @@ func (opts *InitAppOpts) Validate() error {
 		}
 	}
 	if opts.DockerfilePath != "" {
-		if _, err := listDockerfiles(opts.fs, opts.DockerfilePath); err != nil {
+		if _, err := opts.fs.Stat(opts.DockerfilePath); err != nil {
 			return err
+		}
+		if !strings.HasSuffix(opts.DockerfilePath, "/Dockerfile") {
+			return fmt.Errorf("a valid Dockerfile path is required")
 		}
 	}
 	if opts.ProjectName() == "" {

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -88,7 +88,7 @@ func (opts *InitAppOpts) Validate() error {
 			return err
 		}
 		if isDir {
-			return fmt.Errorf("dockerfile path expected, got %s", opts.DockerfilePath)
+			return fmt.Errorf("dockerfile path is a directory %s, please provide a path to file", opts.DockerfilePath)
 		}
 	}
 	if opts.ProjectName() == "" {

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -83,11 +83,12 @@ func (opts *InitAppOpts) Validate() error {
 		}
 	}
 	if opts.DockerfilePath != "" {
-		if !strings.HasSuffix(opts.DockerfilePath, "/Dockerfile") {
-			return fmt.Errorf("a valid Dockerfile path is required")
-		}
-		if _, err := opts.fs.Stat(opts.DockerfilePath); err != nil {
+		isDir, err := afero.IsDir(opts.fs, opts.DockerfilePath)
+		if err != nil {
 			return err
+		}
+		if isDir {
+			return fmt.Errorf("dockerfile path expected, got %s", opts.DockerfilePath)
 		}
 	}
 	if opts.ProjectName() == "" {

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -214,7 +214,7 @@ func TestAppInitOpts_Validate(t *testing.T) {
 			mockFileSystem: func(mockFS afero.Fs) {
 				mockFS.MkdirAll("hello", 0755)
 			},
-			wantedErr: errors.New("dockerfile path expected, got ./hello"),
+			wantedErr: errors.New("dockerfile path is a directory ./hello, please provide a path to file"),
 		},
 		"valid flags": {
 			inAppName:        "frontend",

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -206,7 +206,7 @@ func TestAppInitOpts_Validate(t *testing.T) {
 			inProjectName: "",
 			wantedErr:     errNoProjectInWorkspace,
 		},
-		"valid dockerfile path but not Dockerfile": {
+		"invalid dockerfile path with a directory path": {
 			inAppName:        "frontend",
 			inAppType:        "Load Balanced Web App",
 			inDockerfilePath: "./hello",
@@ -214,7 +214,7 @@ func TestAppInitOpts_Validate(t *testing.T) {
 			mockFileSystem: func(mockFS afero.Fs) {
 				mockFS.MkdirAll("hello", 0755)
 			},
-			wantedErr: errors.New("a valid Dockerfile path is required"),
+			wantedErr: errors.New("dockerfile path expected, got ./hello"),
 		},
 		"valid flags": {
 			inAppName:        "frontend",

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -199,14 +199,14 @@ func TestAppInitOpts_Validate(t *testing.T) {
 			wantedErr: fmt.Errorf("application name 1234 is invalid: %s", errValueBadFormat),
 		},
 		"invalid dockerfile directory path": {
-			inDockerfilePath: "./hello",
-			wantedErr:        errors.New("read directory: open hello: file does not exist"),
+			inDockerfilePath: "./hello/Dockerfile",
+			wantedErr:        errors.New("open hello/Dockerfile: file does not exist"),
 		},
 		"invalid project name": {
 			inProjectName: "",
 			wantedErr:     errNoProjectInWorkspace,
 		},
-		"valid dockerfile directory with no dockerfile": {
+		"valid dockerfile path but not Dockerfile": {
 			inAppName:        "frontend",
 			inAppType:        "Load Balanced Web App",
 			inDockerfilePath: "./hello",
@@ -214,12 +214,12 @@ func TestAppInitOpts_Validate(t *testing.T) {
 			mockFileSystem: func(mockFS afero.Fs) {
 				mockFS.MkdirAll("hello", 0755)
 			},
-			wantedErr: errors.New("no Dockerfiles found within ./hello or a sub-directory level below"),
+			wantedErr: errors.New("a valid Dockerfile path is required"),
 		},
 		"valid flags": {
 			inAppName:        "frontend",
 			inAppType:        "Load Balanced Web App",
-			inDockerfilePath: "./hello",
+			inDockerfilePath: "./hello/Dockerfile",
 			inProjectName:    "phonetool",
 
 			mockFileSystem: func(mockFS afero.Fs) {

--- a/internal/pkg/cli/flag.go
+++ b/internal/pkg/cli/flag.go
@@ -57,7 +57,7 @@ const (
 	yesFlagDescription     = "Skips confirmation prompt."
 	jsonFlagDescription    = "Output in JSON format."
 
-	dockerFileFlagDescription        = "Path to the directory with Dockerfile."
+	dockerFileFlagDescription        = "Path to the Dockerfile."
 	imageTagFlagDescription          = `Optional. The application's image tag.`
 	stackOutputDirFlagDescription    = "Optional. Writes the stack template and template configuration to a directory."
 	prodEnvFlagDescription           = "If the environment contains production services."


### PR DESCRIPTION
<!-- Provide summary of changes -->
Fix #533. I think it would be confusing if we allow "-d" flag to accept either "path to the directory that containers Dockerfile" or "path to Dockerfile". Make more sense to allow only "path to Dockerfile" using "-d" flag.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
