### PR TITLE
chore: fix spacing for app init example

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -345,7 +345,7 @@ func BuildAppInitCmd() *cobra.Command {
 This command is also run as part of "ecs-preview init".`,
 		Example: `
   Create a "frontend" web application.
-	/code $ ecs-preview app init --name frontend --app-type "Load Balanced Web App" --dockerfile ./frontend/Dockerfile`,
+  /code $ ecs-preview app init --name frontend --app-type "Load Balanced Web App" --dockerfile ./frontend/Dockerfile`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newInitAppOpts(vars)
 			if err != nil {


### PR DESCRIPTION
The example was spaced with a tab character instead of two spaces and it looked awkward.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
