### PR TITLE
fix(cli): init addons service in app deploy

### DIFF
--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -348,11 +348,13 @@ func (o *appDeployOpts) getAppDeployTemplate() (string, error) {
 			GlobalOpts: o.GlobalOpts,
 		},
 
-		stackWriter:  buffer,
-		paramsWriter: ioutil.Discard,
-		store:        o.projectService,
-		describer:    o.appPackageCfClient,
-		ws:           o.workspaceService,
+		stackWriter:   buffer,
+		paramsWriter:  ioutil.Discard,
+		addonsWriter:  ioutil.Discard,
+		initAddonsSvc: initPackageAddonsSvc,
+		store:         o.projectService,
+		describer:     o.appPackageCfClient,
+		ws:            o.workspaceService,
 	}
 
 	if err := appPackage.Execute(); err != nil {

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -30,6 +30,16 @@ const (
 	appPackageEnvNamePrompt = "Which environment would you like to create this stack for?"
 )
 
+var initPackageAddonsSvc = func(o *packageAppOpts) error {
+	addonsSvc, err := addons.New(o.AppName)
+	if err != nil {
+		return fmt.Errorf("initiate addons service: %w", err)
+	}
+	o.addonsSvc = addonsSvc
+
+	return nil
+}
+
 type packageAppVars struct {
 	*GlobalOpts
 	AppName   string
@@ -71,23 +81,15 @@ func newPackageAppOpts(vars packageAppVars) (*packageAppOpts, error) {
 
 	return &packageAppOpts{
 		packageAppVars: vars,
-		initAddonsSvc: func(o *packageAppOpts) error {
-			addonsSvc, err := addons.New(o.AppName)
-			if err != nil {
-				return fmt.Errorf("initiate addons service: %w", err)
-			}
-			o.addonsSvc = addonsSvc
-
-			return nil
-		},
-		ws:           ws,
-		store:        store,
-		describer:    cloudformation.New(sess),
-		runner:       command.New(),
-		stackWriter:  os.Stdout,
-		paramsWriter: ioutil.Discard,
-		addonsWriter: ioutil.Discard,
-		fs:           &afero.Afero{Fs: afero.NewOsFs()},
+		initAddonsSvc:  initPackageAddonsSvc,
+		ws:             ws,
+		store:          store,
+		describer:      cloudformation.New(sess),
+		runner:         command.New(),
+		stackWriter:    os.Stdout,
+		paramsWriter:   ioutil.Discard,
+		addonsWriter:   ioutil.Discard,
+		fs:             &afero.Afero{Fs: afero.NewOsFs()},
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
#678 didn't update the `app deploy` which calls the `Execute()` of `app package` as well. Our e2e test caught the error, which should be caught by the unit test if exists :(
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
