### PR TITLE
feat(cli): update app package to write nested stack template

### DIFF
--- a/internal/pkg/addons/addons.go
+++ b/internal/pkg/addons/addons.go
@@ -16,7 +16,7 @@ const (
 )
 
 type workspaceService interface {
-	ReadAddonFiles(appName string) (*workspace.ReadAddonFilesOutput, error)
+	ReadAddonFiles(appName string) (*workspace.AddonFiles, error)
 }
 
 // Addons represent additional resources for an application.
@@ -49,7 +49,7 @@ func (a *Addons) Template() (string, error) {
 	}
 	content, err := a.parser.Parse(addonsTemplatePath, struct {
 		AppName      string
-		AddonContent *workspace.ReadAddonFilesOutput
+		AddonContent *workspace.AddonFiles
 	}{
 		AppName:      a.appName,
 		AddonContent: out,

--- a/internal/pkg/addons/addons_test.go
+++ b/internal/pkg/addons/addons_test.go
@@ -28,7 +28,7 @@ func TestAddons_Template(t *testing.T) {
 
 			mockDependencies: func(ctrl *gomock.Controller, a *Addons) {
 				ws := mocks.NewMockworkspaceService(ctrl)
-				out := &workspace.ReadAddonFilesOutput{
+				out := &workspace.AddonFiles{
 					Outputs:    []string{"outputs"},
 					Parameters: []string{"params"},
 					Resources:  []string{"resources"},
@@ -38,7 +38,7 @@ func TestAddons_Template(t *testing.T) {
 				parser := templatemocks.NewMockParser(ctrl)
 				parser.EXPECT().Parse(addonsTemplatePath, struct {
 					AppName      string
-					AddonContent *workspace.ReadAddonFilesOutput
+					AddonContent *workspace.AddonFiles
 				}{
 					AppName:      a.appName,
 					AddonContent: out,

--- a/internal/pkg/addons/mocks/mock_addons.go
+++ b/internal/pkg/addons/mocks/mock_addons.go
@@ -5,9 +5,10 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	workspace "github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockworkspaceService is a mock of workspaceService interface
@@ -34,10 +35,10 @@ func (m *MockworkspaceService) EXPECT() *MockworkspaceServiceMockRecorder {
 }
 
 // ReadAddonFiles mocks base method
-func (m *MockworkspaceService) ReadAddonFiles(appName string) (*workspace.ReadAddonFilesOutput, error) {
+func (m *MockworkspaceService) ReadAddonFiles(appName string) (*workspace.AddonFiles, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAddonFiles", appName)
-	ret0, _ := ret[0].(*workspace.ReadAddonFilesOutput)
+	ret0, _ := ret[0].(*workspace.AddonFiles)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/pkg/archer/app.go
+++ b/internal/pkg/archer/app.go
@@ -46,4 +46,7 @@ const (
 	// file name when `app package` is called. It's also used to render the
 	// pipeline CFN template.
 	AppCfnTemplateConfigurationNameFormat = "%s-%s.params.json"
+	// AddonsCfnTemplateNameFormat is the addons output file name when `app package`
+	// is called.
+	AddonsCfnTemplateNameFormat = "%s.addons.stack.yml"
 )

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package cli
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/addons"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
@@ -41,13 +42,16 @@ type packageAppOpts struct {
 	packageAppVars
 
 	// Interfaces to interact with dependencies.
-	ws           wsAppReader
-	store        projectService
-	describer    projectResourcesGetter
-	stackWriter  io.Writer
-	paramsWriter io.Writer
-	fs           afero.Fs
-	runner       runner
+	addonsSvc     templater
+	initAddonsSvc func(*packageAppOpts) error // Overriden in tests.
+	ws            wsAppReader
+	store         projectService
+	describer     projectResourcesGetter
+	stackWriter   io.Writer
+	paramsWriter  io.Writer
+	addonsWriter  io.Writer
+	fs            afero.Fs
+	runner        runner
 }
 
 func newPackageAppOpts(vars packageAppVars) (*packageAppOpts, error) {
@@ -67,13 +71,23 @@ func newPackageAppOpts(vars packageAppVars) (*packageAppOpts, error) {
 
 	return &packageAppOpts{
 		packageAppVars: vars,
-		ws:             ws,
-		store:          store,
-		describer:      cloudformation.New(sess),
-		runner:         command.New(),
-		stackWriter:    os.Stdout,
-		paramsWriter:   ioutil.Discard,
-		fs:             &afero.Afero{Fs: afero.NewOsFs()},
+		initAddonsSvc: func(o *packageAppOpts) error {
+			addonsSvc, err := addons.New(o.AppName)
+			if err != nil {
+				return fmt.Errorf("initiate addons service: %w", err)
+			}
+			o.addonsSvc = addonsSvc
+
+			return nil
+		},
+		ws:           ws,
+		store:        store,
+		describer:    cloudformation.New(sess),
+		runner:       command.New(),
+		stackWriter:  os.Stdout,
+		paramsWriter: ioutil.Discard,
+		addonsWriter: ioutil.Discard,
+		fs:           &afero.Afero{Fs: afero.NewOsFs()},
 	}, nil
 }
 
@@ -118,19 +132,40 @@ func (o *packageAppOpts) Execute() error {
 	}
 
 	if o.OutputDir != "" {
-		if err := o.setFileWriters(); err != nil {
+		if err := o.setAppFileWriters(); err != nil {
 			return err
 		}
 	}
 
-	templates, err := o.getTemplates(env)
+	appTemplates, err := o.getAppTemplates(env)
 	if err != nil {
 		return err
 	}
-	if _, err = o.stackWriter.Write([]byte(templates.stack)); err != nil {
+	if _, err = o.stackWriter.Write([]byte(appTemplates.stack)); err != nil {
 		return err
 	}
-	_, err = o.paramsWriter.Write([]byte(templates.configuration))
+	if _, err = o.paramsWriter.Write([]byte(appTemplates.configuration)); err != nil {
+		return err
+	}
+
+	addonsTemplate, err := o.getAddonsTemplate()
+	// return nil if addons dir doesn't exist.
+	notExistErr := &workspace.ErrAddonsDirNotExist{AppName: o.AppName}
+	if errors.As(err, &notExistErr) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("retrieve addons template: %w", err)
+	}
+
+	// Addons template won't show up without setting --output-dir flag.
+	if o.OutputDir != "" {
+		if err := o.setAddonsFileWriter(); err != nil {
+			return err
+		}
+	}
+
+	_, err = o.addonsWriter.Write([]byte(addonsTemplate))
 	return err
 }
 
@@ -139,18 +174,22 @@ func (o *packageAppOpts) askAppName() error {
 		return nil
 	}
 
-	names, err := o.ws.AppNames()
+	appNames, err := o.ws.AppNames()
 	if err != nil {
 		return fmt.Errorf("list applications in workspace: %w", err)
 	}
-	if len(names) == 0 {
+	if len(appNames) == 0 {
 		return errors.New("there are no applications in the workspace, run `ecs-preview init` first")
 	}
-	app, err := o.prompt.SelectOne(appPackageAppNamePrompt, "", names)
+	if len(appNames) == 1 {
+		o.AppName = appNames[0]
+		return nil
+	}
+	appName, err := o.prompt.SelectOne(appPackageAppNamePrompt, "", appNames)
 	if err != nil {
 		return fmt.Errorf("prompt application name: %w", err)
 	}
-	o.AppName = app
+	o.AppName = appName
 	return nil
 }
 
@@ -159,18 +198,22 @@ func (o *packageAppOpts) askEnvName() error {
 		return nil
 	}
 
-	names, err := o.listEnvNames()
+	envNames, err := o.listEnvNames()
 	if err != nil {
 		return err
 	}
-	if len(names) == 0 {
+	if len(envNames) == 0 {
 		return fmt.Errorf("there are no environments in project %s", o.ProjectName())
 	}
-	env, err := o.prompt.SelectOne(appPackageEnvNamePrompt, "", names)
+	if len(envNames) == 1 {
+		o.EnvName = envNames[0]
+		return nil
+	}
+	envName, err := o.prompt.SelectOne(appPackageEnvNamePrompt, "", envNames)
 	if err != nil {
 		return fmt.Errorf("prompt environment name: %w", err)
 	}
-	o.EnvName = env
+	o.EnvName = envName
 	return nil
 }
 
@@ -191,13 +234,20 @@ func (o *packageAppOpts) askTag() error {
 	return nil
 }
 
-type cfnTemplates struct {
+func (o *packageAppOpts) getAddonsTemplate() (string, error) {
+	if err := o.initAddonsSvc(o); err != nil {
+		return "", err
+	}
+	return o.addonsSvc.Template()
+}
+
+type appCfnTemplates struct {
 	stack         string
 	configuration string
 }
 
-// getTemplates returns the CloudFormation stack's template and its parameters.
-func (o *packageAppOpts) getTemplates(env *archer.Environment) (*cfnTemplates, error) {
+// getAppTemplates returns the CloudFormation stack's template and its parameters for the application.
+func (o *packageAppOpts) getAppTemplates(env *archer.Environment) (*appCfnTemplates, error) {
 	raw, err := o.ws.ReadAppManifest(o.AppName)
 	if err != nil {
 		return nil, err
@@ -250,14 +300,14 @@ func (o *packageAppOpts) getTemplates(env *archer.Environment) (*cfnTemplates, e
 		if err != nil {
 			return nil, err
 		}
-		return &cfnTemplates{stack: tpl, configuration: params}, nil
+		return &appCfnTemplates{stack: tpl, configuration: params}, nil
 	default:
 		return nil, fmt.Errorf("create CloudFormation template for manifest of type %T", t)
 	}
 }
 
-// setFileWriters creates the output directory, and updates the template and param writers to file writers in the directory.
-func (o *packageAppOpts) setFileWriters() error {
+// setAppFileWriters creates the output directory, and updates the template and param writers to file writers in the directory.
+func (o *packageAppOpts) setAppFileWriters() error {
 	if err := o.fs.MkdirAll(o.OutputDir, 0755); err != nil {
 		return fmt.Errorf("create directory %s: %w", o.OutputDir, err)
 	}
@@ -277,6 +327,19 @@ func (o *packageAppOpts) setFileWriters() error {
 		return fmt.Errorf("create file %s: %w", paramsPath, err)
 	}
 	o.paramsWriter = paramsFile
+
+	return nil
+}
+
+func (o *packageAppOpts) setAddonsFileWriter() error {
+	addonsPath := filepath.Join(o.OutputDir,
+		fmt.Sprintf(archer.AddonsCfnTemplateNameFormat, o.AppName))
+	addonsFile, err := o.fs.Create(addonsPath)
+	if err != nil {
+		return fmt.Errorf("create file %s: %w", addonsPath, err)
+	}
+	o.addonsWriter = addonsFile
+
 	return nil
 }
 

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -46,6 +46,10 @@ type cwlogService interface {
 	LogGroupExists(logGroupName string) (bool, error)
 }
 
+type templater interface {
+	Template() (string, error)
+}
+
 type dockerService interface {
 	Build(uri, tag, path string) error
 	Login(uri, username, password string) error

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -404,6 +404,44 @@ func (mr *MockcwlogServiceMockRecorder) LogGroupExists(logGroupName interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogGroupExists", reflect.TypeOf((*MockcwlogService)(nil).LogGroupExists), logGroupName)
 }
 
+// Mocktemplater is a mock of templater interface
+type Mocktemplater struct {
+	ctrl     *gomock.Controller
+	recorder *MocktemplaterMockRecorder
+}
+
+// MocktemplaterMockRecorder is the mock recorder for Mocktemplater
+type MocktemplaterMockRecorder struct {
+	mock *Mocktemplater
+}
+
+// NewMocktemplater creates a new mock instance
+func NewMocktemplater(ctrl *gomock.Controller) *Mocktemplater {
+	mock := &Mocktemplater{ctrl: ctrl}
+	mock.recorder = &MocktemplaterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *Mocktemplater) EXPECT() *MocktemplaterMockRecorder {
+	return m.recorder
+}
+
+// Template mocks base method
+func (m *Mocktemplater) Template() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Template")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Template indicates an expected call of Template
+func (mr *MocktemplaterMockRecorder) Template() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Template", reflect.TypeOf((*Mocktemplater)(nil).Template))
+}
+
 // MockdockerService is a mock of dockerService interface
 type MockdockerService struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -35,3 +35,13 @@ type ErrWorkspaceHasExistingProject struct {
 func (e *ErrWorkspaceHasExistingProject) Error() string {
 	return fmt.Sprintf("this workspace is already registered with project %s", e.ExistingProjectName)
 }
+
+// ErrAddonsDirNotExist means we tried to access in an addons dir for an application
+// but it does not exist.
+type ErrAddonsDirNotExist struct {
+	AppName string
+}
+
+func (e *ErrAddonsDirNotExist) Error() string {
+	return fmt.Sprintf(`"addons" directory does not exist under application %s`, e.AppName)
+}


### PR DESCRIPTION
<!-- Provide summary of changes -->
Resolves #648. Also skip selecting if there's only one available app or env. By default addons template won't show up in `stdout` unless users pass in `--output-dir` flag.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
