### PR TITLE
chore: extract common sections across app types into separate dir

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/lb_fargate_app.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_fargate_app.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	lbFargateAppTemplatePath              = "applications/lb-web-app/cf.yml"
+	lbFargateAppTemplateName              = "lb-web-app"
 	lbFargateAppParamsPath                = "applications/params.json.tmpl"
 	lbFargateAppRulePriorityGeneratorPath = "custom-resources/alb-rule-priority-generator.js"
 )
@@ -48,7 +48,7 @@ type templater interface {
 type LBFargateStackConfig struct {
 	*deploy.CreateLBFargateAppInput
 	httpsEnabled bool
-	parser       template.ReadParser
+	parser       template.AppTemplateReadParser
 	addons       templater
 }
 
@@ -97,7 +97,7 @@ func (c *LBFargateStackConfig) Template() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	content, err := c.parser.Parse(lbFargateAppTemplatePath, struct {
+	content, err := c.parser.ParseAppTemplate("lb-web-app", struct {
 		RulePriorityLambda string
 		AddonsOutputs      []addons.Output
 		*lbFargateTemplateParams

--- a/internal/pkg/deploy/cloudformation/stack/lb_fargate_app.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_fargate_app.go
@@ -97,7 +97,7 @@ func (c *LBFargateStackConfig) Template() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	content, err := c.parser.ParseAppTemplate("lb-web-app", struct {
+	content, err := c.parser.ParseAppTemplate(lbFargateAppTemplateName, struct {
 		RulePriorityLambda string
 		AddonsOutputs      []addons.Output
 		*lbFargateTemplateParams

--- a/internal/pkg/deploy/cloudformation/stack/lb_fargate_app_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_fargate_app_test.go
@@ -113,7 +113,7 @@ func TestLBFargateStackConfig_Template(t *testing.T) {
 	}{
 		"unavailable rule priority lambda template": {
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Read(lbFargateAppRulePriorityGeneratorPath).Return(nil, errors.New("some error"))
 				c.parser = m
 			},
@@ -123,7 +123,7 @@ func TestLBFargateStackConfig_Template(t *testing.T) {
 		"unexpected addons parsing error": {
 			in: mockLBFargateAppInput,
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Read(lbFargateAppRulePriorityGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
 				addons := mockTemplater{err: errors.New("some error")}
 				c.parser = m
@@ -135,9 +135,9 @@ func TestLBFargateStackConfig_Template(t *testing.T) {
 		"failed parsing app template": {
 			in: mockLBFargateAppInput,
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Read(lbFargateAppRulePriorityGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("something")}, nil)
-				m.EXPECT().Parse(lbFargateAppTemplatePath, gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
+				m.EXPECT().ParseAppTemplate(lbFargateAppTemplateName, gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
 				addons := mockTemplater{
 					tpl: `Outputs:
   AdditionalResourcesPolicyArn:
@@ -153,9 +153,9 @@ func TestLBFargateStackConfig_Template(t *testing.T) {
 		"render template without addons": {
 			in: mockLBFargateAppInput,
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Read(lbFargateAppRulePriorityGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("lambda")}, nil)
-				m.EXPECT().Parse(lbFargateAppTemplatePath, struct {
+				m.EXPECT().ParseAppTemplate(lbFargateAppTemplateName, struct {
 					RulePriorityLambda string
 					AddonsOutputs      []addons.Output
 					*lbFargateTemplateParams
@@ -174,9 +174,9 @@ func TestLBFargateStackConfig_Template(t *testing.T) {
 		"render template with addons": {
 			in: mockLBFargateAppInput,
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Read(lbFargateAppRulePriorityGeneratorPath).Return(&template.Content{Buffer: bytes.NewBufferString("lambda")}, nil)
-				m.EXPECT().Parse(lbFargateAppTemplatePath, struct {
+				m.EXPECT().ParseAppTemplate(lbFargateAppTemplateName, struct {
 					RulePriorityLambda string
 					AddonsOutputs      []addons.Output
 					*lbFargateTemplateParams
@@ -354,7 +354,7 @@ func TestLBFargateStackConfig_SerializedParameters(t *testing.T) {
 				ImageTag:     "manual-bf3678c",
 			},
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Parse(lbFargateAppParamsPath, gomock.Any(), gomock.Any()).Return(nil, errors.New("some error"))
 				c.parser = m
 			},
@@ -385,7 +385,7 @@ func TestLBFargateStackConfig_SerializedParameters(t *testing.T) {
 				},
 			},
 			mockDependencies: func(ctrl *gomock.Controller, c *LBFargateStackConfig) {
-				m := mocks.NewMockReadParser(ctrl)
+				m := mocks.NewMockAppTemplateReadParser(ctrl)
 				m.EXPECT().Parse(lbFargateAppParamsPath, gomock.Any(), gomock.Any()).Return(&template.Content{Buffer: bytes.NewBufferString("params")}, nil)
 				c.parser = m
 			},

--- a/internal/pkg/template/mocks/mock_template.go
+++ b/internal/pkg/template/mocks/mock_template.go
@@ -110,3 +110,81 @@ func (mr *MockReadParserMockRecorder) Parse(path, data interface{}, options ...i
 	varargs := append([]interface{}{path, data}, options...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockReadParser)(nil).Parse), varargs...)
 }
+
+// MockAppTemplateReadParser is a mock of AppTemplateReadParser interface
+type MockAppTemplateReadParser struct {
+	ctrl     *gomock.Controller
+	recorder *MockAppTemplateReadParserMockRecorder
+}
+
+// MockAppTemplateReadParserMockRecorder is the mock recorder for MockAppTemplateReadParser
+type MockAppTemplateReadParserMockRecorder struct {
+	mock *MockAppTemplateReadParser
+}
+
+// NewMockAppTemplateReadParser creates a new mock instance
+func NewMockAppTemplateReadParser(ctrl *gomock.Controller) *MockAppTemplateReadParser {
+	mock := &MockAppTemplateReadParser{ctrl: ctrl}
+	mock.recorder = &MockAppTemplateReadParserMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockAppTemplateReadParser) EXPECT() *MockAppTemplateReadParserMockRecorder {
+	return m.recorder
+}
+
+// Read mocks base method
+func (m *MockAppTemplateReadParser) Read(path string) (*template.Content, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Read", path)
+	ret0, _ := ret[0].(*template.Content)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Read indicates an expected call of Read
+func (mr *MockAppTemplateReadParserMockRecorder) Read(path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockAppTemplateReadParser)(nil).Read), path)
+}
+
+// Parse mocks base method
+func (m *MockAppTemplateReadParser) Parse(path string, data interface{}, options ...template.ParseOption) (*template.Content, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{path, data}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Parse", varargs...)
+	ret0, _ := ret[0].(*template.Content)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Parse indicates an expected call of Parse
+func (mr *MockAppTemplateReadParserMockRecorder) Parse(path, data interface{}, options ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{path, data}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockAppTemplateReadParser)(nil).Parse), varargs...)
+}
+
+// ParseAppTemplate mocks base method
+func (m *MockAppTemplateReadParser) ParseAppTemplate(name string, data interface{}, options ...template.ParseOption) (*template.Content, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{name, data}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ParseAppTemplate", varargs...)
+	ret0, _ := ret[0].(*template.Content)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ParseAppTemplate indicates an expected call of ParseAppTemplate
+func (mr *MockAppTemplateReadParserMockRecorder) ParseAppTemplate(name, data interface{}, options ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{name, data}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseAppTemplate", reflect.TypeOf((*MockAppTemplateReadParser)(nil).ParseAppTemplate), varargs...)
+}

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -34,7 +34,7 @@ var (
 
 var box = templates.Box()
 
-// Parser is the interface that wraps the generic Parse method.
+// Parser is the interface that wraps the Parse method.
 type Parser interface {
 	Parse(path string, data interface{}, options ...ParseOption) (*Content, error)
 }
@@ -45,7 +45,7 @@ type ReadParser interface {
 	Parser
 }
 
-// AppTemplateReadParser is the interface that wraps the ParseAppTemplate method.
+// AppTemplateReadParser is the interface that wraps the methods needed to parse all application templates.
 type AppTemplateReadParser interface {
 	ReadParser
 	ParseAppTemplate(name string, data interface{}, options ...ParseOption) (*Content, error)
@@ -130,7 +130,7 @@ func (c *Content) MarshalBinary() ([]byte, error) {
 	return c.Bytes(), nil
 }
 
-// newTemplate returns a named template with the "indent" function.
+// newTemplate returns a named text template with the "indent" and "include" functions.
 func newTemplate(name string) *template.Template {
 	t := template.New(name)
 	t.Funcs(map[string]interface{}{

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -7,15 +7,34 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/aws/amazon-ecs-cli-v2/templates"
 	"github.com/gobuffalo/packd"
 )
 
+// Paths for application cloudformation templates under templates/applications/.
+const (
+	fmtAppCFTemplatePath    = "applications/%s/cf.yml"
+	fmtCommonCFTemplatePath = "applications/common/cf/%s.yml"
+)
+
+var (
+	// Template names under "applications/common/cf/".
+	commonCFTemplateNames = []string{
+		"loggroup",
+		"envvars",
+		"executionrole",
+		"taskrole",
+		"service-base-properties",
+		"addons",
+	}
+)
+
 var box = templates.Box()
 
-// Parser is the interface that wraps the Parse method.
+// Parser is the interface that wraps the generic Parse method.
 type Parser interface {
 	Parse(path string, data interface{}, options ...ParseOption) (*Content, error)
 }
@@ -24,6 +43,12 @@ type Parser interface {
 type ReadParser interface {
 	Read(path string) (*Content, error)
 	Parser
+}
+
+// AppTemplateReadParser is the interface that wraps the ParseAppTemplate method.
+type AppTemplateReadParser interface {
+	ReadParser
+	ParseAppTemplate(name string, data interface{}, options ...ParseOption) (*Content, error)
 }
 
 // Template represents the "/templates/" directory that holds static files to be embedded in the binary.
@@ -59,23 +84,36 @@ func (t *Template) Read(path string) (*Content, error) {
 
 // Parse parses the template under "/templates/{path}" with the specified data object and returns its content.
 func (t *Template) Parse(path string, data interface{}, options ...ParseOption) (*Content, error) {
-	content, err := t.read(path)
+	tpl, err := t.parseTemplate("template", path, options...)
 	if err != nil {
 		return nil, err
 	}
-
-	tpl := template.New("template")
-	for _, opt := range options {
-		tpl = opt(tpl)
-	}
-	parsedTpl, err := tpl.Parse(content)
-	if err != nil {
-		return nil, fmt.Errorf("parse template %s: %w", path, err)
-	}
-
 	buf := &bytes.Buffer{}
-	if err := parsedTpl.Execute(buf, data); err != nil {
+	if err := tpl.Execute(buf, data); err != nil {
 		return nil, fmt.Errorf("execute template %s with data %v: %w", path, data, err)
+	}
+	return &Content{buf}, nil
+}
+
+// ParseAppTemplate parses an application's CloudFormation template with the specified data object and returns its content.
+func (t *Template) ParseAppTemplate(name string, data interface{}, options ...ParseOption) (*Content, error) {
+	tpl, err := t.parseTemplate("base", fmt.Sprintf(fmtAppCFTemplatePath, name), options...)
+	if err != nil {
+		return nil, err
+	}
+	for _, templateName := range commonCFTemplateNames {
+		nestedTpl, err := t.parseTemplate(templateName, fmt.Sprintf(fmtCommonCFTemplatePath, templateName), options...)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tpl.AddParseTree(templateName, nestedTpl.Tree)
+		if err != nil {
+			return nil, fmt.Errorf("add parse tree of %s to base template: %w", templateName, err)
+		}
+	}
+	buf := &bytes.Buffer{}
+	if err := tpl.Execute(buf, data); err != nil {
+		return nil, fmt.Errorf("execute app template %s with data %v: %w", name, data, err)
 	}
 	return &Content{buf}, nil
 }
@@ -92,10 +130,48 @@ func (c *Content) MarshalBinary() ([]byte, error) {
 	return c.Bytes(), nil
 }
 
+// newTemplate returns a named template with the "indent" function.
+func newTemplate(name string) *template.Template {
+	t := template.New(name)
+	t.Funcs(map[string]interface{}{
+		"include": func(name string, data interface{}) (string, error) {
+			// Taken from https://github.com/helm/helm/blob/8648ccf5d35d682dcd5f7a9c2082f0aaf071e817/pkg/engine/engine.go#L147-L154
+			buf := bytes.NewBuffer(nil)
+			if err := t.ExecuteTemplate(buf, name, data); err != nil {
+				return "", err
+			}
+			return buf.String(), nil
+		},
+		"indent": func(spaces int, s string) string {
+			// Taken from https://github.com/Masterminds/sprig/blob/48e6b77026913419ba1a4694dde186dc9c4ad74d/strings.go#L109-L112
+			pad := strings.Repeat(" ", spaces)
+			return pad + strings.Replace(s, "\n", "\n"+pad, -1)
+		},
+	})
+	return t
+}
+
 func (t *Template) read(path string) (string, error) {
 	s, err := t.box.FindString(path)
 	if err != nil {
 		return "", fmt.Errorf("read template %s: %w", path, err)
 	}
 	return s, nil
+}
+
+func (t *Template) parseTemplate(name, path string, options ...ParseOption) (*template.Template, error) {
+	content, err := t.read(path)
+	if err != nil {
+		return nil, err
+	}
+
+	tpl := newTemplate(name)
+	for _, opt := range options {
+		tpl = opt(tpl)
+	}
+	parsedTpl, err := tpl.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse template %s: %w", path, err)
+	}
+	return parsedTpl, nil
 }

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -88,7 +88,7 @@ func (t *Template) Parse(path string, data interface{}, options ...ParseOption) 
 	if err != nil {
 		return nil, err
 	}
-	buf := &bytes.Buffer{}
+	buf := new(bytes.Buffer)
 	if err := tpl.Execute(buf, data); err != nil {
 		return nil, fmt.Errorf("execute template %s with data %v: %w", path, data, err)
 	}

--- a/internal/pkg/template/template_test.go
+++ b/internal/pkg/template/template_test.go
@@ -132,3 +132,57 @@ func TestTemplate_Parse(t *testing.T) {
 		})
 	}
 }
+
+func TestTemplate_ParseAppTemplate(t *testing.T) {
+	const (
+		testAppName = "backend-app"
+	)
+	testCases := map[string]struct {
+		mockDependencies func(t *Template)
+		wantedContent    string
+		wantedErr        error
+	}{
+		"renders all common templates": {
+			mockDependencies: func(t *Template) {
+				mockBox := packd.NewMemoryBox()
+				var baseContent string
+				for _, name := range commonCFTemplateNames {
+					baseContent += fmt.Sprintf(`{{include "%s" . | indent 2}}`+"\n", name)
+				}
+				mockBox.AddString("applications/backend-app/cf.yml", baseContent)
+				mockBox.AddString("applications/common/cf/loggroup.yml", "loggroup")
+				mockBox.AddString("applications/common/cf/envvars.yml", "envvars")
+				mockBox.AddString("applications/common/cf/executionrole.yml", "executionrole")
+				mockBox.AddString("applications/common/cf/taskrole.yml", "taskrole")
+				mockBox.AddString("applications/common/cf/service-base-properties.yml", "service-base-properties")
+				mockBox.AddString("applications/common/cf/addons.yml", "addons")
+
+				t.box = mockBox
+			},
+			wantedContent: `  loggroup
+  envvars
+  executionrole
+  taskrole
+  service-base-properties
+  addons
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			tpl := &Template{}
+			tc.mockDependencies(tpl)
+
+			// WHEN
+			c, err := tpl.ParseAppTemplate(testAppName, nil)
+
+			if tc.wantedErr != nil {
+				require.Contains(t, err.Error(), tc.wantedErr.Error())
+			} else {
+				require.Equal(t, tc.wantedContent, c.String())
+			}
+		})
+	}
+}

--- a/templates/applications/common/cf/addons.yml
+++ b/templates/applications/common/cf/addons.yml
@@ -1,0 +1,10 @@
+AddonsStack:
+  Type: AWS::CloudFormation::Stack
+  Condition: HasAddons
+  Properties:
+    Parameters:
+      Project: !Ref ProjectName
+      Env: !Ref EnvName
+      App: !Ref AppName
+    TemplateURL:
+      !Ref AddonsTemplateURL

--- a/templates/applications/common/cf/envvars.yml
+++ b/templates/applications/common/cf/envvars.yml
@@ -1,0 +1,27 @@
+# We pipe certain environment variables directly into the task definition.
+# This lets customers have access to, for example, their LB endpoint - which they'd
+# have no way of otherwise determining.
+Environment:
+- Name: ECS_CLI_PROJECT_NAME
+  Value: !Sub '${ProjectName}'
+- Name: ECS_APP_DISCOVERY_ENDPOINT
+  Value: !Sub '${ProjectName}.local'
+- Name: ECS_CLI_ENVIRONMENT_NAME
+  Value: !Sub '${EnvName}'
+- Name: ECS_CLI_APP_NAME
+  Value: !Sub '${AppName}'
+- Name: ECS_CLI_LB_DNS
+  Value:
+    Fn::ImportValue:
+      !Sub "${ProjectName}-${EnvName}-PublicLoadBalancerDNS" {{if .App.Variables}}{{range $name, $value := .App.Variables}}
+- Name: {{$name}}
+  Value: {{$value}}{{end}}{{end}}{{range $output := .AddonsOutputs}}{{if and (not $output.IsSecret) (not $output.IsManagedPolicy)}}
+- Name: {{toSnakeCase $output.Name}}
+  Value:
+    Fn::GetAtt: [AddonsStack, Outputs.{{$output.Name}}]{{end}}{{end}}{{if or .App.Secrets (gt (len (filterSecrets .AddonsOutputs)) 0)}}
+Secrets:{{range $name, $valueFrom := .App.Secrets}}
+- Name: {{$name}}
+  ValueFrom: {{$valueFrom}}{{end}}{{end}}{{range $secret := (filterSecrets .AddonsOutputs)}}
+- Name: {{toSnakeCase $secret.Name}}
+  ValueFrom:
+    Fn::GetAtt: [AddonsStack, Outputs.{{$secret.Name}}]{{end}}

--- a/templates/applications/common/cf/executionrole.yml
+++ b/templates/applications/common/cf/executionrole.yml
@@ -1,0 +1,25 @@
+ExecutionRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+          Action: 'sts:AssumeRole'
+    Policies:
+      - PolicyName: !Join ['', [!Ref ProjectName, '-', !Ref EnvName, '-', !Ref AppName, SecretsPolicy]]
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Action:
+                - 'ssm:GetParameters'
+                - 'secretsmanager:GetSecretValue'
+                - 'kms:Decrypt'
+              Resource:
+                - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
+                - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
+                - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'
+    ManagedPolicyArns:
+      - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'

--- a/templates/applications/common/cf/loggroup.yml
+++ b/templates/applications/common/cf/loggroup.yml
@@ -1,0 +1,5 @@
+LogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: !Join ['', [/ecs/, !Ref ProjectName, '-', !Ref EnvName, '-', !Ref AppName]]
+    RetentionInDays: !Ref LogRetention

--- a/templates/applications/common/cf/service-base-properties.yml
+++ b/templates/applications/common/cf/service-base-properties.yml
@@ -1,0 +1,23 @@
+Cluster:
+  Fn::ImportValue:
+    !Sub '${ProjectName}-${EnvName}-ClusterId'
+TaskDefinition: !Ref TaskDefinition
+DesiredCount: !Ref TaskCount
+PropagateTags: SERVICE
+LaunchType: FARGATE
+NetworkConfiguration:
+  AwsvpcConfiguration:
+    AssignPublicIp: ENABLED
+    Subnets:
+      - Fn::Select:
+        - 0
+        - Fn::Split:
+          - ','
+          - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-PublicSubnets'
+      - Fn::Select:
+        - 1
+        - Fn::Split:
+          - ','
+          - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-PublicSubnets'
+    SecurityGroups:
+      - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-EnvironmentSecurityGroup'

--- a/templates/applications/common/cf/taskrole.yml
+++ b/templates/applications/common/cf/taskrole.yml
@@ -1,0 +1,78 @@
+TaskRole:
+  Type: AWS::IAM::Role
+  Properties:{{if gt (len (filterManagedPolicies .AddonsOutputs)) 0}}
+    ManagedPolicyArns:{{range $managedPolicy := (filterManagedPolicies .AddonsOutputs)}}
+    - Fn::GetAtt: [AddonsStack, Outputs.{{$managedPolicy.Name}}]{{end}}{{end}}
+    AssumeRolePolicyDocument:
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+          Action: 'sts:AssumeRole'
+    Policies:
+      - PolicyName: 'DenyIAMExceptTaggedRoles'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Deny'
+              Action: 'iam:*'
+              Resource: '*'
+            - Effect: 'Allow'
+              Action: 'sts:AssumeRole'
+              Resource:
+                - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*'
+              Condition:
+                StringEquals:
+                  'iam:ResourceTag/ecs-project': !Sub '${ProjectName}'
+                  'iam:ResourceTag/ecs-environment': !Sub '${EnvName}'
+      - PolicyName: 'AllowPrefixedResources'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Action: '*'
+              Resource:
+                - !Sub 'arn:aws:s3:::${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:elasticache:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:*:${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:*:${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+                - !Sub 'arn:aws:kinesisanalytics:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+      - PolicyName: 'AllowTaggedResources' # See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Action: '*'
+              Resource: '*'
+              Condition:
+                StringEquals:
+                  'aws:ResourceTag/ecs-project': !Sub '${ProjectName}'
+                  'aws:ResourceTag/ecs-environment': !Sub '${EnvName}'
+            - Effect: 'Allow'
+              Action: '*'
+              Resource: '*'
+              Condition:
+                StringEquals:
+                  'secretsmanager:ResourceTag/ecs-project': !Sub '${ProjectName}'
+                  'secretsmanager:ResourceTag/ecs-environment': !Sub '${EnvName}'
+      - PolicyName: 'CloudWatchMetricsAndDashboard'
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: 'Allow'
+              Action:
+                - 'cloudwatch:PutMetricData'
+              Resource: '*'
+            - Effect: 'Allow'
+              Action:
+                - 'cloudwatch:GetDashboard'
+                - 'cloudwatch:ListDashboards'
+                - 'cloudwatch:PutDashboard'
+                - 'cloudwatch:ListMetrics'
+              Resource: '*'

--- a/templates/applications/lb-web-app/cf.yml
+++ b/templates/applications/lb-web-app/cf.yml
@@ -55,11 +55,7 @@ Conditions:
   HTTPRootPath: # If we're using path based routing and use the root path, we have some special logic
     !Equals [!Ref RulePath, "/"]
 Resources:
-  LogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Join ['', [/ecs/, !Ref ProjectName, '-', !Ref EnvName, '-', !Ref AppName]]
-      RetentionInDays: !Ref LogRetention
+{{include "loggroup" . | indent 2}}
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -78,33 +74,7 @@ Resources:
           Image: !Ref ContainerImage
           PortMappings:
             - ContainerPort: !Ref ContainerPort
-          # We pipe certain environment variables directly into the task definition.
-          # This lets customers have access to, for example, their LB endpoint - which they'd
-          # have no way of otherwise determining.
-          Environment:
-          - Name: ECS_CLI_PROJECT_NAME
-            Value: !Sub '${ProjectName}'
-          - Name: ECS_APP_DISCOVERY_ENDPOINT
-            Value: !Sub '${ProjectName}.local'
-          - Name: ECS_CLI_ENVIRONMENT_NAME
-            Value: !Sub '${EnvName}'
-          - Name: ECS_CLI_APP_NAME
-            Value: !Sub '${AppName}'
-          - Name: ECS_CLI_LB_DNS
-            Value:
-              Fn::ImportValue:
-                !Sub "${ProjectName}-${EnvName}-PublicLoadBalancerDNS" {{if .App.Variables}}{{range $name, $value := .App.Variables}}
-          - Name: {{$name}}
-            Value: {{$value}}{{end}}{{end}}{{range $output := .AddonsOutputs}}{{if and (not $output.IsSecret) (not $output.IsManagedPolicy)}}
-          - Name: {{toSnakeCase $output.Name}}
-            Value:
-              Fn::GetAtt: [AddonsStack, Outputs.{{$output.Name}}]{{end}}{{end}}{{if or .App.Secrets (gt (len (filterSecrets .AddonsOutputs)) 0)}}
-          Secrets:{{range $name, $valueFrom := .App.Secrets}}
-          - Name: {{$name}}
-            ValueFrom: {{$valueFrom}}{{end}}{{end}}{{range $secret := (filterSecrets .AddonsOutputs)}}
-          - Name: {{toSnakeCase $secret.Name}}
-            ValueFrom:
-              Fn::GetAtt: [AddonsStack, Outputs.{{$secret.Name}}]{{end}}
+{{include "envvars" . | indent 10}}
           LogConfiguration:
             LogDriver: awslogs
             Options:
@@ -112,111 +82,10 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-stream-prefix: ecs
 
-  ExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
-      Policies:
-        - PolicyName: !Join ['', [!Ref ProjectName, '-', !Ref EnvName, '-', !Ref AppName, SecretsPolicy]]
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action:
-                  - 'ssm:GetParameters'
-                  - 'secretsmanager:GetSecretValue'
-                  - 'kms:Decrypt'
-                Resource:
-                  - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
-                  - !Sub 'arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*'
-      ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+{{include "executionrole" . | indent 2}}
 
-  TaskRole:
-    Type: AWS::IAM::Role
-    Properties:{{if gt (len (filterManagedPolicies .AddonsOutputs)) 0}}
-      ManagedPolicyArns:{{range $managedPolicy := (filterManagedPolicies .AddonsOutputs)}}
-      - Fn::GetAtt: [AddonsStack, Outputs.{{$managedPolicy.Name}}]{{end}}{{end}}
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-            Action: 'sts:AssumeRole'
-      Policies:
-        - PolicyName: 'DenyIAMExceptTaggedRoles'
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Deny'
-                Action: 'iam:*'
-                Resource: '*'
-              - Effect: 'Allow'
-                Action: 'sts:AssumeRole'
-                Resource:
-                  - !Sub 'arn:aws:iam::${AWS::AccountId}:role/*'
-                Condition:
-                  StringEquals:
-                    'iam:ResourceTag/ecs-project': !Sub '${ProjectName}'
-                    'iam:ResourceTag/ecs-environment': !Sub '${EnvName}'
-        - PolicyName: 'AllowPrefixedResources'
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action: '*'
-                Resource:
-                  - !Sub 'arn:aws:s3:::${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:elasticache:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:redshift:${AWS::Region}:${AWS::AccountId}:*:${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:*:${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
+{{include "taskrole" . | indent 2}}
 
-                  - !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
-                  - !Sub 'arn:aws:kinesisanalytics:${AWS::Region}:${AWS::AccountId}:*/${ProjectName}-${EnvName}-*'
-        - PolicyName: 'AllowTaggedResources' # See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action: '*'
-                Resource: '*'
-                Condition:
-                  StringEquals:
-                    'aws:ResourceTag/ecs-project': !Sub '${ProjectName}'
-                    'aws:ResourceTag/ecs-environment': !Sub '${EnvName}'
-              - Effect: 'Allow'
-                Action: '*'
-                Resource: '*'
-                Condition:
-                  StringEquals:
-                    'secretsmanager:ResourceTag/ecs-project': !Sub '${ProjectName}'
-                    'secretsmanager:ResourceTag/ecs-environment': !Sub '${EnvName}'
-        - PolicyName: 'CloudWatchMetricsAndDashboard'
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action:
-                  - 'cloudwatch:PutMetricData'
-                Resource: '*'
-              - Effect: 'Allow'
-                Action:
-                  - 'cloudwatch:GetDashboard'
-                  - 'cloudwatch:ListDashboards'
-                  - 'cloudwatch:PutDashboard'
-                  - 'cloudwatch:ListMetrics'
-                Resource: '*'
   DiscoveryService:
     Type: AWS::ServiceDiscovery::Service
     Properties:
@@ -238,34 +107,12 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn: WaitUntilListenerRuleIsCreated
     Properties:
-      Cluster:
-        Fn::ImportValue:
-          !Sub '${ProjectName}-${EnvName}-ClusterId'
-      TaskDefinition: !Ref TaskDefinition
+{{include "service-base-properties" . | indent 6}}
       DeploymentConfiguration:
         MinimumHealthyPercent: 100
         MaximumPercent: 200
-      DesiredCount: !Ref TaskCount
-      PropagateTags: SERVICE
       # This may need to be adjusted if the container takes a while to start up
       HealthCheckGracePeriodSeconds: 60
-      LaunchType: FARGATE
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets:
-            - Fn::Select:
-              - 0
-              - Fn::Split:
-                - ','
-                - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-PublicSubnets'
-            - Fn::Select:
-              - 1
-              - Fn::Split:
-                - ','
-                - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-PublicSubnets'
-          SecurityGroups:
-            - Fn::ImportValue: !Sub '${ProjectName}-${EnvName}-EnvironmentSecurityGroup'
       LoadBalancers:
         - ContainerName: !Ref AppName
           ContainerPort: !Ref ContainerPort
@@ -451,13 +298,4 @@ Resources:
       Timeout: "1"
       Count: 0
 
-  AddonsStack:
-    Type: AWS::CloudFormation::Stack
-    Condition: HasAddons
-    Properties:
-      Parameters:
-        Project: !Ref ProjectName
-        Env: !Ref EnvName
-        App: !Ref AppName
-      TemplateURL:
-        !Ref AddonsTemplateURL
+{{include "addons" . | indent 2}}


### PR DESCRIPTION
Part 1 of #833

The files under `templates/applications/common/cf/` are sections that should be shared across all app types. This will allow us to DRY our templates. We should be able to write new app type templates faster, remove the chance of errors while copy pasting, and keep things consistent across applications.

Please let me know if you have any disagreements, also if you think there are other sections that can be extracted to the `common/cf` dir.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
