### PR TITLE
Quick fix to app init

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
@@ -83,12 +82,8 @@ func (opts *InitAppOpts) Validate() error {
 		}
 	}
 	if opts.DockerfilePath != "" {
-		isDir, err := afero.IsDir(opts.fs, opts.DockerfilePath)
-		if err != nil {
+		if _, err := opts.fs.Stat(opts.DockerfilePath); err != nil {
 			return err
-		}
-		if isDir {
-			return fmt.Errorf("dockerfile path is a directory %s, please provide a path to file", opts.DockerfilePath)
 		}
 	}
 	if opts.ProjectName() == "" {
@@ -209,8 +204,7 @@ func (opts *InitAppOpts) askDockerfile() error {
 		return fmt.Errorf("failed to select Dockerfile: %w", err)
 	}
 
-	// NOTE: Trim "/Dockerfile" from the selected option for storing in the app manifest.
-	opts.DockerfilePath = strings.TrimSuffix(sel, "/Dockerfile")
+	opts.DockerfilePath = sel
 
 	return nil
 }

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -23,7 +23,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 	const (
 		wantedAppType        = manifest.LoadBalancedWebApplication
 		wantedAppName        = "frontend"
-		wantedDockerfilePath = "frontend"
+		wantedDockerfilePath = "frontend/Dockerfile"
 	)
 	testCases := map[string]struct {
 		inAppType        string
@@ -205,16 +205,6 @@ func TestAppInitOpts_Validate(t *testing.T) {
 		"invalid project name": {
 			inProjectName: "",
 			wantedErr:     errNoProjectInWorkspace,
-		},
-		"invalid dockerfile path with a directory path": {
-			inAppName:        "frontend",
-			inAppType:        "Load Balanced Web App",
-			inDockerfilePath: "./hello",
-			inProjectName:    "phonetool",
-			mockFileSystem: func(mockFS afero.Fs) {
-				mockFS.MkdirAll("hello", 0755)
-			},
-			wantedErr: errors.New("dockerfile path is a directory ./hello, please provide a path to file"),
 		},
 		"valid flags": {
 			inAppName:        "frontend",


### PR DESCRIPTION
<!-- Provide summary of changes -->
Currently `app init` will fail because it validates if the dockerfile path is a directory (need to be a file path) and the dockerfile path gets trimmed "/Dockerfile". Now remove the trim and also remove the validation for if dockerfile path is a dir or not. Just validate if the file/dir exists.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
