### PR TITLE
fix(cli): make app init idempotent

### DIFF
--- a/internal/pkg/store/app.go
+++ b/internal/pkg/store/app.go
@@ -13,8 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
-// CreateApplication instantiates a new application within an existing project. Returns ErrApplicationAlreadyExists
-// if the application already exists in the project.
+// CreateApplication instantiates a new application within an existing project. Skip if
+// the application already exists in the project.
 func (s *Store) CreateApplication(app *archer.Application) error {
 	if _, err := s.GetProject(app.Project); err != nil {
 		return err
@@ -36,9 +36,7 @@ func (s *Store) CreateApplication(app *archer.Application) error {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case ssm.ErrCodeParameterAlreadyExists:
-				return &ErrApplicationAlreadyExists{
-					ApplicationName: app.Name,
-					ProjectName:     app.Project}
+				return nil
 			}
 		}
 		return fmt.Errorf("create application %s in project %s: %w", app.Name, app.Project, err)

--- a/internal/pkg/store/app_test.go
+++ b/internal/pkg/store/app_test.go
@@ -264,10 +264,7 @@ func TestStore_CreateApplication(t *testing.T) {
 					},
 				}, nil
 			},
-			wantedErr: &ErrApplicationAlreadyExists{
-				ApplicationName: testApplication.Name,
-				ProjectName:     testApplication.Project,
-			},
+			wantedErr: nil,
 		},
 		"with SSM error": {
 			mockPutParameter: func(t *testing.T, param *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {

--- a/internal/pkg/store/errors.go
+++ b/internal/pkg/store/errors.go
@@ -89,27 +89,6 @@ func (e *ErrNoSuchEnvironment) Error() string {
 		e.EnvironmentName, e.ProjectName)
 }
 
-// ErrApplicationAlreadyExists means that an application is already created in a specific project.
-type ErrApplicationAlreadyExists struct {
-	ApplicationName string
-	ProjectName     string
-}
-
-// Is returns whether the provided error equals this error.
-func (e *ErrApplicationAlreadyExists) Is(target error) bool {
-	t, ok := target.(*ErrApplicationAlreadyExists)
-	if !ok {
-		return false
-	}
-	return e.ProjectName == t.ProjectName &&
-		e.ApplicationName == t.ApplicationName
-}
-
-func (e *ErrApplicationAlreadyExists) Error() string {
-	return fmt.Sprintf("application %s already exists in project %s",
-		e.ApplicationName, e.ProjectName)
-}
-
 // ErrNoSuchApplication means a specific application couldn't be found in a specific project.
 type ErrNoSuchApplication struct {
 	ProjectName     string

--- a/internal/pkg/store/errors_test.go
+++ b/internal/pkg/store/errors_test.go
@@ -164,34 +164,3 @@ func TestErrNoSuchApplication_Is(t *testing.T) {
 		})
 	}
 }
-
-func TestErrApplicationAlreadyExists(t *testing.T) {
-	err := &ErrApplicationAlreadyExists{ApplicationName: "api", ProjectName: "chicken"}
-	require.EqualError(t, err, "application api already exists in project chicken")
-}
-
-func TestErrApplicationAlreadyExists_Is(t *testing.T) {
-	err := &ErrApplicationAlreadyExists{ApplicationName: "api", ProjectName: "chicken"}
-	testCases := map[string]struct {
-		wantedSame bool
-		otherError error
-	}{
-		"errors are same": {
-			wantedSame: true,
-			otherError: &ErrApplicationAlreadyExists{ApplicationName: "api", ProjectName: "chicken"},
-		},
-		"errors have different values": {
-			wantedSame: false,
-			otherError: &ErrApplicationAlreadyExists{ApplicationName: "api", ProjectName: "rooster"},
-		},
-		"errors are different type": {
-			wantedSame: false,
-			otherError: errors.New("different error"),
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, err.Is(tc.otherError), tc.wantedSame)
-		})
-	}
-}

--- a/internal/pkg/store/store_integration_test.go
+++ b/internal/pkg/store/store_integration_test.go
@@ -115,10 +115,6 @@ func Test_SSM_Application_Integration(t *testing.T) {
 		err = s.CreateApplication(&feApplication)
 		require.NoError(t, err)
 
-		// Make sure we can't add a duplicate apps
-		err = s.CreateApplication(&apiApplication)
-		require.EqualError(t, &store.ErrApplicationAlreadyExists{ProjectName: projectToCreate.Name, ApplicationName: apiApplication.Name}, err.Error())
-
 		// Wait for consistency to kick in (ssm path commands are eventually consistent)
 		time.Sleep(5 * time.Second)
 

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -35,3 +35,12 @@ type ErrWorkspaceHasExistingProject struct {
 func (e *ErrWorkspaceHasExistingProject) Error() string {
 	return fmt.Sprintf("this workspace is already registered with project %s", e.ExistingProjectName)
 }
+
+// ErrFileExists means we tried to create an existing file.
+type ErrFileExists struct {
+	FileName string
+}
+
+func (e *ErrFileExists) Error() string {
+	return fmt.Sprintf("file %s already exists", e.FileName)
+}

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -151,7 +151,6 @@ func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
 }
 
 // WriteAppManifest writes the application manifest under the project directory.
-// If successful returns the full path of the file, otherwise returns an empty string and the error.
 func (ws *Workspace) WriteAppManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error) {
 	data, err := marshaler.MarshalBinary()
 	if err != nil {
@@ -295,7 +294,6 @@ func (ws *Workspace) projectDirPath() (string, error) {
 }
 
 // write flushes the data to a file under the project directory joined by path elements.
-// If successful returns the full path of the file, otherwise returns an empty string and the error.
 func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
 	projectPath, err := ws.projectDirPath()
 	if err != nil {
@@ -305,10 +303,17 @@ func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
 	filename := filepath.Join(pathElems...)
 
 	if err := ws.fsUtils.MkdirAll(filepath.Dir(filename), 0755 /* -rwxr-xr-x */); err != nil {
-		return "", fmt.Errorf("failed to create directories for file %s: %w", filename, err)
+		return "", fmt.Errorf("create directories for file %s: %w", filename, err)
+	}
+	exist, err := ws.fsUtils.Exists(filename)
+	if err != nil {
+		return "", fmt.Errorf("check if manifest file %s exists: %w", filename, err)
+	}
+	if exist {
+		return "", &ErrFileExists{FileName: filename}
 	}
 	if err := ws.fsUtils.WriteFile(filename, data, 0644 /* -rw-r--r-- */); err != nil {
-		return "", fmt.Errorf("failed to write manifest file: %w", err)
+		return "", fmt.Errorf("write manifest file: %w", err)
 	}
 	return filename, nil
 }

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -361,19 +361,25 @@ func TestWorkspace_Write(t *testing.T) {
 			elems:      []string{pipelineFileName},
 			wantedPath: "/ecs-project/pipeline.yml",
 		},
+		"return ErrFileExists if file already exists": {
+			elems:     []string{"manifest.yml"},
+			wantedErr: &ErrFileExists{FileName: "/ecs-project/manifest.yml"},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
 			fs := afero.NewMemMapFs()
-			fs.MkdirAll("/ecs-project", 0755)
+			utils := &afero.Afero{
+				Fs: fs,
+			}
+			utils.MkdirAll("/ecs-project", 0755)
+			utils.WriteFile("/ecs-project/manifest.yml", []byte{}, 0644)
 			ws := &Workspace{
 				workingDir: "/",
 				projectDir: "/ecs-project",
-				fsUtils: &afero.Afero{
-					Fs: fs,
-				},
+				fsUtils:    utils,
 			}
 
 			// WHEN


### PR DESCRIPTION
<!-- Provide summary of changes -->
fix #552.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
## Manual test

Suppose we already have created an application named "my-app". Then I run the following command again:

```
$ archer app init
Note: It's best to run this command in the root of your workspace.

? Which type of infrastructure pattern best represents your application? Load Balanced Web App

? What do you want to name this Load Balanced Web App? my-app

? Which Dockerfile would you like to use for my-app? ./Dockerfile

? What port do you want requests from your load balancer forwarded to? 80

✔ Skip writing since the manifest for my-app app already exists at ecs-project/my-app/manifest.yml
Your manifest contains configurations like your container size and ports.

✔ Created ECR repositories for application my-app.
Recommended follow-up actions:
- Update your manifest ecs-project/my-app/manifest.yml to change the defaults.
- Run `ecs-preview app deploy --name my-app --env test` to deploy your application to a test environment.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
