### PR TITLE
style: update prompt templates and resource colors

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -107,7 +107,7 @@ Common categorical data are debug, info, warning, success, failure messages.
 We respectively use _white_, default, _yellow_, _bright green_ and _bright red_ for these messages.  
 For highlighting user input, use _cyan_.  
 For highlighting created resources, use _bring cyan_.  
-For highlighting follow-up commands, use _bring cyan_ and wrap the text with the back quote character (`).  
+For highlighting follow-up commands, use _bring cyan_ and wrap the text with the back quote character (\`).  
 
 ### Data
 Commands that perform “read” operations should write their results to `stdout`. 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -66,8 +66,9 @@ but by providing sane defaults we reduce the cognitive load to accomplish a task
 Prompt the user for any required flag that the user did not provide a value for. Prompting is a human-friendly way of showing options:
 ![prompt](https://user-images.githubusercontent.com/879348/65549185-e4394380-ded1-11e9-9fce-f1b19cd4f27f.png)
 
-Don’t prompt the user if a flag value was provided to enable scripting.
-Prompts should be written to `stderr`.
+Don’t prompt the user if a flag value was provided to enable scripting.  
+Prompts should be written to `stderr`.  
+Highlight the important words in a prompt by bolding and italicizing the words. 
 
 ### Deleting and modifying production resources
 Any command that deletes or acts on a production resource should prompt the user to make sure they want to proceed with the action. 
@@ -100,17 +101,13 @@ won't be able to move above 24 lines and you'll have truncated progress events.
 ### Colors
 We use [colors](https://en.wikipedia.org/wiki/ANSI_escape_code#Colors) to set highlights — catching the user’s eye with important information. 
 We do not use color as the primary means of communication. Running without color support should not meaningfully degrade the UX. 
-For continuous data, we use gradients, and for categorical data we use distinctive colors.
-
-The gradients in order of lowest to highest emphasis are: _plain_, _bright_, _bold bright_, _bold underlined bright_. An example of continuous data can be found in the help menu of the CLI while listing which sub-category a command belongs to.  
-![gradient](https://user-images.githubusercontent.com/879348/65549210-ef8c6f00-ded1-11e9-865d-b30ef7b94223.png) 
+For categorical data we use distinctive colors.
 
 Common categorical data are debug, info, warning, success, failure messages. 
 We respectively use _white_, default, _yellow_, _bright green_ and _bright red_ for these messages.  
 For highlighting user input, use _cyan_.  
-For highlighting created resources, use _bold underlined_.  
-For highlighting follow-up commands, use _magenta_.  
-![colors](https://user-images.githubusercontent.com/879348/68536239-80919b00-0304-11ea-9393-d6f0ff1f6d68.png)
+For highlighting created resources, use _bring cyan_.  
+For highlighting follow-up commands, use _bring cyan_ and wrap the text with the back quote character (`).  
 
 ### Data
 Commands that perform “read” operations should write their results to `stdout`. 

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -22,12 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	fmtAppInitAppTypePrompt  = "Which type of %s best represents your application?"
+var (
+	appInitAppTypePrompt     = "Which type of " + color.Emphasize("infrastructure pattern") + " best represents your application?"
 	appInitAppTypeHelpPrompt = `Your application's architecture. Most applications need additional AWS resources to run.
 To help setup the infrastructure resources, select what "kind" or "type" of application you want to build.`
 
-	fmtAppInitAppNamePrompt     = "What do you want to %s this %s?"
+	fmtAppInitAppNamePrompt     = "What do you want to " + color.Emphasize("name") + " this %s?"
 	fmtAppInitAppNameHelpPrompt = `The name will uniquely identify this application within your %s project.
 Deployed resources (such as your service, logs) will contain this app's name and be tagged with it.`
 
@@ -173,11 +173,7 @@ func (opts *InitAppOpts) createAppInProject(projectName string) error {
 }
 
 func (opts *InitAppOpts) askAppType() error {
-	t, err := opts.prompt.SelectOne(
-		fmt.Sprintf(fmtAppInitAppTypePrompt, color.Emphasize("infrastructure pattern")),
-		appInitAppTypeHelpPrompt,
-		manifest.AppTypes)
-
+	t, err := opts.prompt.SelectOne(appInitAppTypePrompt, appInitAppTypeHelpPrompt, manifest.AppTypes)
 	if err != nil {
 		return fmt.Errorf("failed to get type selection: %w", err)
 	}
@@ -187,7 +183,7 @@ func (opts *InitAppOpts) askAppType() error {
 
 func (opts *InitAppOpts) askAppName() error {
 	name, err := opts.prompt.Get(
-		fmt.Sprintf(fmtAppInitAppNamePrompt, color.Emphasize("name"), color.HighlightUserInput(opts.AppType)),
+		fmt.Sprintf(fmtAppInitAppNamePrompt, color.HighlightUserInput(opts.AppType)),
 		fmt.Sprintf(fmtAppInitAppNameHelpPrompt, opts.ProjectName()),
 		validateApplicationName)
 	if err != nil {

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -23,6 +23,19 @@ import (
 )
 
 const (
+	fmtAppInitAppTypePrompt  = "Which type of %s best represents your application?"
+	appInitAppTypeHelpPrompt = `Your application's architecture. Most applications need additional AWS resources to run.
+To help setup the infrastructure resources, select what "kind" or "type" of application you want to build.`
+
+	fmtAppInitAppNamePrompt     = "What do you want to %s this %s?"
+	fmtAppInitAppNameHelpPrompt = `The name will uniquely identify this application within your %s project.
+Deployed resources (such as your service, logs) will contain this app's name and be tagged with it.`
+
+	fmtAppInitDockerfilePrompt  = "Which Dockerfile would you like to use for %s app?"
+	appInitDockerfileHelpPrompt = "Dockerfile to use for building your application's container image."
+)
+
+const (
 	fmtAddAppToProjectStart    = "Creating ECR repositories for application %s."
 	fmtAddAppToProjectFailed   = "Failed to create ECR repositories for application %s."
 	fmtAddAppToProjectComplete = "Created ECR repositories for application %s."
@@ -161,9 +174,8 @@ func (opts *InitAppOpts) createAppInProject(projectName string) error {
 
 func (opts *InitAppOpts) askAppType() error {
 	t, err := opts.prompt.SelectOne(
-		"Which type of infrastructure pattern best represents your application?",
-		`Your application's architecture. Most applications need additional AWS resources to run.
-To help setup the infrastructure resources, select what "kind" or "type" of application you want to build.`,
+		fmt.Sprintf(fmtAppInitAppTypePrompt, color.Emphasize("infrastructure pattern")),
+		appInitAppTypeHelpPrompt,
 		manifest.AppTypes)
 
 	if err != nil {
@@ -175,9 +187,8 @@ To help setup the infrastructure resources, select what "kind" or "type" of appl
 
 func (opts *InitAppOpts) askAppName() error {
 	name, err := opts.prompt.Get(
-		fmt.Sprintf("What do you want to call this %s?", opts.AppType),
-		fmt.Sprintf(`The name will uniquely identify this application within your %s project.
-Deployed resources (such as your service, logs) will contain this app's name and be tagged with it.`, opts.ProjectName()),
+		fmt.Sprintf(fmtAppInitAppNamePrompt, color.Emphasize("name"), color.HighlightUserInput(opts.AppType)),
+		fmt.Sprintf(fmtAppInitAppNameHelpPrompt, opts.ProjectName()),
 		validateApplicationName)
 	if err != nil {
 		return fmt.Errorf("failed to get application name: %w", err)
@@ -196,8 +207,8 @@ func (opts *InitAppOpts) askDockerfile() error {
 	}
 
 	sel, err := opts.prompt.SelectOne(
-		fmt.Sprintf("Which Dockerfile would you like to use for %s app?", opts.AppName),
-		"Dockerfile to use for building your application's container image.",
+		fmt.Sprintf(fmtAppInitDockerfilePrompt, color.HighlightUserInput(opts.AppName)),
+		appInitDockerfileHelpPrompt,
 		dockerfiles,
 	)
 	if err != nil {

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -31,7 +31,7 @@ To help setup the infrastructure resources, select what "kind" or "type" of appl
 	fmtAppInitAppNameHelpPrompt = `The name will uniquely identify this application within your %s project.
 Deployed resources (such as your service, logs) will contain this app's name and be tagged with it.`
 
-	fmtAppInitDockerfilePrompt  = "Which Dockerfile would you like to use for %s app?"
+	fmtAppInitDockerfilePrompt  = "Which Dockerfile would you like to use for %s?"
 	appInitDockerfileHelpPrompt = "Dockerfile to use for building your application's container image."
 )
 

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -118,7 +118,7 @@ func (opts *InitAppOpts) Execute() error {
 	opts.manifestPath = manifestPath
 
 	log.Infoln()
-	log.Successf("Wrote the manifest for %s app at '%s'\n", color.HighlightUserInput(opts.AppName), color.HighlightResource(opts.manifestPath))
+	log.Successf("Wrote the manifest for %s app at %s\n", color.HighlightUserInput(opts.AppName), color.HighlightResource(opts.manifestPath))
 	log.Infoln("Your manifest contains configurations like your container size and ports.")
 	log.Infoln()
 

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -12,7 +12,6 @@ import (
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/manifest"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
 	"github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
@@ -43,7 +42,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitAppTypePrompt, color.Emphasize("infrastructure pattern"))), appInitAppTypeHelpPrompt, gomock.Eq(manifest.AppTypes)).
+				m.EXPECT().SelectOne(gomock.Eq("Which type of infrastructure pattern best represents your application?"), appInitAppTypeHelpPrompt, gomock.Eq(manifest.AppTypes)).
 					Return(wantedAppType, nil)
 			},
 			wantedErr: nil,
@@ -67,7 +66,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(fmtAppInitAppNamePrompt, color.Emphasize("name"), wantedAppType)), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf("What do you want to name this %s?", wantedAppType)), gomock.Any(), gomock.Any()).
 					Return(wantedAppName, nil)
 			},
 			wantedErr: nil,
@@ -98,7 +97,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, color.HighlightUserInput(wantedAppName))), appInitDockerfileHelpPrompt, gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, wantedAppName)), appInitDockerfileHelpPrompt, gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",
@@ -133,7 +132,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, color.HighlightUserInput(wantedAppName))), gomock.Any(), gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, wantedAppName)), gomock.Any(), gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -12,6 +12,7 @@ import (
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/manifest"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
 	"github.com/aws/amazon-ecs-cli-v2/mocks"
 	"github.com/golang/mock/gomock"
@@ -42,7 +43,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq("Which type of infrastructure pattern best represents your application?"), gomock.Any(), gomock.Eq(manifest.AppTypes)).
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitAppTypePrompt, color.Emphasize("infrastructure pattern"))), appInitAppTypeHelpPrompt, gomock.Eq(manifest.AppTypes)).
 					Return(wantedAppType, nil)
 			},
 			wantedErr: nil,
@@ -54,7 +55,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq("Which type of infrastructure pattern best represents your application?"), gomock.Any(), gomock.Eq(manifest.AppTypes)).
+				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Eq(manifest.AppTypes)).
 					Return("", errors.New("some error"))
 			},
 			wantedErr: fmt.Errorf("failed to get type selection: some error"),
@@ -66,7 +67,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq("What do you want to call this Load Balanced Web App?"), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(fmtAppInitAppNamePrompt, color.Emphasize("name"), wantedAppType)), gomock.Any(), gomock.Any()).
 					Return(wantedAppName, nil)
 			},
 			wantedErr: nil,
@@ -78,7 +79,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq("What do you want to call this Load Balanced Web App?"), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			wantedErr: fmt.Errorf("failed to get application name: some error"),
@@ -97,7 +98,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq("Which Dockerfile would you like to use for frontend app?"), gomock.Any(), gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, color.HighlightUserInput(wantedAppName))), appInitDockerfileHelpPrompt, gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",
@@ -132,7 +133,7 @@ func TestAppInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq("Which Dockerfile would you like to use for frontend app?"), gomock.Any(), gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtAppInitDockerfilePrompt, color.HighlightUserInput(wantedAppName))), gomock.Any(), gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -72,12 +72,12 @@ func (opts *InitProjectOpts) Ask() error {
 	summary, err := opts.ws.Summary()
 	if err == nil {
 		msg := fmt.Sprintf(
-			"Looks like you are using a workspace that's registered to project %s. We'll use that as your project.",
-			color.HighlightUserInput(summary.ProjectName))
+			"Looks like you are using a workspace that's registered to project %s.\nWe'll use that as your project.",
+			color.HighlightResource(summary.ProjectName))
 		if opts.ProjectName != "" && opts.ProjectName != summary.ProjectName {
 			msg = fmt.Sprintf(
-				"Looks like you are using a workspace that's registered to project %s. We'll use that as your project instead of %s.",
-				color.HighlightUserInput(summary.ProjectName),
+				"Looks like you are using a workspace that's registered to project %s.\nWe'll use that as your project instead of %s.",
+				color.HighlightResource(summary.ProjectName),
 				color.HighlightUserInput(opts.ProjectName))
 		}
 		log.Infoln(msg)
@@ -97,7 +97,8 @@ func (opts *InitProjectOpts) Ask() error {
 	}
 
 	log.Infoln("Looks like you have some projects already.")
-	useExistingProject, err := opts.prompt.Confirm("Would you like to use one of your existing projects?", "", prompt.WithTrueDefault())
+	useExistingProject, err := opts.prompt.Confirm(
+		"Would you like to use one of your existing projects?", "", prompt.WithTrueDefault())
 	if err != nil {
 		return fmt.Errorf("prompt to confirm using existing project: %w", err)
 	}
@@ -160,7 +161,7 @@ func (opts *InitProjectOpts) RecommendedActions() []string {
 
 func (opts *InitProjectOpts) askNewProjectName() error {
 	projectName, err := opts.prompt.Get(
-		"What would you like to call your project?",
+		fmt.Sprintf("What would you like to %s your project?", color.Emphasize("name")),
 		"Applications under the same project share the same VPC and ECS Cluster and are discoverable via service discovery.",
 		validateProjectName)
 	if err != nil {
@@ -176,7 +177,7 @@ func (opts *InitProjectOpts) askSelectExistingProjectName(existingProjects []*ar
 		projectNames = append(projectNames, p.Name)
 	}
 	projectName, err := opts.prompt.SelectOne(
-		"Which one do you want to add a new application to?",
+		fmt.Sprintf("Which %s do you want to add a new application to?", color.Emphasize("existing project")),
 		"Applications in the same project share the same VPC, ECS Cluster and are discoverable via service discovery.",
 		projectNames)
 	if err != nil {

--- a/internal/pkg/term/color/color.go
+++ b/internal/pkg/term/color/color.go
@@ -16,12 +16,11 @@ import (
 // Refer to https://en.wikipedia.org/wiki/ANSI_escape_code to validate if colors would
 // be visible on white or black screen backgrounds.
 var (
-	Grey          = color.New(color.FgWhite)
-	Red           = color.New(color.FgHiRed)
-	Cyan          = color.New(color.FgCyan)
-	BoldUnderline = color.New(color.Bold, color.Underline)
-	Magenta       = color.New(color.FgMagenta)
-	Blue          = color.New(color.FgBlue)
+	Grey       = color.New(color.FgWhite)
+	Red        = color.New(color.FgHiRed)
+	Cyan       = color.New(color.FgCyan)
+	HiCyan     = color.New(color.FgHiCyan)
+	BoldItalic = color.New(color.Bold).Add(color.Italic)
 )
 
 const colorEnvVar = "COLOR"
@@ -50,6 +49,11 @@ func DisableColorBasedOnEnvVar() {
 	}
 }
 
+// Emphasize colors the string to denote that it as important, and returns it.
+func Emphasize(s string) string {
+	return BoldItalic.Sprint(s)
+}
+
 // HighlightUserInput colors the string to denote it as an input from standard input, and returns it.
 func HighlightUserInput(s string) string {
 	return Cyan.Sprint(s)
@@ -57,10 +61,10 @@ func HighlightUserInput(s string) string {
 
 // HighlightResource colors the string to denote it as a resource created by the CLI, and returns it.
 func HighlightResource(s string) string {
-	return BoldUnderline.Sprint(s)
+	return HiCyan.Sprint(s)
 }
 
 // HighlightCode wraps the string with the ` character, colors it to denote it's a code block, and returns it.
 func HighlightCode(s string) string {
-	return Magenta.Sprintf("`%s`", s)
+	return HiCyan.Sprintf("`%s`", s)
 }

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -12,6 +12,51 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
+func init() {
+	survey.ConfirmQuestionTemplate = `
+{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default"}}{{ .Message }} {{color "reset"}}
+{{- if .Answer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
+  {{- color "cyan"}}{{if .Default}}(Y/n) {{else}}(y/N) {{end}}{{color "reset"}}
+{{- end}}`
+
+	survey.SelectQuestionTemplate = `
+{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else}}
+  {{- "  "}}{{- color "white"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+  {{- "\n"}}
+  {{- range $ix, $choice := .PageEntries}}
+    {{- if eq $ix $.SelectedIndex }}{{color "cyan+b" }}{{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
+    {{- $choice.Value}}
+    {{- color "reset"}}{{"\n"}}
+  {{- end}}
+{{- end}}`
+
+	survey.InputQuestionTemplate = `
+{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ print .Config.HelpInput }} for help]{{color "reset"}} {{end}}
+  {{- if .Default}}{{color "cyan"}}({{.Default}}) {{color "reset"}}{{end}}
+{{- end}}`
+
+	survey.PasswordQuestionTemplate = `
+{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+{{- color "default"}}{{ .Message }} {{color "reset"}}
+{{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}`
+}
+
 // ErrEmptyOptions indicates the input options list was empty.
 var ErrEmptyOptions = errors.New("list of provided options is empty")
 
@@ -117,8 +162,8 @@ func stdio() survey.AskOpt {
 
 func icons() survey.AskOpt {
 	return survey.WithIcons(func(icons *survey.IconSet) {
-		icons.Question.Format = "cyan"
-		icons.Help.Format = "white"
+		icons.Question.Format = "cyan+b"
+		icons.Help.Format = "default+ih:default"
 	})
 }
 

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -162,8 +162,11 @@ func stdio() survey.AskOpt {
 
 func icons() survey.AskOpt {
 	return survey.WithIcons(func(icons *survey.IconSet) {
+		// The question mark "?" icon to denote a prompt will be colored in bold cyan.
 		icons.Question.Format = "cyan+b"
-		icons.Help.Format = "default+ih:default"
+		// Help text shown when user presses "?" will have the inverse color "i" and be surrounded by a background box ":default" of default text color.
+		// For example, if your terminal background is white with black text, the help text will have a black background with white text.
+		icons.Help.Format = "default+i:default"
 	})
 }
 


### PR DESCRIPTION
1. The prompt now starts with a new line character.
The use of extra space makes the CLI feels less cluttered.

2. Added color.Emphasize() as a way for us to highlight
the important words in a prompt.

3. Reduced the number of colors used to only Cyan and HiCyan.
Cyan is used for user inputs, and HiCyan for outputs generated by us.
Just like spacing, this makes the CLI feel less jarring.

4. The help text is now inverted and catches the eye of the user
immediately.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
