### PR TITLE
chore: put nonprod environments before prod when listing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ This document describes how to set up a development environment and submit your 
 
 From the repository root run:
 
-`git remote add upstream git@github.com:aws/amazon-ecs-cli`
+`git remote add upstream git@github.com:aws/amazon-ecs-cli-v2`
 
 `git fetch upstream`
 

--- a/internal/pkg/store/env.go
+++ b/internal/pkg/store/env.go
@@ -6,6 +6,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/aws/aws-sdk-go/aws"
@@ -92,6 +93,9 @@ func (s *Store) ListEnvironments(projectName string) ([]*archer.Environment, err
 
 		environments = append(environments, &env)
 	}
+	// non-prod env before prod env. sort by alphabetically if same
+	sort.SliceStable(environments, func(i, j int) bool { return environments[i].Name < environments[i].Name })
+	sort.SliceStable(environments, func(i, j int) bool { return !environments[i].Prod })
 	return environments, nil
 }
 

--- a/internal/pkg/store/env_test.go
+++ b/internal/pkg/store/env_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func TestStore_ListEnvironments(t *testing.T) {
-	testEnvironment := archer.Environment{Name: "test", AccountID: "12345", Project: "chicken", Region: "us-west-2s"}
+	testEnvironment := archer.Environment{Name: "test", AccountID: "12345", Project: "chicken", Region: "us-west-2s", Prod: false}
 	testEnvironmentString, err := marshal(testEnvironment)
 	testEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, testEnvironment.Project, testEnvironment.Name)
 	require.NoError(t, err, "Marshal environment should not fail")
 
-	prodEnvironment := archer.Environment{Name: "prod", AccountID: "12345", Project: "chicken", Region: "us-west-2s"}
+	prodEnvironment := archer.Environment{Name: "prod", AccountID: "12345", Project: "chicken", Region: "us-west-2s", Prod: true}
 	prodEnvironmentString, err := marshal(prodEnvironment)
 	prodEnvironmentPath := fmt.Sprintf(fmtEnvParamPath, prodEnvironment.Project, prodEnvironment.Name)
 	require.NoError(t, err, "Marshal environment should not fail")
@@ -42,12 +42,12 @@ func TestStore_ListEnvironments(t *testing.T) {
 				return &ssm.GetParametersByPathOutput{
 					Parameters: []*ssm.Parameter{
 						{
-							Name:  aws.String(testEnvironmentPath),
-							Value: aws.String(testEnvironmentString),
+							Name:  aws.String(prodEnvironmentPath), // <- return prod before test on purpose to test sorting by Prod
+							Value: aws.String(prodEnvironmentString),
 						},
 						{
-							Name:  aws.String(prodEnvironmentPath),
-							Value: aws.String(prodEnvironmentString),
+							Name:  aws.String(testEnvironmentPath),
+							Value: aws.String(testEnvironmentString),
 						},
 					},
 				}, nil

--- a/internal/pkg/store/store_integration_test.go
+++ b/internal/pkg/store/store_integration_test.go
@@ -45,8 +45,8 @@ func Test_SSM_Project_Integration(t *testing.T) {
 func Test_SSM_Environment_Integration(t *testing.T) {
 	s, _ := store.New()
 	projectToCreate := archer.Project{Name: randStringBytes(10), Version: "1.0"}
-	testEnvironment := archer.Environment{Name: "test", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234"}
-	prodEnvironment := archer.Environment{Name: "prod", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234"}
+	testEnvironment := archer.Environment{Name: "test", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234", Prod: false}
+	prodEnvironment := archer.Environment{Name: "prod", Project: projectToCreate.Name, Region: "us-west-2", AccountID: " 1234", Prod: true}
 
 	t.Run("Create, Get and List Environments", func(t *testing.T) {
 		// Create our first project


### PR DESCRIPTION
<!-- Provide summary of changes -->
when listing environments, put nonprod environments first so user keep typing "Enter" will not accidentally deploy to production.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
fixes #716 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
