### PR TITLE
refactor: move cfn logic to aws/cfn from deploy/cfn

### DIFF
--- a/internal/pkg/aws/cloudformation/changeset.go
+++ b/internal/pkg/aws/cloudformation/changeset.go
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/google/uuid"
+)
+
+const (
+	// The change set name must match the regex [a-zA-Z][-a-zA-Z0-9]*. The generated UUID can start with a number,
+	// by prefixing the uuid with a word we guarantee that we start with a letter.
+	fmtChangeSetName = "ecscli-%s"
+
+	// Status reasons that can occur if the change set execution status is "FAILED".
+	noChangesReason = "NO_CHANGES_REASON"
+	noUpdatesReason = "NO_UPDATES_REASON"
+)
+
+type changeSetAPI interface {
+	CreateChangeSet(*cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error)
+	WaitUntilChangeSetCreateCompleteWithContext(aws.Context, *cloudformation.DescribeChangeSetInput, ...request.WaiterOption) error
+	DescribeChangeSet(*cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error)
+	ExecuteChangeSet(*cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error)
+	DeleteChangeSet(*cloudformation.DeleteChangeSetInput) (*cloudformation.DeleteChangeSetOutput, error)
+}
+
+type changeSet struct {
+	name      string
+	stackName string
+	client    changeSetAPI
+}
+
+type changeSetDescription struct {
+	executionStatus string
+	statusReason    string
+	changes         []*cloudformation.Change
+}
+
+func newChangeSet(cfnClient changeSetAPI, stackName string) (*changeSet, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return nil, fmt.Errorf("generate random id for Change Set: %w", err)
+	}
+
+	return &changeSet{
+		name:      fmt.Sprintf(fmtChangeSetName, id.String()),
+		stackName: stackName,
+
+		client: cfnClient,
+	}, nil
+}
+
+func (cs *changeSet) String() string {
+	return fmt.Sprintf("change set %s for stack %s", cs.name, cs.stackName)
+}
+
+// create creates a Change Set with type CREATE and waits until it's created.
+func (cs *changeSet) create(template string, params []*cloudformation.Parameter, tags []*cloudformation.Tag) error {
+	_, err := cs.client.CreateChangeSet(&cloudformation.CreateChangeSetInput{
+		ChangeSetName: aws.String(cs.name),
+		StackName:     aws.String(cs.stackName),
+		ChangeSetType: aws.String(cloudformation.ChangeSetTypeCreate),
+		TemplateBody:  aws.String(template),
+		Parameters:    params,
+		Tags:          tags,
+		Capabilities: aws.StringSlice([]string{
+			cloudformation.CapabilityCapabilityIam,
+			cloudformation.CapabilityCapabilityNamedIam,
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("create %s: %w", cs, err)
+	}
+	err = cs.client.WaitUntilChangeSetCreateCompleteWithContext(context.Background(), &cloudformation.DescribeChangeSetInput{
+		ChangeSetName: aws.String(cs.name),
+		StackName:     aws.String(cs.stackName),
+	}, waiters...)
+	if err != nil {
+		return fmt.Errorf("wait for creation of %s: %w", cs, err)
+	}
+	return nil
+}
+
+// describe collects all the changes and statuses that the change set will apply and returns them.
+func (cs *changeSet) describe() (*changeSetDescription, error) {
+	var executionStatus, statusReason string
+	var changes []*cloudformation.Change
+	var nextToken *string
+	for {
+		out, err := cs.client.DescribeChangeSet(&cloudformation.DescribeChangeSetInput{
+			ChangeSetName: aws.String(cs.name),
+			StackName:     aws.String(cs.stackName),
+			NextToken:     nextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("describe %s: %w", cs, err)
+		}
+		executionStatus = aws.StringValue(out.ExecutionStatus)
+		statusReason = aws.StringValue(out.StatusReason)
+		changes = append(changes, out.Changes...)
+		nextToken = out.NextToken
+
+		if nextToken == nil { // no more results left
+			break
+		}
+	}
+	return &changeSetDescription{
+		executionStatus: executionStatus,
+		statusReason:    statusReason,
+		changes:         changes,
+	}, nil
+}
+
+// execute executes a created change set.
+func (cs *changeSet) execute() error {
+	descr, err := cs.describe()
+	if err != nil {
+		return err
+	}
+	if descr.executionStatus != cloudformation.ExecutionStatusAvailable {
+		// Ignore execute request if the change set does not contain any modifications.
+		if descr.statusReason == noChangesReason {
+			return nil
+		}
+		if descr.statusReason == noUpdatesReason {
+			return nil
+		}
+		return &errChangeSetNotExecutable{
+			cs:    cs,
+			descr: descr,
+		}
+	}
+	_, err = cs.client.ExecuteChangeSet(&cloudformation.ExecuteChangeSetInput{
+		ChangeSetName: aws.String(cs.name),
+		StackName:     aws.String(cs.stackName),
+	})
+	if err != nil {
+		return fmt.Errorf("execute %s: %w", cs, err)
+	}
+	return nil
+}
+
+// delete removes the change set.
+func (cs *changeSet) delete() error {
+	_, err := cs.client.DeleteChangeSet(&cloudformation.DeleteChangeSetInput{
+		ChangeSetName: aws.String(cs.name),
+		StackName:     aws.String(cs.stackName),
+	})
+	if err != nil {
+		return fmt.Errorf("delete %s: %w", cs, err)
+	}
+	return nil
+}

--- a/internal/pkg/aws/cloudformation/cloudformation.go
+++ b/internal/pkg/aws/cloudformation/cloudformation.go
@@ -1,0 +1,132 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cloudformation provides a client to make API requests to AWS CloudFormation.
+package cloudformation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+var waiters = []request.WaiterOption{
+	request.WithWaiterDelay(request.ConstantWaiterDelay(3 * time.Second)), // Poll for cfn updates every 3 seconds.
+	request.WithWaiterMaxAttempts(1800),                                   // Wait for at most 90 mins for any cfn action.
+}
+
+type api interface {
+	changeSetAPI
+
+	DescribeStacks(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+	DeleteStack(*cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error)
+	WaitUntilStackDeleteCompleteWithContext(aws.Context, *cloudformation.DescribeStacksInput, ...request.WaiterOption) error
+}
+
+// CloudFormation represents a client to make requests to AWS CloudFormation.
+type CloudFormation struct {
+	client api
+}
+
+// New creates a new CloudFormation client.
+func New(s *session.Session) *CloudFormation {
+	return &CloudFormation{
+		client: cloudformation.New(s),
+	}
+}
+
+// Create deploys a new CloudFormation stack.
+func (c *CloudFormation) Create(stack *Stack) error {
+	descr, err := c.describe(stack.name)
+	if err != nil {
+		var stackNotFound *errStackNotFound
+		if !errors.As(err, &stackNotFound) {
+			return err
+		}
+		// If the stack does not exist, create it.
+		return c.createChangeSet(stack)
+	}
+	status := stackStatus(aws.StringValue(descr.StackStatus))
+	if status.requiresCleanup() {
+		// If the stack exists, but failed to create, we'll clean it up and then re-create it.
+		if err := c.delete(stack.name); err != nil {
+			return fmt.Errorf("cleanup previously failed stack %s: %w", stack.name, err)
+		}
+		return c.createChangeSet(stack)
+	}
+	if status.inProgress() {
+		return &errStackUpdateInProgress{
+			name: stack.name,
+		}
+	}
+	return &ErrStackAlreadyExists{
+		name: stack.name,
+	}
+}
+
+func (c *CloudFormation) describe(name string) (*cloudformation.Stack, error) {
+	out, err := c.client.DescribeStacks(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(name),
+	})
+	if err != nil {
+		if stackDoesNotExist(err) {
+			return nil, &errStackNotFound{name: name}
+		}
+		return nil, err
+	}
+	if len(out.Stacks) == 0 {
+		return nil, &errStackNotFound{name: name}
+	}
+	return out.Stacks[0], nil
+}
+
+func (c *CloudFormation) delete(stackName string) error {
+	_, err := c.client.DeleteStack(&cloudformation.DeleteStackInput{
+		StackName: aws.String(stackName),
+	})
+	if err != nil {
+		if stackDoesNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("delete stack %s: %w", stackName, err)
+	}
+	err = c.client.WaitUntilStackDeleteCompleteWithContext(context.Background(), &cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	}, waiters...)
+	if err != nil {
+		return fmt.Errorf("wait until stack %s delete is complete: %w", stackName, err)
+	}
+	return nil
+}
+
+func (c *CloudFormation) createChangeSet(stack *Stack) error {
+	cs, err := newChangeSet(c.client, stack.name)
+	if err != nil {
+		return err
+	}
+	if err := cs.create(stack.template, stack.parameters, stack.tags); err != nil {
+		// It's possible that there are no changes between the previous and proposed stack change sets.
+		// We make a call to describe the change set to see if that is indeed the case and handle it gracefully.
+		descr, descrErr := cs.describe()
+		if descrErr != nil {
+			return descrErr
+		}
+		// The change set was empty - so we clean it up.
+		// We have to clean up the change set because there's a limit on the number
+		// of failed change sets a customer can have on a particular stack.
+		if len(descr.changes) == 0 {
+			cs.delete()
+			return &ErrChangeSetEmpty{
+				cs: cs,
+			}
+		}
+		return err
+	}
+	return cs.execute()
+}

--- a/internal/pkg/aws/cloudformation/errors.go
+++ b/internal/pkg/aws/cloudformation/errors.go
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+// ErrChangeSetEmpty occurs when the change set does not contain any new or updated resources.
+type ErrChangeSetEmpty struct {
+	cs *changeSet
+}
+
+func (e *ErrChangeSetEmpty) Error() string {
+	return fmt.Sprintf("change set with name %s for stack %s has no changes", e.cs.name, e.cs.stackName)
+}
+
+// ErrStackAlreadyExists occurs when a CloudFormation stack already exists with a given name.
+type ErrStackAlreadyExists struct {
+	name string
+}
+
+func (e *ErrStackAlreadyExists) Error() string {
+	return fmt.Sprintf("stack %s already exists", e.name)
+}
+
+// errStackNotFound occurs when a particular CloudFormation stack does not exist.
+type errStackNotFound struct {
+	name string
+}
+
+func (e *errStackNotFound) Error() string {
+	return fmt.Sprintf("stack named %s cannot be found", e.name)
+}
+
+// errChangeSetNotExecutable occurs when the change set cannot be executed.
+type errChangeSetNotExecutable struct {
+	cs    *changeSet
+	descr *changeSetDescription
+}
+
+func (e *errChangeSetNotExecutable) Error() string {
+	return fmt.Sprintf("execute change set %s for stack %s because status is %s with reason %s", e.cs.name, e.cs.stackName, e.descr.executionStatus, e.descr.statusReason)
+}
+
+// errStackUpdateInProgress occurs when we try to update a stack that's already being updated.
+type errStackUpdateInProgress struct {
+	name string
+}
+
+func (e *errStackUpdateInProgress) Error() string {
+	return fmt.Sprintf("stack %s is currently being updated and cannot be deployed to", e.name)
+}
+
+// stackDoesNotExist returns true if the underlying error is a stack doesn't exist.
+func stackDoesNotExist(err error) bool {
+	if aerr, ok := err.(awserr.Error); ok {
+		switch aerr.Code() {
+		case "ValidationError":
+			// A ValidationError occurs if we describe a stack which doesn't exist.
+			if strings.Contains(aerr.Message(), "does not exist") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/pkg/aws/cloudformation/stack.go
+++ b/internal/pkg/aws/cloudformation/stack.go
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+// Stack represents a AWS CloudFormation stack.
+type Stack struct {
+	name       string
+	template   string
+	parameters []*cloudformation.Parameter
+	tags       []*cloudformation.Tag
+}
+
+// StackOption allows you to initialize a Stack with additional properties.
+type StackOption func(s *Stack)
+
+// NewStack creates a stack with the given name and template body.
+func NewStack(name, template string, opts ...StackOption) *Stack {
+	s := &Stack{
+		name:     name,
+		template: template,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// WithParameters passes parameters to a stack.
+func WithParameters(params map[string]string) StackOption {
+	return func(s *Stack) {
+		var flatParams []*cloudformation.Parameter
+		for k, v := range params {
+			flatParams = append(flatParams, &cloudformation.Parameter{
+				ParameterKey:   aws.String(k),
+				ParameterValue: aws.String(v),
+			})
+		}
+		s.parameters = flatParams
+	}
+}
+
+// WithTags applies the tags to a stack.
+func WithTags(tags map[string]string) StackOption {
+	return func(s *Stack) {
+		var flatTags []*cloudformation.Tag
+		for k, v := range tags {
+			flatTags = append(flatTags, &cloudformation.Tag{
+				Key:   aws.String(k),
+				Value: aws.String(v),
+			})
+		}
+		s.tags = flatTags
+	}
+}

--- a/internal/pkg/aws/cloudformation/stackstatus.go
+++ b/internal/pkg/aws/cloudformation/stackstatus.go
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cloudformation
+
+import (
+	"strings"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+)
+
+type stackStatus string
+
+// requiresCleanup returns true if the stack was created, but failed and should be deleted.
+func (s stackStatus) requiresCleanup() bool {
+	return cloudformation.StackStatusRollbackComplete == string(s) || cloudformation.StackStatusRollbackFailed == string(s)
+}
+
+// inProgress returns true if the stack is currently being updated.
+func (s stackStatus) inProgress() bool {
+	return strings.HasSuffix(string(s), "IN_PROGRESS")
+}

--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package cloudwatchlogs contains utility functions for Cloudwatch Logs client.
+// Package cloudwatchlogs provides a client to make API requests to Amazon CloudWatch Logs.
 package cloudwatchlogs
 
 import (

--- a/internal/pkg/aws/ecr/ecr.go
+++ b/internal/pkg/aws/ecr/ecr.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package ecr contains utility functions for dealing with ECR repos
+// Package ecr provides a client to make API requests to Amazon EC2 Container Registry.
 package ecr
 
 import (

--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package ecs contains utility functions for dealing with ECS repos.
+// Package ecs provides a client to make API requests to Amazon Elastic Container Service.
 package ecs
 
 import (

--- a/internal/pkg/aws/identity/identity.go
+++ b/internal/pkg/aws/identity/identity.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package identity wraps AWS Security Token Service (STS) API functionality.
+// Package identity provides a client to make API requests to AWS Security Token Service.
 package identity
 
 import (

--- a/internal/pkg/aws/route53/route53.go
+++ b/internal/pkg/aws/route53/route53.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package route53 wraps AWS route 53 API functionality.
+// Package route53 provides functionality to manipulate route53 primitives.
 package route53
 
 import (

--- a/internal/pkg/aws/s3/s3.go
+++ b/internal/pkg/aws/s3/s3.go
@@ -1,7 +1,7 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package s3 contains utility functions for Amazon Simple Storage Service Client.
+// Package s3 provides a client to make API requests to Amazon Simple Storage Service.
 package s3
 
 import (

--- a/internal/pkg/aws/secretsmanager/secretsmanager.go
+++ b/internal/pkg/aws/secretsmanager/secretsmanager.go
@@ -1,7 +1,7 @@
 // Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Package secretsmanager wraps AWS SecretsManager API functionality.
+// Package secretsmanager provides a client to make API requests to AWS Secrets Manager.
 package secretsmanager
 
 import (


### PR DESCRIPTION
### Context
This is a WIP PR.   
The goal is to eventually move completely low-level CFN wrappers to `aws/cloudformation` from `deploy/cloudformation`. This way `deploy/cloudformation` will just be responsible to transform CLI structs into CFN structs and call the appropriate function in `aws/cloudformation`.

### What I'm looking for
I've only moved the `Create(stack)` method to `aws/cloudformation` to illustrate the package.   
1. Does the `Stack` struct input to `Create` make sense? This is different than our current version which accepts an **interface** instead. 
2. Are we happy with the direction of this package overall?  This package should not surface any `cloudformation` construct from the SDK to the clients instead we'll define our own CFN structs.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
