### PR TITLE
Move to text/template instead of html/template

### DIFF
--- a/internal/pkg/cli/pipeline_init.go
+++ b/internal/pkg/cli/pipeline_init.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html/template"
+	"text/template"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/internal/pkg/deploy/cloudformation/stack/project.go
+++ b/internal/pkg/deploy/cloudformation/stack/project.go
@@ -6,7 +6,7 @@ package stack
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"text/template"
 	"sort"
 	"strings"
 


### PR DESCRIPTION
html/template escapes content - which is generally not what
we want.

This was generating invalid buildspecs. 