### PR TITLE
fix(pipeline): buildspec fails to get app name to generate CFN template

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
 gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/templates/cicd/buildspec.yml
+++ b/templates/cicd/buildspec.yml
@@ -20,10 +20,9 @@ phases:
     commands:
       - ls -l
       - export COLOR="false"
-      # Find all the local applications in the workspace
-      - manifests=$(find ./ecs-project -name '*-app.yml')
-      # Remove forward slashes and the trailing -app.yml to get the names
-      - apps=$(find ./ecs-project -name '*-app.yml' | sed -e 's!.*/!!' -e 's/-app.yml//')
+      # Find all the local applications in the workspace.
+      - apps=$(./ecs-preview app ls --local --json | jq '.applications[].name' | sed 's/"//g')
+      # Find all the environments.
       - envs=$(./ecs-preview env ls --json | jq '.environments[].name' | sed 's/"//g')
       # Generate the cloudformation templates.
       # The tag is the build ID but we replaced the colon ':' with a dash '-'.
@@ -44,7 +43,7 @@ phases:
       #     - Login and push the image.
       - >
         for app in $apps; do
-          for docker_dir in $(cat $CODEBUILD_SRC_DIR/ecs-project/$app-app.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' | jq '.image.build' | sed 's/"//g'); do
+          for docker_dir in $(cat $CODEBUILD_SRC_DIR/ecs-project/$app/manifest.yml | ruby -ryaml -rjson -e 'puts JSON.pretty_generate(YAML.load(ARGF))' | jq '.image.build' | sed 's/"//g'); do
           cd $CODEBUILD_SRC_DIR/$docker_dir;
           docker build -t $app:$tag .;
           image_id=$(docker images -q $app:$tag);


### PR DESCRIPTION
<!-- Provide summary of changes -->
After #657, the structure for `ecs-project` changed. We need to update the `buildspec.yml` for pipeline as well. Otherwise the codebuild fails.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
