### PR TITLE
fix: profile selection trims the word "profile" from profile names

### DIFF
--- a/internal/pkg/aws/profile/profile.go
+++ b/internal/pkg/aws/profile/profile.go
@@ -47,7 +47,7 @@ func (c *Config) Names() []string {
 	var profiles []string
 	for _, section := range c.f.Sections() {
 		// Named profiles created with "aws configure" are formatted as "[profile test]".
-		profiles = append(profiles, strings.TrimSpace(strings.ReplaceAll(section, "profile", "")))
+		profiles = append(profiles, strings.TrimSpace(strings.TrimPrefix(section, "profile")))
 	}
 	return profiles
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
c.f.Sections returns the section names. If the profile name contains the word 'profile', it will be replaced by an empty string. 

Example:
```
profile profile1
```

becomes

```
1
```

The change is to use ``strings.TrimPrefix`` instead.
```
profile profile1
```

becomes

```
profile1
```

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #627

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
