### PR TITLE
refactor: split initAppOpts into cmd and opts structs

### DIFF
--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -151,30 +151,30 @@ func TestAppInitOpts_Ask(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPrompt := climocks.NewMockprompter(ctrl)
-			opts := &InitAppOpts{
+			cmd := &initAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
 
-				fs: &afero.Afero{Fs: afero.NewMemMapFs()},
 				GlobalOpts: &GlobalOpts{
 					prompt: mockPrompt,
 				},
+				fs: &afero.Afero{Fs: afero.NewMemMapFs()},
 			}
-			tc.mockFileSystem(opts.fs)
+			tc.mockFileSystem(cmd.fs)
 			tc.mockPrompt(mockPrompt)
 
 			// WHEN
-			err := opts.Ask()
+			err := cmd.Ask()
 
 			// THEN
 			if tc.wantedErr != nil {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			} else {
 				require.Nil(t, err)
-				require.Equal(t, wantedAppType, opts.AppType)
-				require.Equal(t, wantedAppName, opts.AppName)
-				require.Equal(t, wantedDockerfilePath, opts.DockerfilePath)
+				require.Equal(t, wantedAppType, cmd.AppType)
+				require.Equal(t, wantedAppName, cmd.AppName)
+				require.Equal(t, wantedDockerfilePath, cmd.DockerfilePath)
 			}
 		})
 	}
@@ -223,12 +223,12 @@ func TestAppInitOpts_Validate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
-			opts := InitAppOpts{
+			opts := initAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
-				fs:             &afero.Afero{Fs: afero.NewMemMapFs()},
 				GlobalOpts:     &GlobalOpts{projectName: tc.inProjectName},
+				fs:             &afero.Afero{Fs: afero.NewMemMapFs()},
 			}
 			if tc.mockFileSystem != nil {
 				tc.mockFileSystem(opts.fs)
@@ -435,17 +435,16 @@ func TestAppInitOpts_Execute(t *testing.T) {
 			mockProjGetter := mocks.NewMockProjectGetter(ctrl)
 			mockProjDeployer := climocks.NewMockprojectDeployer(ctrl)
 			mockProg := climocks.NewMockprogress(ctrl)
-			opts := InitAppOpts{
+			opts := initAppOpts{
 				AppType:        tc.inAppType,
 				AppName:        tc.inAppName,
 				DockerfilePath: tc.inDockerfilePath,
+				GlobalOpts:     &GlobalOpts{projectName: tc.inProjectName},
 				manifestWriter: mockWriter,
 				appStore:       mockAppStore,
 				projGetter:     mockProjGetter,
 				projDeployer:   mockProjDeployer,
 				prog:           mockProg,
-
-				GlobalOpts: &GlobalOpts{projectName: tc.inProjectName},
 			}
 			tc.mockManifestWriter(mockWriter)
 			tc.mockAppStore(mockAppStore)

--- a/internal/pkg/cli/factory.go
+++ b/internal/pkg/cli/factory.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+	termprogress "github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/progress"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
+	"github.com/spf13/afero"
+	"github.com/spf13/viper"
+)
+
+type optsFactory struct{}
+
+func (f *optsFactory) CreateInitAppOpts() (*initAppOpts, error) {
+	store, err := store.New()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't connect to metadata datastore: %w", err)
+	}
+
+	ws, err := workspace.New()
+	if err != nil {
+		return nil, fmt.Errorf("workspace cannot be created: %w", err)
+	}
+
+	sess, err := session.Default()
+	if err != nil {
+		return nil, err
+	}
+	return &initAppOpts{
+		AppType:        viper.GetString(appTypeFlag),
+		AppName:        viper.GetString(nameFlag),
+		DockerfilePath: viper.GetString(dockerFileFlag),
+		GlobalOpts:     NewGlobalOpts(),
+
+		fs:             &afero.Afero{Fs: afero.NewOsFs()},
+		appStore:       store,
+		projGetter:     store,
+		manifestWriter: ws,
+		projDeployer:   cloudformation.New(sess),
+		prog:           termprogress.NewSpinner(),
+	}, nil
+}

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -82,14 +82,14 @@ func NewInitOpts() (*InitOpts, error) {
 		deployer:     deployer,
 		prog:         spin,
 	}
-	initApp := &InitAppOpts{
+	initApp := &initAppOpts{
+		GlobalOpts:     NewGlobalOpts(),
 		fs:             &afero.Afero{Fs: afero.NewOsFs()},
 		manifestWriter: ws,
 		appStore:       ssm,
 		projGetter:     ssm,
 		projDeployer:   deployer,
 		prog:           spin,
-		GlobalOpts:     NewGlobalOpts(),
 	}
 	initEnv := &InitEnvOpts{
 		EnvName:       defaultEnvironmentName,


### PR DESCRIPTION
**I'm looking for feedback on this refactor as a way for us to write new/update our commands.**

1. Made `initAppOpts` a private struct as it's not used outside of the cli
package.

2. Split `initAppOpts` into an `Opts` and `Cmd` struct. Previously, we
couldn't have a constructor for `initAppOpts` inside the
`BuildAppInitCmd` function as the initialization can fail. By decoupling
flags from the actual command, we can have the command creation happen
inside the `RunE` function.

3. The constructor `newInitAppCmd` provides an entry point to take in a
struct to share dependencies in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
