### PR TITLE
feat(ecs): add Service and Task struct

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -6,31 +6,70 @@ package ecs
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
+const (
+	shortTaskIDLength      = 7
+	shortImageDigestLength = 7
+	imageDigestPrefix      = "sha256:"
+)
+
 type ecsClient interface {
+	DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
 	DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error)
+	DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error)
+	ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
 }
 
-// Service wraps an AWS ECS client.
-type Service struct {
-	ecs ecsClient
+// ECS wraps an AWS ECS client.
+type ECS struct {
+	client ecsClient
+}
+
+// TaskDefinition wraps up ECS TaskDefinition struct.
+type TaskDefinition ecs.TaskDefinition
+
+// Service wraps up ECS Service struct.
+type Service ecs.Service
+
+// Task wraps up ECS Task struct.
+type Task ecs.Task
+
+// ServiceStatus contains the status info of a service.
+type ServiceStatus struct {
+	DesiredCount int64
+	RunningCount int64
+	Status       string
+}
+
+// TaskStatus contains the status info of a task
+type TaskStatus struct {
+	DesiredStatus string
+	ID            string
+	Image         string
+	ImageDigest   string
+	LastStatus    string
+	StartedAt     int64
+	StoppedAt     int64
+	StoppedReason string
 }
 
 // New returns a Service configured against the input session.
-func New(s *session.Session) *Service {
-	return &Service{
-		ecs: ecs.New(s),
+func New(s *session.Session) *ECS {
+	return &ECS{
+		client: ecs.New(s),
 	}
 }
 
 // TaskDefinition calls ECS API and returns the task definition.
-func (s Service) TaskDefinition(taskDefName string) (*TaskDefinition, error) {
-	resp, err := s.ecs.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+func (e *ECS) TaskDefinition(taskDefName string) (*TaskDefinition, error) {
+	resp, err := e.client.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefName),
 	})
 	if err != nil {
@@ -40,8 +79,90 @@ func (s Service) TaskDefinition(taskDefName string) (*TaskDefinition, error) {
 	return &td, nil
 }
 
-// TaskDefinition wraps up ECS TaskDefinition struct.
-type TaskDefinition ecs.TaskDefinition
+// Service calls ECS API and returns the specified service running in the cluster.
+func (e *ECS) Service(clusterName, serviceName string) (*Service, error) {
+	resp, err := e.client.DescribeServices(&ecs.DescribeServicesInput{
+		Cluster:  aws.String(clusterName),
+		Services: aws.StringSlice([]string{serviceName}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe service %s: %w", serviceName, err)
+	}
+	for _, service := range resp.Services {
+		if aws.StringValue(service.ServiceName) == serviceName {
+			svc := Service(*service)
+			return &svc, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find service %s", serviceName)
+}
+
+// Tasks calls ECS API and returns ECS tasks running in the cluster.
+func (e *ECS) Tasks(clusterName, serviceName string) ([]*Task, error) {
+	var tasks []*Task
+	listTaskResp := &ecs.ListTasksOutput{}
+	for {
+		listTaskResp, err := e.client.ListTasks(&ecs.ListTasksInput{
+			Cluster:     aws.String(clusterName),
+			ServiceName: aws.String(serviceName),
+			NextToken:   listTaskResp.NextToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("list running tasks of service %s: %w", serviceName, err)
+		}
+		descTaskResp, err := e.client.DescribeTasks(&ecs.DescribeTasksInput{
+			Cluster: aws.String(clusterName),
+			Tasks:   listTaskResp.TaskArns,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("describe running tasks in cluster %s: %w", clusterName, err)
+		}
+		for _, task := range descTaskResp.Tasks {
+			t := Task(*task)
+			tasks = append(tasks, &t)
+		}
+		if listTaskResp.NextToken == nil {
+			break
+		}
+	}
+	return tasks, nil
+}
+
+// TaskStatus returns the status of the running task.
+func (t *Task) TaskStatus() (*TaskStatus, error) {
+	taskID, err := taskIDParser(aws.StringValue(t.TaskArn))
+	if err != nil {
+		return nil, err
+	}
+	var stoppedAt int64
+	var stoppedReason string
+	if t.StoppedAt != nil {
+		stoppedAt = t.StoppedAt.Unix()
+	}
+	if t.StoppedReason != nil {
+		stoppedReason = aws.StringValue(t.StoppedReason)
+	}
+	return &TaskStatus{
+		DesiredStatus: aws.StringValue(t.DesiredStatus),
+		ID:            taskID,
+		// assume only have one container
+		Image:         aws.StringValue(t.Containers[0].Image),
+		ImageDigest:   imageDigestParser(aws.StringValue(t.Containers[0].ImageDigest)),
+		LastStatus:    aws.StringValue(t.LastStatus),
+		StartedAt:     t.StartedAt.Unix(),
+		StoppedAt:     stoppedAt,
+		StoppedReason: stoppedReason,
+	}, nil
+}
+
+// ServiceStatus returns the status of the running service.
+func (s *Service) ServiceStatus() ServiceStatus {
+	return ServiceStatus{
+		Status:       aws.StringValue(s.Status),
+		DesiredCount: aws.Int64Value(s.DesiredCount),
+		RunningCount: aws.Int64Value(s.RunningCount),
+	}
+}
 
 // EnvironmentVariables returns environment variables of the task definition.
 func (t *TaskDefinition) EnvironmentVariables() map[string]string {
@@ -50,4 +171,24 @@ func (t *TaskDefinition) EnvironmentVariables() map[string]string {
 		envs[aws.StringValue(env.Name)] = aws.StringValue(env.Value)
 	}
 	return envs
+}
+
+// taskIDParser parses the task ARN and returns the short task ID.
+// For example: arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d
+// becomes 4082490.
+func taskIDParser(taskArn string) (string, error) {
+	parsedArn, err := arn.Parse(taskArn)
+	if err != nil {
+		return "", fmt.Errorf("parse task ARN %s: %w", taskArn, err)
+	}
+	resources := strings.Split(parsedArn.Resource, "/")
+	taskID := resources[len(resources)-1]
+	return taskID[:shortTaskIDLength], nil
+}
+
+// imageDigestParser returns the short image digest.
+// For example: sha256:18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7
+// becomes 18f7eb6c.
+func imageDigestParser(imageDigest string) string {
+	return strings.TrimPrefix(imageDigest, imageDigestPrefix)[:shortImageDigestLength]
 }

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package ecs
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/ecs/mocks"
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestService_TaskDefinition(t *testing.T) {
+func TestECS_TaskDefinition(t *testing.T) {
 	mockError := errors.New("error")
 
 	testCases := map[string]struct {
@@ -102,6 +103,231 @@ func TestService_TaskDefinition(t *testing.T) {
 	}
 }
 
+func TestECS_Service(t *testing.T) {
+	testCases := map[string]struct {
+		clusterName   string
+		serviceName   string
+		mockECSClient func(m *mocks.MockecsClient)
+
+		wantErr error
+		wantSvc *Service
+	}{
+		"success": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  aws.String("mockCluster"),
+					Services: aws.StringSlice([]string{"mockService"}),
+				}).Return(&ecs.DescribeServicesOutput{
+					Services: []*ecs.Service{
+						&ecs.Service{
+							ServiceName: aws.String("mockService"),
+						},
+					},
+				}, nil)
+			},
+			wantSvc: &Service{
+				ServiceName: aws.String("mockService"),
+			},
+		},
+		"errors if failed to describe service": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  aws.String("mockCluster"),
+					Services: aws.StringSlice([]string{"mockService"}),
+				}).Return(nil, errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("describe service mockService: some error"),
+		},
+		"errors if failed to find the service": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().DescribeServices(&ecs.DescribeServicesInput{
+					Cluster:  aws.String("mockCluster"),
+					Services: aws.StringSlice([]string{"mockService"}),
+				}).Return(&ecs.DescribeServicesOutput{
+					Services: []*ecs.Service{
+						&ecs.Service{
+							ServiceName: aws.String("badMockService"),
+						},
+					},
+				}, nil)
+			},
+			wantErr: fmt.Errorf("cannot find service mockService"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockecsClient(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			service := ECS{
+				client: mockECSClient,
+			}
+
+			gotSvc, gotErr := service.Service(tc.clusterName, tc.serviceName)
+
+			if gotErr != nil {
+				require.EqualError(t, tc.wantErr, gotErr.Error())
+			} else {
+				require.Equal(t, tc.wantSvc, gotSvc)
+			}
+		})
+
+	}
+}
+
+func TestECS_Tasks(t *testing.T) {
+	testCases := map[string]struct {
+		clusterName   string
+		serviceName   string
+		mockECSClient func(m *mocks.MockecsClient)
+
+		wantErr   error
+		wantTasks []*Task
+	}{
+		"errors if failed to list running tasks": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().ListTasks(&ecs.ListTasksInput{
+					Cluster:     aws.String("mockCluster"),
+					ServiceName: aws.String("mockService"),
+				}).Return(nil, errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("list running tasks of service mockService: some error"),
+		},
+		"errors if failed to describe running tasks": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().ListTasks(&ecs.ListTasksInput{
+					Cluster:     aws.String("mockCluster"),
+					ServiceName: aws.String("mockService"),
+				}).Return(&ecs.ListTasksOutput{
+					NextToken: nil,
+					TaskArns:  aws.StringSlice([]string{"mockTaskArn"}),
+				}, nil)
+				m.EXPECT().DescribeTasks(&ecs.DescribeTasksInput{
+					Cluster: aws.String("mockCluster"),
+					Tasks:   aws.StringSlice([]string{"mockTaskArn"}),
+				}).Return(nil, errors.New("some error"))
+			},
+			wantErr: fmt.Errorf("describe running tasks in cluster mockCluster: some error"),
+		},
+		"success": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().ListTasks(&ecs.ListTasksInput{
+					Cluster:     aws.String("mockCluster"),
+					ServiceName: aws.String("mockService"),
+				}).Return(&ecs.ListTasksOutput{
+					NextToken: nil,
+					TaskArns:  aws.StringSlice([]string{"mockTaskArn"}),
+				}, nil)
+				m.EXPECT().DescribeTasks(&ecs.DescribeTasksInput{
+					Cluster: aws.String("mockCluster"),
+					Tasks:   aws.StringSlice([]string{"mockTaskArn"}),
+				}).Return(&ecs.DescribeTasksOutput{
+					Tasks: []*ecs.Task{
+						&ecs.Task{
+							TaskArn: aws.String("mockTaskArn"),
+						},
+					},
+				}, nil)
+			},
+			wantTasks: []*Task{
+				&Task{
+					TaskArn: aws.String("mockTaskArn"),
+				},
+			},
+		},
+		"success with pagination": {
+			clusterName: "mockCluster",
+			serviceName: "mockService",
+			mockECSClient: func(m *mocks.MockecsClient) {
+				m.EXPECT().ListTasks(&ecs.ListTasksInput{
+					Cluster:     aws.String("mockCluster"),
+					ServiceName: aws.String("mockService"),
+				}).Return(&ecs.ListTasksOutput{
+					NextToken: aws.String("mockNextToken"),
+					TaskArns:  aws.StringSlice([]string{"mockTaskArn1"}),
+				}, nil)
+				m.EXPECT().DescribeTasks(&ecs.DescribeTasksInput{
+					Cluster: aws.String("mockCluster"),
+					Tasks:   aws.StringSlice([]string{"mockTaskArn1"}),
+				}).Return(&ecs.DescribeTasksOutput{
+					Tasks: []*ecs.Task{
+						&ecs.Task{
+							TaskArn: aws.String("mockTaskArn1"),
+						},
+					},
+				}, nil)
+				m.EXPECT().ListTasks(&ecs.ListTasksInput{
+					Cluster:     aws.String("mockCluster"),
+					ServiceName: aws.String("mockService"),
+					NextToken:   aws.String("mockNextToken"),
+				}).Return(&ecs.ListTasksOutput{
+					NextToken: nil,
+					TaskArns:  aws.StringSlice([]string{"mockTaskArn2"}),
+				}, nil)
+				m.EXPECT().DescribeTasks(&ecs.DescribeTasksInput{
+					Cluster: aws.String("mockCluster"),
+					Tasks:   aws.StringSlice([]string{"mockTaskArn2"}),
+				}).Return(&ecs.DescribeTasksOutput{
+					Tasks: []*ecs.Task{
+						&ecs.Task{
+							TaskArn: aws.String("mockTaskArn2"),
+						},
+					},
+				}, nil)
+			},
+			wantTasks: []*Task{
+				&Task{
+					TaskArn: aws.String("mockTaskArn1"),
+				},
+				&Task{
+					TaskArn: aws.String("mockTaskArn2"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockECSClient := mocks.NewMockecsClient(ctrl)
+			tc.mockECSClient(mockECSClient)
+
+			service := ECS{
+				client: mockECSClient,
+			}
+
+			gotTasks, gotErr := service.Tasks(tc.clusterName, tc.serviceName)
+
+			if gotErr != nil {
+				require.EqualError(t, tc.wantErr, gotErr.Error())
+			} else {
+				require.Equal(t, tc.wantTasks, gotTasks)
+			}
+		})
+
+	}
+}
+
 func TestTaskDefinition_EnvVars(t *testing.T) {
 	testCases := map[string]struct {
 		inContainers []*ecs.ContainerDefinition
@@ -144,6 +370,101 @@ func TestTaskDefinition_EnvVars(t *testing.T) {
 			gotEnvVars := taskDefinition.EnvironmentVariables()
 
 			require.Equal(t, tc.wantEnvVars, gotEnvVars)
+		})
+
+	}
+}
+
+func TestTask_TaskStatus(t *testing.T) {
+	startTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+00:00")
+	stopTime, _ := time.Parse(time.RFC3339, "2006-01-02T16:04:05+00:00")
+	testCases := map[string]struct {
+		desiredStatus *string
+		taskArn       *string
+		containers    []*ecs.Container
+		lastStatus    *string
+		startedAt     *time.Time
+		stoppedAt     *time.Time
+		stoppedReason *string
+
+		wantTaskStatus *TaskStatus
+		wantErr        error
+	}{
+		"errors if failed to parse task ID": {
+			taskArn: aws.String("badTaskArn"),
+			wantErr: fmt.Errorf("arn: invalid prefix"),
+		},
+		"success with a running task": {
+			taskArn: aws.String("arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d"),
+			containers: []*ecs.Container{
+				&ecs.Container{
+					Image:       aws.String("mockImageArn"),
+					ImageDigest: aws.String("sha256:18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7"),
+				},
+			},
+			desiredStatus: aws.String("ACTIVE"),
+			lastStatus:    aws.String("UNKNOWN"),
+			startedAt:     &startTime,
+
+			wantTaskStatus: &TaskStatus{
+				DesiredStatus: "ACTIVE",
+				ID:            "4082490",
+				Images:        []string{"mockImageArn"},
+				ImageDigests:  []string{"18f7eb6"},
+				LastStatus:    "UNKNOWN",
+				StartedAt:     1136214245,
+			},
+		},
+		"success with a stopped task": {
+			taskArn: aws.String("arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d"),
+			containers: []*ecs.Container{
+				&ecs.Container{
+					Image:       aws.String("mockImageArn"),
+					ImageDigest: aws.String("sha256:18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7"),
+				},
+			},
+			desiredStatus: aws.String("ACTIVE"),
+			lastStatus:    aws.String("UNKNOWN"),
+			startedAt:     &startTime,
+			stoppedAt:     &stopTime,
+			stoppedReason: aws.String("some reason"),
+
+			wantTaskStatus: &TaskStatus{
+				DesiredStatus: "ACTIVE",
+				ID:            "4082490",
+				Images:        []string{"mockImageArn"},
+				ImageDigests:  []string{"18f7eb6"},
+				LastStatus:    "UNKNOWN",
+				StartedAt:     1136214245,
+				StoppedAt:     1136217845,
+				StoppedReason: "some reason",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			task := Task{
+				DesiredStatus: tc.desiredStatus,
+				TaskArn:       tc.taskArn,
+				Containers:    tc.containers,
+				LastStatus:    tc.lastStatus,
+				StartedAt:     tc.startedAt,
+				StoppedAt:     tc.stoppedAt,
+				StoppedReason: tc.stoppedReason,
+			}
+
+			gotTaskStatus, gotErr := task.TaskStatus()
+
+			if gotErr != nil {
+				require.EqualError(t, tc.wantErr, gotErr.Error())
+			} else {
+				require.Equal(t, tc.wantTaskStatus, gotTaskStatus)
+			}
 		})
 
 	}

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -316,7 +316,7 @@ func TestECS_Tasks(t *testing.T) {
 				client: mockECSClient,
 			}
 
-			gotTasks, gotErr := service.Tasks(tc.clusterName, tc.serviceName)
+			gotTasks, gotErr := service.ServiceTasks(tc.clusterName, tc.serviceName)
 
 			if gotErr != nil {
 				require.EqualError(t, tc.wantErr, gotErr.Error())

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -86,8 +86,8 @@ func TestService_TaskDefinition(t *testing.T) {
 			mockECSClient := mocks.NewMockecsClient(ctrl)
 			tc.mockECSClient(mockECSClient)
 
-			service := Service{
-				ecs: mockECSClient,
+			service := ECS{
+				client: mockECSClient,
 			}
 
 			gotTaskDef, gotErr := service.TaskDefinition(tc.taskDefinitionName)

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -409,10 +409,14 @@ func TestTask_TaskStatus(t *testing.T) {
 			wantTaskStatus: &TaskStatus{
 				DesiredStatus: "ACTIVE",
 				ID:            "4082490",
-				Images:        []string{"mockImageArn"},
-				ImageDigests:  []string{"18f7eb6"},
-				LastStatus:    "UNKNOWN",
-				StartedAt:     1136214245,
+				Images: []Image{
+					Image{
+						Digest: "18f7eb6",
+						ID:     "mockImageArn",
+					},
+				},
+				LastStatus: "UNKNOWN",
+				StartedAt:  1136214245,
 			},
 		},
 		"success with a stopped task": {
@@ -432,8 +436,12 @@ func TestTask_TaskStatus(t *testing.T) {
 			wantTaskStatus: &TaskStatus{
 				DesiredStatus: "ACTIVE",
 				ID:            "4082490",
-				Images:        []string{"mockImageArn"},
-				ImageDigests:  []string{"18f7eb6"},
+				Images: []Image{
+					Image{
+						Digest: "18f7eb6",
+						ID:     "mockImageArn",
+					},
+				},
 				LastStatus:    "UNKNOWN",
 				StartedAt:     1136214245,
 				StoppedAt:     1136217845,

--- a/internal/pkg/aws/ecs/mocks/mock_ecs.go
+++ b/internal/pkg/aws/ecs/mocks/mock_ecs.go
@@ -33,6 +33,21 @@ func (m *MockecsClient) EXPECT() *MockecsClientMockRecorder {
 	return m.recorder
 }
 
+// DescribeTasks mocks base method
+func (m *MockecsClient) DescribeTasks(input *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTasks", input)
+	ret0, _ := ret[0].(*ecs.DescribeTasksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTasks indicates an expected call of DescribeTasks
+func (mr *MockecsClientMockRecorder) DescribeTasks(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasks", reflect.TypeOf((*MockecsClient)(nil).DescribeTasks), input)
+}
+
 // DescribeTaskDefinition mocks base method
 func (m *MockecsClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
 	m.ctrl.T.Helper()
@@ -46,4 +61,34 @@ func (m *MockecsClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinition
 func (mr *MockecsClientMockRecorder) DescribeTaskDefinition(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskDefinition", reflect.TypeOf((*MockecsClient)(nil).DescribeTaskDefinition), input)
+}
+
+// DescribeServices mocks base method
+func (m *MockecsClient) DescribeServices(input *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeServices", input)
+	ret0, _ := ret[0].(*ecs.DescribeServicesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeServices indicates an expected call of DescribeServices
+func (mr *MockecsClientMockRecorder) DescribeServices(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeServices", reflect.TypeOf((*MockecsClient)(nil).DescribeServices), input)
+}
+
+// ListTasks mocks base method
+func (m *MockecsClient) ListTasks(input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTasks", input)
+	ret0, _ := ret[0].(*ecs.ListTasksOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTasks indicates an expected call of ListTasks
+func (mr *MockecsClientMockRecorder) ListTasks(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockecsClient)(nil).ListTasks), input)
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Add Service and Task struct to `ecs` package, so that we can get the info for ECS service and its running tasks. This PR also fixes #751 and #752.

Note that unit tests will be added later.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
