### PR TITLE
chore(e2e): remove interactive flag form e2e command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ e2e: build-e2e
 	@echo "Building E2E Docker Image" &&\
 	docker build -t ecs-cli-v2/e2e . -f e2e/Dockerfile
 	@echo "Running E2E Tests" &&\
-	docker run --privileged -it -v ${HOME}/.aws:/home/.aws -e "HOME=/home" ecs-cli-v2/e2e:latest
+	docker run --privileged -v ${HOME}/.aws:/home/.aws -e "HOME=/home" ecs-cli-v2/e2e:latest
 
 .PHONY: e2e-test-update-golden-files
 e2e-test-update-golden-files:

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,15 +1,14 @@
-FROM golang:1.13
-
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go get -u github.com/onsi/ginkgo/ginkgo && go get -u github.com/onsi/gomega/...
-
 FROM docker:stable-dind
 # Docker needs somewhere to put creds from docker login.
 RUN wget https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz && tar -xf docker-credential-pass-v0.6.0-amd64.tar.gz && chmod +x docker-credential-pass &&  mv docker-credential-pass /bin
 ENV DOCKER_HOST=tcp://127.0.0.1:2375
 ENV GOPROXY direct
+ENV GOBIN /go/bin
 
 # Install Go, Git and other dependencies so we can run ginkgo
 RUN apk add --no-cache --virtual .build-deps bash gcc musl-dev openssl go git
+
+RUN go get github.com/onsi/ginkgo/ginkgo && go get github.com/onsi/gomega/...
 
 # Copy the binary
 ADD bin/local/ecs-preview-amd64 /bin/ecs-preview

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -21,4 +21,4 @@ do
 done
 
 #Run all the e2e tests
-cd /github.com/aws/amazon-ecs-cli-v2/e2e/ && ginkgo -v -r
+cd /github.com/aws/amazon-ecs-cli-v2/e2e/ && /go/bin/ginkgo -v -r

--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -70,11 +70,11 @@ type AppDeployInput struct {
 
 // NewCLI returns a wrapper around CLI
 func NewCLI() (*CLI, error) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("get wd: %w", err)
-	}
-	cliPath := filepath.Join(wd, "..", "..", "bin", "local", "ecs-preview")
+	// These tests should be run in a dockerfile so that
+	// your file system and docker image repo isn't polluted
+	// with test data and files. Since this is going to run
+	// from Docker, the binary will localted in the root bin.
+	cliPath := filepath.Join("/", "bin", "ecs-preview")
 	if _, err := os.Stat(cliPath); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is just a little clean up, but removes the interactive
flag from ducker run (causing CodeBuild to fail) and also
getting rid of the unneeded multi-stage build.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
