### PR TITLE
fix(cli): fix the bug for panic when startedAt is nil

### DIFF
--- a/internal/pkg/aws/ecs/ecs.go
+++ b/internal/pkg/aws/ecs/ecs.go
@@ -142,10 +142,13 @@ func (t *Task) TaskStatus() (*TaskStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	var stoppedAt int64
+	var startedAt, stoppedAt int64
 	var stoppedReason string
 	if t.StoppedAt != nil {
 		stoppedAt = t.StoppedAt.Unix()
+	}
+	if t.StartedAt != nil {
+		startedAt = t.StartedAt.Unix()
 	}
 	if t.StoppedReason != nil {
 		stoppedReason = aws.StringValue(t.StoppedReason)
@@ -162,7 +165,7 @@ func (t *Task) TaskStatus() (*TaskStatus, error) {
 		ID:            taskID,
 		Images:        images,
 		LastStatus:    aws.StringValue(t.LastStatus),
-		StartedAt:     t.StartedAt.Unix(),
+		StartedAt:     startedAt,
 		StoppedAt:     stoppedAt,
 		StoppedReason: stoppedReason,
 	}, nil

--- a/internal/pkg/aws/ecs/ecs_test.go
+++ b/internal/pkg/aws/ecs/ecs_test.go
@@ -394,6 +394,29 @@ func TestTask_TaskStatus(t *testing.T) {
 			taskArn: aws.String("badTaskArn"),
 			wantErr: fmt.Errorf("arn: invalid prefix"),
 		},
+		"success with a provisioning task": {
+			taskArn: aws.String("arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d"),
+			containers: []*ecs.Container{
+				{
+					Image:       aws.String("mockImageArn"),
+					ImageDigest: aws.String("sha256:18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7"),
+				},
+			},
+			desiredStatus: aws.String("ACTIVE"),
+			lastStatus:    aws.String("UNKNOWN"),
+
+			wantTaskStatus: &TaskStatus{
+				DesiredStatus: "ACTIVE",
+				ID:            "4082490ee6c245e09d2145010aa1ba8d",
+				Images: []Image{
+					{
+						Digest: "18f7eb6cff6e63e5f5273fb53f672975fe6044580f66c354f55d2de8dd28aec7",
+						ID:     "mockImageArn",
+					},
+				},
+				LastStatus: "UNKNOWN",
+			},
+		},
 		"success with a running task": {
 			taskArn: aws.String("arn:aws:ecs:us-west-2:123456789:task/my-project-test-Cluster-9F7Y0RLP60R7/4082490ee6c245e09d2145010aa1ba8d"),
 			containers: []*ecs.Container{


### PR DESCRIPTION
<!-- Provide summary of changes -->
Quick fix the bug that app-status panics when task status "startedAt" is nil. Thanks @kohidave for finding the bug!

When running `app status` at the app deployment stage, golang panics:

```
[ecs-kudos-api] ecs-v2 app status                                                                                                                                                                          master  ✭
Only found one deployed app, defaulting to: api (test)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1abf342]

goroutine 1 [running]:
github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/ecs.(*Task).TaskStatus(0xc000030f20, 0xc0000f222e, 0x22, 0xc0000f2251)
        /Users/killmond/Dev/amazon-ecs-cli-v2/internal/pkg/aws/ecs/ecs.go:165 +0x412
github.com/aws/amazon-ecs-cli-v2/internal/pkg/describe.(*WebAppStatus).Describe(0xc000317da0, 0x0, 0x0, 0x0)
        /Users/killmond/Dev/amazon-ecs-cli-v2/internal/pkg/describe/status.go:90 +0x4d8
github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli.(*appStatusOpts).Execute(0xc00012d200, 0x0, 0x0)
        /Users/killmond/Dev/amazon-ecs-cli-v2/internal/pkg/cli/app_status.go:124 +0x71
github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli.BuildAppStatusCmd.func1(0xc000289340, 0x2f16468, 0x0, 0x0, 0xc000275d30, 0x0)
        /Users/killmond/Dev/amazon-ecs-cli-v2/internal/pkg/cli/app_status.go:301 +0xef
github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli.runCmdE.func1(0xc000289340, 0x2f16468, 0x0, 0x0, 0x0, 0x0)
        /Users/killmond/Dev/amazon-ecs-cli-v2/internal/pkg/cli/cli.go:105 +0x72
github.com/spf13/cobra.(*Command).execute(0xc000289340, 0x2f16468, 0x0, 0x0, 0xc000289340, 0x2f16468)
        /Users/killmond/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:838 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000d9080, 0x0, 0x0, 0xc000098058)
        /Users/killmond/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:943 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/killmond/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:883
main.main()
        /Users/killmond/Dev/amazon-ecs-cli-v2/cmd/ecs-preview/main.go:25 +0x27
```
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
