### PR TITLE
test(e2e): allow for CloudWatch logs delay

### DIFF
--- a/e2e/init/init_test.go
+++ b/e2e/init/init_test.go
@@ -102,26 +102,20 @@ var _ = Describe("init flow", func() {
 	})
 
 	Context("app logs", func() {
-		var (
-			appLogs    []client.AppLogsOutput
-			appLogsErr error
-		)
-
-		BeforeAll(func() {
-			appLogs, appLogsErr = cli.AppLogs(&client.AppLogsRequest{
-				ProjectName: projectName,
-				AppName:     appName,
-				EnvName:     "test",
-				Since:       "1h",
-			})
-		})
-
-		It("should not return an error", func() {
-			Expect(appLogsErr).NotTo(HaveOccurred())
-		})
 
 		It("should return valid log lines", func() {
-			Expect(len(appLogs)).NotTo(Equal(0))
+			var appLogs []client.AppLogsOutput
+			var appLogsErr error
+			Eventually(func() ([]client.AppLogsOutput, error) {
+				appLogs, appLogsErr = cli.AppLogs(&client.AppLogsRequest{
+					ProjectName: projectName,
+					AppName:     appName,
+					EnvName:     "test",
+					Since:       "1h",
+				})
+				return appLogs, appLogsErr
+			}, "60s", "10s").ShouldNot(BeEmpty())
+
 			for _, logLine := range appLogs {
 				Expect(logLine.Message).NotTo(Equal(""))
 				Expect(logLine.TaskID).NotTo(Equal(""))

--- a/e2e/multi-app-project/multi_app_project_test.go
+++ b/e2e/multi-app-project/multi_app_project_test.go
@@ -165,13 +165,18 @@ var _ = Describe("Multiple App Project", func() {
 
 		It("app logs should display logs", func() {
 			for _, appName := range []string{"front-end", "back-end"} {
-				appLogs, appLogsErr := cli.AppLogs(&client.AppLogsRequest{
-					ProjectName: projectName,
-					AppName:     appName,
-					EnvName:     "test",
-					Since:       "1h",
-				})
-				Expect(appLogsErr).NotTo(HaveOccurred())
+				var appLogs []client.AppLogsOutput
+				var appLogsErr error
+				Eventually(func() ([]client.AppLogsOutput, error) {
+					appLogs, appLogsErr = cli.AppLogs(&client.AppLogsRequest{
+						ProjectName: projectName,
+						AppName:     appName,
+						EnvName:     "test",
+						Since:       "1h",
+					})
+					return appLogs, appLogsErr
+				}, "60s", "10s").ShouldNot(BeEmpty())
+
 				for _, logLine := range appLogs {
 					Expect(logLine.Message).NotTo(Equal(""))
 					Expect(logLine.TaskID).NotTo(Equal(""))

--- a/e2e/multi-env-project/multi_env_test.go
+++ b/e2e/multi-env-project/multi_env_test.go
@@ -179,13 +179,18 @@ var _ = Describe("Multiple Env Project", func() {
 
 		It("app logs should display logs", func() {
 			for _, envName := range []string{"test", "prod"} {
-				appLogs, appLogsErr := cli.AppLogs(&client.AppLogsRequest{
-					ProjectName: projectName,
-					AppName:     appName,
-					EnvName:     envName,
-					Since:       "1h",
-				})
-				Expect(appLogsErr).NotTo(HaveOccurred())
+				var appLogs []client.AppLogsOutput
+				var appLogsErr error
+				Eventually(func() ([]client.AppLogsOutput, error) {
+					appLogs, appLogsErr = cli.AppLogs(&client.AppLogsRequest{
+						ProjectName: projectName,
+						AppName:     appName,
+						EnvName:     envName,
+						Since:       "1h",
+					})
+					return appLogs, appLogsErr
+				}, "60s", "10s").ShouldNot(BeEmpty())
+
 				for _, logLine := range appLogs {
 					Expect(logLine.Message).NotTo(Equal(""))
 					Expect(logLine.TaskID).NotTo(Equal(""))


### PR DESCRIPTION
CloudWatch logs can sometimes have a few second delay getting
logs from the ECS service into CloudWatch. This change makes
it so we'll wait up to 60 seconds for the logs to get there,
then we'll fail.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
