### PR TITLE
fix!: move containers security group from app to env stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ e2e-test-update-golden-files:
 	#
 	# make e2e-test-update-golden-files // this is expected to fail but will update the golden files
 	# make e2e-test // this should pass because the golden files were updated
-	go test -v -p 1 -parallel 1 -tags=e2e ./e2e... -update
+	go test -p 1 -parallel 1 -tags=e2e ./e2e... -update
 
 .PHONY: tools
 tools:

--- a/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation_integration_test.go
@@ -445,16 +445,6 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 					output.OutputValue,
 					"VpcId value should not be nil")
 			},
-			"PublicLoadBalancerSecurityGroupId": func(output *awsCF.Output) {
-				require.Equal(t,
-					fmt.Sprintf("%s-PublicLoadBalancerSecurityGroupId", envStackName),
-					*output.ExportName,
-					"Should export PublicLoadBalancerSecurityGroupId as stackname-PublicLoadBalancerSecurityGroupId")
-
-				require.NotNil(t,
-					output.OutputValue,
-					"PublicLoadBalancerSecurityGroupId value should not be nil")
-			},
 			"PublicSubnets": func(output *awsCF.Output) {
 				require.Equal(t,
 					fmt.Sprintf("%s-PublicSubnets", envStackName),
@@ -465,15 +455,15 @@ func Test_Environment_Deployment_Integration(t *testing.T) {
 					output.OutputValue,
 					"PublicSubnets value should not be nil")
 			},
-			"PublicLoadBalancerArn": func(output *awsCF.Output) {
+			"EnvironmentSecurityGroup": func(output *awsCF.Output) {
 				require.Equal(t,
-					fmt.Sprintf("%s-PublicLoadBalancerArn", envStackName),
+					fmt.Sprintf("%s-EnvironmentSecurityGroup", envStackName),
 					*output.ExportName,
-					"Should export PublicLoadBalancerArn as stackname-PublicLoadBalancerArn")
+					"Should export EnvironmentSecurityGroup as stackname-EnvironmentSecurityGroup")
 
 				require.NotNil(t,
 					output.OutputValue,
-					"PublicLoadBalancerArn value should not be nil")
+					"EnvironmentSecurityGroup value should not be nil")
 			},
 			"PublicLoadBalancerDNSName": func(output *awsCF.Output) {
 				require.NotNil(t,

--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -63,9 +63,16 @@ Resources:
       EnableDnsHostnames: true
       EnableDnsSupport: true
       InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}'
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}'
 
   InternetGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -80,6 +87,9 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 0, !GetAZs '' ]
       MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-pub0'
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
@@ -88,6 +98,9 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 1, !GetAZs '' ]
       MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-pub1'
 
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
@@ -96,6 +109,9 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 0, !GetAZs '' ]
       MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-priv0'
 
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
@@ -104,11 +120,17 @@ Resources:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [ 1, !GetAZs '' ]
       MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-priv1'
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}'
 
   DefaultPublicRoute:
     Type: AWS::EC2::Route
@@ -150,6 +172,35 @@ Resources:
           IpProtocol: tcp
           ToPort: 443
       VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-lb'
+
+  # Only accept requests coming from the public ALB or other containers in the same security group.
+  EnvironmentSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Join ['', [!Ref ProjectName, '-', !Ref EnvironmentName, EnvironmentSecurityGroup]]
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub 'ecs-${ProjectName}-${EnvironmentName}-env'
+
+  EnvironmentSecurityGroupIngressFromPublicALB:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from the public ALB
+      GroupId: !Ref EnvironmentSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref PublicLoadBalancerSecurityGroup
+
+  EnvironmentSecurityGroupIngressFromSelf:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      Description: Ingress from other containers in the same security group
+      GroupId: !Ref EnvironmentSecurityGroup
+      IpProtocol: -1
+      SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
   PublicLoadBalancer:
     Condition: CreatePublicLoadBalancer
@@ -159,7 +210,6 @@ Resources:
       SecurityGroups: [ !GetAtt PublicLoadBalancerSecurityGroup.GroupId ]
       Subnets: [ !Ref PublicSubnet1, !Ref PublicSubnet2 ]
       Type: application
-
 
   # Assign a dummy target group that with no real services as targets, so that we can create
   # the listeners for the services.
@@ -554,23 +604,16 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-PrivateSubnets
 
+  EnvironmentSecurityGroup:
+    Value: !Ref EnvironmentSecurityGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-EnvironmentSecurityGroup
+
   PublicLoadBalancerDNSName:
     Condition: CreatePublicLoadBalancer
     Value: !GetAtt PublicLoadBalancer.DNSName
     Export:
       Name: !Sub ${AWS::StackName}-PublicLoadBalancerDNS
-
-  PublicLoadBalancerArn:
-    Condition: CreatePublicLoadBalancer
-    Value: !Ref PublicLoadBalancer
-    Export:
-      Name: !Sub ${AWS::StackName}-PublicLoadBalancerArn
-
-  PublicLoadBalancerSecurityGroupId:
-    Condition: CreatePublicLoadBalancer
-    Value: !GetAtt PublicLoadBalancerSecurityGroup.GroupId
-    Export:
-      Name: !Sub ${AWS::StackName}-PublicLoadBalancerSecurityGroupId
 
   PublicLoadBalancerHostedZone:
     Condition: CreatePublicLoadBalancer

--- a/templates/lb-fargate-service/cf.yml
+++ b/templates/lb-fargate-service/cf.yml
@@ -193,32 +193,6 @@ Resources:
                   - 'cloudwatch:ListMetrics'
                 Resource: '*'
 
-  ContainerSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: !Join ['', [!Ref ProjectName, '-', !Ref EnvName, '-', !Ref AppName, ContainerSecurityGroup]]
-      VpcId:
-        Fn::ImportValue:
-          !Sub "${ProjectName}-${EnvName}-VpcId"
-
-  ContainerSecurityGroupIngressFromPublicALB:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      Description: Ingress from the public ALB
-      GroupId: !Ref 'ContainerSecurityGroup'
-      IpProtocol: -1
-      SourceSecurityGroupId:
-        Fn::ImportValue:
-          !Sub "${ProjectName}-${EnvName}-PublicLoadBalancerSecurityGroupId"
-
-  ContainerSecurityGroupIngressFromSelf:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      Description: Ingress from other containers in the same security group
-      GroupId: !Ref 'ContainerSecurityGroup'
-      IpProtocol: -1
-      SourceSecurityGroupId: !Ref 'ContainerSecurityGroup'
-
   Service:
     Type: AWS::ECS::Service
     DependsOn: WaitUntilListenerRuleIsCreated
@@ -249,7 +223,7 @@ Resources:
                 - ','
                 - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-PublicSubnets'
           SecurityGroups:
-            - !Ref ContainerSecurityGroup
+            - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-EnvironmentSecurityGroup'
       LoadBalancers:
         - ContainerName: !Ref AppName
           ContainerPort: !Ref ContainerPort


### PR DESCRIPTION
Related #599 

BREAKING CHANGE: Previously, the security group was defined in the application stack which meant that containers could not communicate inter-application. This change moves the security group to the environment level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
