### PR TITLE
fix: name flags in example of help menu

### DIFF
--- a/internal/pkg/cli/app_show.go
+++ b/internal/pkg/cli/app_show.go
@@ -300,7 +300,7 @@ func BuildAppShowCmd() *cobra.Command {
 
 		Example: `
   Shows info about the application "my-app"
-  /code $ ecs-preview app show -a my-app`,
+  /code $ ecs-preview app show -n my-app`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newShowAppOpts(vars)
 			if err != nil {

--- a/internal/pkg/cli/project_show.go
+++ b/internal/pkg/cli/project_show.go
@@ -162,7 +162,7 @@ func BuildProjectShowCmd() *cobra.Command {
 		Long:  "Shows configuration, environments and applications for a project.",
 		Example: `
   Shows info about the project "my-project"
-  /code $ ecs-preview project show -p my-project`,
+  /code $ ecs-preview project show -n my-project`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newShowProjectOpts(vars)
 			if err != nil {


### PR DESCRIPTION
For consistency, we changed the flags `--project` and `-p`, as well as `--app` and `-a` in project_show and app_show, respectively, to `--name` and `-n` (PR # 773). Here, I changed the flag in the example command of the help menu to reflect this change.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
