### PR TITLE
refactor: use sessions as singletons

### DIFF
--- a/internal/pkg/aws/session/session.go
+++ b/internal/pkg/aws/session/session.go
@@ -30,11 +30,11 @@ func userAgentHandler() request.NamedHandler {
 	}
 }
 
-// Factory holds methods to create sessions.
-type Factory struct{}
+// Provider holds methods to create sessions.
+type Provider struct{}
 
 // Default returns a session configured against the "default" AWS profile.
-func (f *Factory) Default() (*session.Session, error) {
+func (p *Provider) Default() (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
@@ -49,7 +49,7 @@ func (f *Factory) Default() (*session.Session, error) {
 }
 
 // DefaultWithRegion returns a session configured against the "default" AWS profile and the input region.
-func (f *Factory) DefaultWithRegion(region string) (*session.Session, error) {
+func (p *Provider) DefaultWithRegion(region string) (*session.Session, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})
@@ -61,7 +61,7 @@ func (f *Factory) DefaultWithRegion(region string) (*session.Session, error) {
 }
 
 // FromProfile returns a session configured against the input profile name.
-func (f *Factory) FromProfile(name string) (*session.Session, error) {
+func (p *Provider) FromProfile(name string) (*session.Session, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
 			CredentialsChainVerboseErrors: aws.Bool(true),
@@ -77,8 +77,8 @@ func (f *Factory) FromProfile(name string) (*session.Session, error) {
 }
 
 // FromRole returns a session configured against the input role and region.
-func (f *Factory) FromRole(roleARN string, region string) (*session.Session, error) {
-	defaultSession, err := f.Default()
+func (p *Provider) FromRole(roleARN string, region string) (*session.Session, error) {
+	defaultSession, err := p.Default()
 
 	if err != nil {
 		return nil, fmt.Errorf("error creating default session: %w", err)

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -272,7 +272,7 @@ func BuildAppDeleteCmd() *cobra.Command {
 		GlobalOpts:  NewGlobalOpts(),
 		spinner:     termprogress.NewSpinner(),
 		prompter:    prompt.New(),
-		sessFactory: &session.Factory{},
+		sessFactory: &session.Provider{},
 	}
 
 	cmd := &cobra.Command{

--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -38,7 +38,7 @@ type deleteAppOpts struct {
 	// Interfaces to dependencies.
 	projectService   projectService
 	workspaceService archer.Workspace
-	sessFactory      sessionProvider
+	sessProvider     sessionProvider
 	spinner          progress
 	prompter         prompter
 
@@ -166,7 +166,7 @@ func (opts *deleteAppOpts) sourceProjectEnvironments() error {
 
 func (opts deleteAppOpts) deleteStacks() error {
 	for _, env := range opts.projectEnvironments {
-		sess, err := opts.sessFactory.FromRole(env.ManagerRoleARN, env.Region)
+		sess, err := opts.sessProvider.FromRole(env.ManagerRoleARN, env.Region)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func (opts deleteAppOpts) emptyECRRepos() error {
 	repoName := fmt.Sprintf("%s/%s", opts.projectName, opts.AppName)
 
 	for _, region := range uniqueRegions {
-		sess, err := opts.sessFactory.DefaultWithRegion(region)
+		sess, err := opts.sessProvider.DefaultWithRegion(region)
 		if err != nil {
 			return err
 		}
@@ -222,7 +222,7 @@ func (opts deleteAppOpts) removeAppProjectResources() error {
 		return err
 	}
 
-	sess, err := opts.sessFactory.Default()
+	sess, err := opts.sessProvider.Default()
 	if err != nil {
 		return err
 	}
@@ -269,10 +269,10 @@ func (opts *deleteAppOpts) RecommendedActions() []string {
 // BuildAppDeleteCmd builds the command to delete application(s).
 func BuildAppDeleteCmd() *cobra.Command {
 	opts := &deleteAppOpts{
-		GlobalOpts:  NewGlobalOpts(),
-		spinner:     termprogress.NewSpinner(),
-		prompter:    prompt.New(),
-		sessFactory: &session.Provider{},
+		GlobalOpts:   NewGlobalOpts(),
+		spinner:      termprogress.NewSpinner(),
+		prompter:     prompt.New(),
+		sessProvider: session.NewProvider(),
 	}
 
 	cmd := &cobra.Command{

--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -43,7 +43,7 @@ func BuildAppDeployCommand() *cobra.Command {
 		spinner:       termprogress.NewSpinner(),
 		dockerService: docker.New(),
 		runner:        command.New(),
-		sessFactory:   &session.Provider{},
+		sessProvider:  session.NewProvider(),
 	}
 
 	cmd := &cobra.Command{
@@ -93,7 +93,7 @@ type appDeployOpts struct {
 	runner             runner
 	appPackageCfClient projectResourcesGetter
 	appDeployCfClient  cloudformation.CloudFormation
-	sessFactory        sessionProvider
+	sessProvider       sessionProvider
 
 	spinner progress
 
@@ -292,12 +292,12 @@ func (opts *appDeployOpts) sourceTargetEnv() error {
 }
 
 func (opts *appDeployOpts) configureClients() error {
-	defaultSessEnvRegion, err := opts.sessFactory.DefaultWithRegion(opts.targetEnvironment.Region)
+	defaultSessEnvRegion, err := opts.sessProvider.DefaultWithRegion(opts.targetEnvironment.Region)
 	if err != nil {
 		return fmt.Errorf("create ECR session with region %s: %w", opts.targetEnvironment.Region, err)
 	}
 
-	envSession, err := opts.sessFactory.FromRole(opts.targetEnvironment.ManagerRoleARN, opts.targetEnvironment.Region)
+	envSession, err := opts.sessProvider.FromRole(opts.targetEnvironment.ManagerRoleARN, opts.targetEnvironment.Region)
 	if err != nil {
 		return fmt.Errorf("assuming environment manager role: %w", err)
 	}
@@ -309,7 +309,7 @@ func (opts *appDeployOpts) configureClients() error {
 	opts.appDeployCfClient = cloudformation.New(envSession)
 
 	// app package CF client against tools account
-	appPackageCfSess, err := opts.sessFactory.Default()
+	appPackageCfSess, err := opts.sessProvider.Default()
 	if err != nil {
 		return fmt.Errorf("create app package CF session: %w", err)
 	}

--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -43,7 +43,7 @@ func BuildAppDeployCommand() *cobra.Command {
 		spinner:       termprogress.NewSpinner(),
 		dockerService: docker.New(),
 		runner:        command.New(),
-		sessFactory:   &session.Factory{},
+		sessFactory:   &session.Provider{},
 	}
 
 	cmd := &cobra.Command{

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -270,8 +270,8 @@ This command is also run as part of "ecs-preview init".`,
 			}
 			opts.manifestWriter = ws
 
-			f := &session.Provider{}
-			sess, err := f.Default()
+			p := session.NewProvider()
+			sess, err := p.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -270,7 +270,7 @@ This command is also run as part of "ecs-preview init".`,
 			}
 			opts.manifestWriter = ws
 
-			f := &session.Factory{}
+			f := &session.Provider{}
 			sess, err := f.Default()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -326,7 +326,7 @@ func BuildAppPackageCmd() *cobra.Command {
 			}
 			opts.store = store
 
-			f := &session.Factory{}
+			f := &session.Provider{}
 			sess, err := f.Default()
 			if err != nil {
 				return fmt.Errorf("error retrieving default session: %w", err)

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -326,8 +326,8 @@ func BuildAppPackageCmd() *cobra.Command {
 			}
 			opts.store = store
 
-			f := &session.Provider{}
-			sess, err := f.Default()
+			p := session.NewProvider()
+			sess, err := p.Default()
 			if err != nil {
 				return fmt.Errorf("error retrieving default session: %w", err)
 			}

--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -208,8 +208,8 @@ func BuildEnvDeleteCmd() *cobra.Command {
 				return fmt.Errorf("connect to ecs-cli metadata store: %w", err)
 			}
 			opts.storeClient = store
-			f := &session.Provider{}
-			profileSess, err := f.FromProfile(opts.EnvProfile)
+			p := session.NewProvider()
+			profileSess, err := p.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return fmt.Errorf("cannot create session from profile %s: %w", opts.EnvProfile, err)
 			}

--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -208,7 +208,7 @@ func BuildEnvDeleteCmd() *cobra.Command {
 				return fmt.Errorf("connect to ecs-cli metadata store: %w", err)
 			}
 			opts.storeClient = store
-			f := &session.Factory{}
+			f := &session.Provider{}
 			profileSess, err := f.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return fmt.Errorf("cannot create session from profile %s: %w", opts.EnvProfile, err)

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -265,12 +265,12 @@ func BuildEnvInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			f := &session.Provider{}
-			profileSess, err := f.FromProfile(opts.EnvProfile)
+			sessProvider := session.NewProvider()
+			profileSess, err := sessProvider.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return err
 			}
-			defaultSession, err := f.Default()
+			defaultSession, err := sessProvider.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -265,7 +265,7 @@ func BuildEnvInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			f := &session.Factory{}
+			f := &session.Provider{}
 			profileSess, err := f.FromProfile(opts.EnvProfile)
 			if err != nil {
 				return err

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -65,7 +65,7 @@ func NewInitOpts() (*InitOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	f := &session.Factory{}
+	f := &session.Provider{}
 	sess, err := f.Default()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -65,8 +65,8 @@ func NewInitOpts() (*InitOpts, error) {
 	if err != nil {
 		return nil, err
 	}
-	f := &session.Provider{}
-	sess, err := f.Default()
+	sessProvider := session.NewProvider()
+	sess, err := sessProvider.Default()
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func NewInitOpts() (*InitOpts, error) {
 		spinner:       spin,
 		dockerService: docker.New(),
 		runner:        command.New(),
-		sessFactory:   f,
+		sessProvider:  sessProvider,
 
 		GlobalOpts: NewGlobalOpts(),
 	}

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -250,8 +250,8 @@ func BuildPipelineUpdateCmd() *cobra.Command {
 			}
 			opts.project = project
 
-			f := &session.Provider{}
-			defaultSession, err := f.Default()
+			p := session.NewProvider()
+			defaultSession, err := p.Default()
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -250,7 +250,7 @@ func BuildPipelineUpdateCmd() *cobra.Command {
 			}
 			opts.project = project
 
-			f := &session.Factory{}
+			f := &session.Provider{}
 			defaultSession, err := f.Default()
 			if err != nil {
 				return err

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -42,7 +42,7 @@ type InitProjectOpts struct {
 
 // NewInitProjectOpts returns a new InitProjectOpts.
 func NewInitProjectOpts() (*InitProjectOpts, error) {
-	f := &session.Factory{}
+	f := &session.Provider{}
 	defaultSession, err := f.Default()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -42,8 +42,8 @@ type InitProjectOpts struct {
 
 // NewInitProjectOpts returns a new InitProjectOpts.
 func NewInitProjectOpts() (*InitProjectOpts, error) {
-	f := &session.Provider{}
-	defaultSession, err := f.Default()
+	p := session.NewProvider()
+	defaultSession, err := p.Default()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/describe/webapp.go
+++ b/internal/pkg/describe/webapp.go
@@ -33,7 +33,7 @@ type webAppDescriber struct {
 
 	store           archer.EnvironmentGetter
 	stackDescribers map[string]stackDescriber
-	sessFactory     sessionFromRoleProvider
+	sessProvider    sessionFromRoleProvider
 }
 
 func newWebAppDescriber(app *archer.Application, store archer.EnvironmentGetter) *webAppDescriber {
@@ -41,7 +41,7 @@ func newWebAppDescriber(app *archer.Application, store archer.EnvironmentGetter)
 		app:             app,
 		store:           store,
 		stackDescribers: make(map[string]stackDescriber),
-		sessFactory:     &session.Provider{},
+		sessProvider:    session.NewProvider(),
 	}
 }
 
@@ -118,7 +118,7 @@ func (d *webAppDescriber) stack(roleARN, region, stackName string) (*cloudformat
 
 func (d *webAppDescriber) stackDescriber(roleARN, region string) (stackDescriber, error) {
 	if _, ok := d.stackDescribers[roleARN]; !ok {
-		sess, err := d.sessFactory.FromRole(roleARN, region)
+		sess, err := d.sessProvider.FromRole(roleARN, region)
 		if err != nil {
 			return nil, fmt.Errorf("session for role %s and region %s: %w", roleARN, region, err)
 		}

--- a/internal/pkg/describe/webapp.go
+++ b/internal/pkg/describe/webapp.go
@@ -41,7 +41,7 @@ func newWebAppDescriber(app *archer.Application, store archer.EnvironmentGetter)
 		app:             app,
 		store:           store,
 		stackDescribers: make(map[string]stackDescriber),
-		sessFactory:     &session.Factory{},
+		sessFactory:     &session.Provider{},
 	}
 }
 

--- a/internal/pkg/store/secretsmanager/secretsmanager.go
+++ b/internal/pkg/store/secretsmanager/secretsmanager.go
@@ -23,8 +23,8 @@ type SecretsManager struct {
 
 // NewSecretsManager returns a SecretsManager configured with the input session.
 func NewStore() (*SecretsManager, error) {
-	f := &session.Provider{}
-	sess, err := f.Default()
+	p := session.NewProvider()
+	sess, err := p.Default()
 
 	if err != nil {
 		return nil, err

--- a/internal/pkg/store/secretsmanager/secretsmanager.go
+++ b/internal/pkg/store/secretsmanager/secretsmanager.go
@@ -23,7 +23,7 @@ type SecretsManager struct {
 
 // NewSecretsManager returns a SecretsManager configured with the input session.
 func NewStore() (*SecretsManager, error) {
-	f := &session.Factory{}
+	f := &session.Provider{}
 	sess, err := f.Default()
 
 	if err != nil {

--- a/internal/pkg/store/store.go
+++ b/internal/pkg/store/store.go
@@ -55,7 +55,7 @@ type Store struct {
 
 // New returns a Store allowing you to query or create Projects or Environments.
 func New() (*Store, error) {
-	f := &session.Factory{}
+	f := &session.Provider{}
 	sess, err := f.Default()
 
 	if err != nil {

--- a/internal/pkg/store/store.go
+++ b/internal/pkg/store/store.go
@@ -55,8 +55,8 @@ type Store struct {
 
 // New returns a Store allowing you to query or create Projects or Environments.
 func New() (*Store, error) {
-	f := &session.Provider{}
-	sess, err := f.Default()
+	p := session.NewProvider()
+	sess, err := p.Default()
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Commands such as `init` can share the same `session.Provider` without having to re-create the sessions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
