### PR TITLE
refactor: replace session creation from functions to factory methods

### DIFF
--- a/internal/pkg/aws/session/session.go
+++ b/internal/pkg/aws/session/session.go
@@ -30,8 +30,11 @@ func userAgentHandler() request.NamedHandler {
 	}
 }
 
+// Factory holds methods to create sessions.
+type Factory struct{}
+
 // Default returns a session configured against the "default" AWS profile.
-func Default() (*session.Session, error) {
+func (f *Factory) Default() (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
@@ -46,7 +49,7 @@ func Default() (*session.Session, error) {
 }
 
 // DefaultWithRegion returns a session configured against the "default" AWS profile and the input region.
-func DefaultWithRegion(region string) (*session.Session, error) {
+func (f *Factory) DefaultWithRegion(region string) (*session.Session, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})
@@ -58,7 +61,7 @@ func DefaultWithRegion(region string) (*session.Session, error) {
 }
 
 // FromProfile returns a session configured against the input profile name.
-func FromProfile(name string) (*session.Session, error) {
+func (f *Factory) FromProfile(name string) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
@@ -74,8 +77,8 @@ func FromProfile(name string) (*session.Session, error) {
 }
 
 // FromRole returns a session configured against the input role and region.
-func FromRole(roleARN string, region string) (*session.Session, error) {
-	defaultSession, err := Default()
+func (f *Factory) FromRole(roleARN string, region string) (*session.Session, error) {
+	defaultSession, err := f.Default()
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating default session: %w", err)

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -270,7 +270,8 @@ This command is also run as part of "ecs-preview init".`,
 			}
 			opts.manifestWriter = ws
 
-			sess, err := session.Default()
+			f := &session.Factory{}
+			sess, err := f.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -326,7 +326,8 @@ func BuildAppPackageCmd() *cobra.Command {
 			}
 			opts.store = store
 
-			sess, err := session.Default()
+			f := &session.Factory{}
+			sess, err := f.Default()
 			if err != nil {
 				return fmt.Errorf("error retrieving default session: %w", err)
 			}

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/prompt"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -108,4 +109,22 @@ func runCmdE(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Co
 		}
 		return f(cmd, args)
 	}
+}
+
+type defaultSessionProvider interface {
+	Default() (*session.Session, error)
+}
+
+type regionalSessionProvider interface {
+	DefaultWithRegion(region string) (*session.Session, error)
+}
+
+type sessionFromRoleProvider interface {
+	FromRole(roleARN string, region string) (*session.Session, error)
+}
+
+type sessionProvider interface {
+	defaultSessionProvider
+	regionalSessionProvider
+	sessionFromRoleProvider
 }

--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -208,7 +208,8 @@ func BuildEnvDeleteCmd() *cobra.Command {
 				return fmt.Errorf("connect to ecs-cli metadata store: %w", err)
 			}
 			opts.storeClient = store
-			profileSess, err := session.FromProfile(opts.EnvProfile)
+			f := &session.Factory{}
+			profileSess, err := f.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return fmt.Errorf("cannot create session from profile %s: %w", opts.EnvProfile, err)
 			}

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -265,11 +265,12 @@ func BuildEnvInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			profileSess, err := session.FromProfile(opts.EnvProfile)
+			f := &session.Factory{}
+			profileSess, err := f.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return err
 			}
-			defaultSession, err := session.Default()
+			defaultSession, err := f.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -65,7 +65,8 @@ func NewInitOpts() (*InitOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	sess, err := session.Default()
+	f := &session.Factory{}
+	sess, err := f.Default()
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +111,7 @@ func NewInitOpts() (*InitOpts, error) {
 		spinner:       spin,
 		dockerService: docker.New(),
 		runner:        command.New(),
+		sessFactory:   f,
 
 		GlobalOpts: NewGlobalOpts(),
 	}

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -250,7 +250,8 @@ func BuildPipelineUpdateCmd() *cobra.Command {
 			}
 			opts.project = project
 
-			defaultSession, err := session.Default()
+			f := &session.Factory{}
+			defaultSession, err := f.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -42,7 +42,8 @@ type InitProjectOpts struct {
 
 // NewInitProjectOpts returns a new InitProjectOpts.
 func NewInitProjectOpts() (*InitProjectOpts, error) {
-	defaultSession, err := session.Default()
+	f := &session.Factory{}
+	defaultSession, err := f.Default()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/describe/describe.go
+++ b/internal/pkg/describe/describe.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/manifest"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 )
 
@@ -37,4 +38,8 @@ func NewAppIdentifier(project, app string) (ResourceIdentifier, error) {
 
 type stackDescriber interface {
 	DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+}
+
+type sessionFromRoleProvider interface {
+	FromRole(roleARN string, region string) (*session.Session, error)
 }

--- a/internal/pkg/describe/webapp.go
+++ b/internal/pkg/describe/webapp.go
@@ -33,6 +33,7 @@ type webAppDescriber struct {
 
 	store           archer.EnvironmentGetter
 	stackDescribers map[string]stackDescriber
+	sessFactory     sessionFromRoleProvider
 }
 
 func newWebAppDescriber(app *archer.Application, store archer.EnvironmentGetter) *webAppDescriber {
@@ -40,6 +41,7 @@ func newWebAppDescriber(app *archer.Application, store archer.EnvironmentGetter)
 		app:             app,
 		store:           store,
 		stackDescribers: make(map[string]stackDescriber),
+		sessFactory:     &session.Factory{},
 	}
 }
 
@@ -116,7 +118,7 @@ func (d *webAppDescriber) stack(roleARN, region, stackName string) (*cloudformat
 
 func (d *webAppDescriber) stackDescriber(roleARN, region string) (stackDescriber, error) {
 	if _, ok := d.stackDescribers[roleARN]; !ok {
-		sess, err := session.FromRole(roleARN, region)
+		sess, err := d.sessFactory.FromRole(roleARN, region)
 		if err != nil {
 			return nil, fmt.Errorf("session for role %s and region %s: %w", roleARN, region, err)
 		}

--- a/internal/pkg/store/secretsmanager/secretsmanager.go
+++ b/internal/pkg/store/secretsmanager/secretsmanager.go
@@ -23,7 +23,8 @@ type SecretsManager struct {
 
 // NewSecretsManager returns a SecretsManager configured with the input session.
 func NewStore() (*SecretsManager, error) {
-	sess, err := session.Default()
+	f := &session.Factory{}
+	sess, err := f.Default()
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/store/store.go
+++ b/internal/pkg/store/store.go
@@ -55,7 +55,8 @@ type Store struct {
 
 // New returns a Store allowing you to query or create Projects or Environments.
 func New() (*Store, error) {
-	sess, err := session.Default()
+	f := &session.Factory{}
+	sess, err := f.Default()
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using [factory methods](https://refactoring.com/catalog/replaceConstructorWithFactoryFunction.html) over functions for initializing sessions allows us to mock session creation!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
