### PR TITLE
test(e2e): add some buffer for validating endpoints

### DIFF
--- a/e2e/multi-env-project/multi_env_test.go
+++ b/e2e/multi-env-project/multi_env_test.go
@@ -171,9 +171,10 @@ var _ = Describe("Multiple Env Project", func() {
 				route := envRoutes[env]
 				Expect(route.Environment).To(Equal(env))
 				Expect(route.Path).To(Equal(appName))
-				resp, fetchErr := http.Get(fmt.Sprintf("http://%s/%s/", route.URL, route.Path))
-				Expect(fetchErr).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(200))
+				Eventually(func() (int, error) {
+					resp, fetchErr := http.Get(fmt.Sprintf("http://%s/%s/", route.URL, route.Path))
+					return resp.StatusCode, fetchErr
+				}, "10s", "1s").Should(Equal(200))
 			}
 		})
 


### PR DESCRIPTION
There seems to be times when we call the endpoint, but
it's not quite ready yet, after we do a deployment. I can't
reproduce this localy, which leads me to believe it's because
CodeBuild instance is just faster.

This change lets the tests retry a few times (up to 10s) before
failing.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
