### PR TITLE
test(profile): add unit tests to the "aws/profile" package

### DIFF
--- a/internal/pkg/aws/profile/profile.go
+++ b/internal/pkg/aws/profile/profile.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Package profile provides functionality to parse AWS named profiles.
@@ -18,10 +18,14 @@ const (
 	awsConfigFileName = "config"
 )
 
+type sectionsGetter interface {
+	Sections() []string
+}
+
 // Config represents the local AWS config file.
 type Config struct {
 	// f is the ~/.aws/config INI file.
-	f *ini.INI
+	f sectionsGetter
 }
 
 // NewConfig returns a new parsed Config object from $HOME/.aws/config.

--- a/internal/pkg/aws/profile/profile_test.go
+++ b/internal/pkg/aws/profile/profile_test.go
@@ -1,0 +1,62 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockINI struct {
+	sections []string
+}
+
+func (m *mockINI) Sections() []string {
+	return m.sections
+}
+
+func TestConfig_Names(t *testing.T) {
+	testCases := map[string]struct {
+		ini *mockINI
+
+		wantedNames []string
+	}{
+		"return nil if there are no sections in the file": {
+			ini: &mockINI{
+				sections: nil,
+			},
+		},
+		"trim 'profile' from profile names": {
+			ini: &mockINI{
+				sections: []string{
+					"profile profile1",
+					"test",
+					"default",
+				},
+			},
+
+			wantedNames: []string{
+				"profile1",
+				"test",
+				"default",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			conf := &Config{
+				f: tc.ini,
+			}
+
+			// WHEN
+			profiles := conf.Names()
+
+			// THEN
+			require.Equal(t, tc.wantedNames, profiles)
+		})
+	}
+}


### PR DESCRIPTION
The "profile" package has no unit tests, this fixes that :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
