### PR TITLE
fix: do not fail project delete if pipeline manifest does not exist

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -233,3 +233,16 @@ type statusDescriber interface {
 type pipelineGetter interface {
 	GetPipeline(pipelineName string) (*codepipeline.Pipeline, error)
 }
+
+type deleteAppExecutor interface {
+	Execute() error
+}
+
+type deletePipelineRunner interface {
+	Run() error
+}
+
+type deleteEnvRunner interface {
+	Ask() error
+	Execute() error
+}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -234,7 +234,7 @@ type pipelineGetter interface {
 	GetPipeline(pipelineName string) (*codepipeline.Pipeline, error)
 }
 
-type deleteAppExecutor interface {
+type executor interface {
 	Execute() error
 }
 
@@ -242,7 +242,7 @@ type deletePipelineRunner interface {
 	Run() error
 }
 
-type deleteEnvRunner interface {
+type askExecutor interface {
 	Ask() error
-	Execute() error
+	executor
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -107,6 +107,10 @@ type storeReader interface {
 	archer.ApplicationGetter
 }
 
+type workspaceDeleter interface {
+	DeleteAll() error
+}
+
 type wsAppManifestReader interface {
 	ReadAppManifest(appName string) ([]byte, error)
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2488,31 +2488,31 @@ func (mr *MockpipelineGetterMockRecorder) GetPipeline(pipelineName interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipeline", reflect.TypeOf((*MockpipelineGetter)(nil).GetPipeline), pipelineName)
 }
 
-// MockdeleteAppExecutor is a mock of deleteAppExecutor interface
-type MockdeleteAppExecutor struct {
+// Mockexecutor is a mock of executor interface
+type Mockexecutor struct {
 	ctrl     *gomock.Controller
-	recorder *MockdeleteAppExecutorMockRecorder
+	recorder *MockexecutorMockRecorder
 }
 
-// MockdeleteAppExecutorMockRecorder is the mock recorder for MockdeleteAppExecutor
-type MockdeleteAppExecutorMockRecorder struct {
-	mock *MockdeleteAppExecutor
+// MockexecutorMockRecorder is the mock recorder for Mockexecutor
+type MockexecutorMockRecorder struct {
+	mock *Mockexecutor
 }
 
-// NewMockdeleteAppExecutor creates a new mock instance
-func NewMockdeleteAppExecutor(ctrl *gomock.Controller) *MockdeleteAppExecutor {
-	mock := &MockdeleteAppExecutor{ctrl: ctrl}
-	mock.recorder = &MockdeleteAppExecutorMockRecorder{mock}
+// NewMockexecutor creates a new mock instance
+func NewMockexecutor(ctrl *gomock.Controller) *Mockexecutor {
+	mock := &Mockexecutor{ctrl: ctrl}
+	mock.recorder = &MockexecutorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdeleteAppExecutor) EXPECT() *MockdeleteAppExecutorMockRecorder {
+func (m *Mockexecutor) EXPECT() *MockexecutorMockRecorder {
 	return m.recorder
 }
 
 // Execute mocks base method
-func (m *MockdeleteAppExecutor) Execute() error {
+func (m *Mockexecutor) Execute() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute")
 	ret0, _ := ret[0].(error)
@@ -2520,9 +2520,9 @@ func (m *MockdeleteAppExecutor) Execute() error {
 }
 
 // Execute indicates an expected call of Execute
-func (mr *MockdeleteAppExecutorMockRecorder) Execute() *gomock.Call {
+func (mr *MockexecutorMockRecorder) Execute() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockdeleteAppExecutor)(nil).Execute))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*Mockexecutor)(nil).Execute))
 }
 
 // MockdeletePipelineRunner is a mock of deletePipelineRunner interface
@@ -2562,31 +2562,31 @@ func (mr *MockdeletePipelineRunnerMockRecorder) Run() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockdeletePipelineRunner)(nil).Run))
 }
 
-// MockdeleteEnvRunner is a mock of deleteEnvRunner interface
-type MockdeleteEnvRunner struct {
+// MockaskExecutor is a mock of askExecutor interface
+type MockaskExecutor struct {
 	ctrl     *gomock.Controller
-	recorder *MockdeleteEnvRunnerMockRecorder
+	recorder *MockaskExecutorMockRecorder
 }
 
-// MockdeleteEnvRunnerMockRecorder is the mock recorder for MockdeleteEnvRunner
-type MockdeleteEnvRunnerMockRecorder struct {
-	mock *MockdeleteEnvRunner
+// MockaskExecutorMockRecorder is the mock recorder for MockaskExecutor
+type MockaskExecutorMockRecorder struct {
+	mock *MockaskExecutor
 }
 
-// NewMockdeleteEnvRunner creates a new mock instance
-func NewMockdeleteEnvRunner(ctrl *gomock.Controller) *MockdeleteEnvRunner {
-	mock := &MockdeleteEnvRunner{ctrl: ctrl}
-	mock.recorder = &MockdeleteEnvRunnerMockRecorder{mock}
+// NewMockaskExecutor creates a new mock instance
+func NewMockaskExecutor(ctrl *gomock.Controller) *MockaskExecutor {
+	mock := &MockaskExecutor{ctrl: ctrl}
+	mock.recorder = &MockaskExecutorMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdeleteEnvRunner) EXPECT() *MockdeleteEnvRunnerMockRecorder {
+func (m *MockaskExecutor) EXPECT() *MockaskExecutorMockRecorder {
 	return m.recorder
 }
 
 // Ask mocks base method
-func (m *MockdeleteEnvRunner) Ask() error {
+func (m *MockaskExecutor) Ask() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ask")
 	ret0, _ := ret[0].(error)
@@ -2594,13 +2594,13 @@ func (m *MockdeleteEnvRunner) Ask() error {
 }
 
 // Ask indicates an expected call of Ask
-func (mr *MockdeleteEnvRunnerMockRecorder) Ask() *gomock.Call {
+func (mr *MockaskExecutorMockRecorder) Ask() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ask", reflect.TypeOf((*MockdeleteEnvRunner)(nil).Ask))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ask", reflect.TypeOf((*MockaskExecutor)(nil).Ask))
 }
 
 // Execute mocks base method
-func (m *MockdeleteEnvRunner) Execute() error {
+func (m *MockaskExecutor) Execute() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute")
 	ret0, _ := ret[0].(error)
@@ -2608,7 +2608,7 @@ func (m *MockdeleteEnvRunner) Execute() error {
 }
 
 // Execute indicates an expected call of Execute
-func (mr *MockdeleteEnvRunnerMockRecorder) Execute() *gomock.Call {
+func (mr *MockaskExecutorMockRecorder) Execute() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockdeleteEnvRunner)(nil).Execute))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockaskExecutor)(nil).Execute))
 }

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2487,3 +2487,128 @@ func (mr *MockpipelineGetterMockRecorder) GetPipeline(pipelineName interface{}) 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipeline", reflect.TypeOf((*MockpipelineGetter)(nil).GetPipeline), pipelineName)
 }
+
+// MockdeleteAppExecutor is a mock of deleteAppExecutor interface
+type MockdeleteAppExecutor struct {
+	ctrl     *gomock.Controller
+	recorder *MockdeleteAppExecutorMockRecorder
+}
+
+// MockdeleteAppExecutorMockRecorder is the mock recorder for MockdeleteAppExecutor
+type MockdeleteAppExecutorMockRecorder struct {
+	mock *MockdeleteAppExecutor
+}
+
+// NewMockdeleteAppExecutor creates a new mock instance
+func NewMockdeleteAppExecutor(ctrl *gomock.Controller) *MockdeleteAppExecutor {
+	mock := &MockdeleteAppExecutor{ctrl: ctrl}
+	mock.recorder = &MockdeleteAppExecutorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdeleteAppExecutor) EXPECT() *MockdeleteAppExecutorMockRecorder {
+	return m.recorder
+}
+
+// Execute mocks base method
+func (m *MockdeleteAppExecutor) Execute() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Execute indicates an expected call of Execute
+func (mr *MockdeleteAppExecutorMockRecorder) Execute() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockdeleteAppExecutor)(nil).Execute))
+}
+
+// MockdeletePipelineRunner is a mock of deletePipelineRunner interface
+type MockdeletePipelineRunner struct {
+	ctrl     *gomock.Controller
+	recorder *MockdeletePipelineRunnerMockRecorder
+}
+
+// MockdeletePipelineRunnerMockRecorder is the mock recorder for MockdeletePipelineRunner
+type MockdeletePipelineRunnerMockRecorder struct {
+	mock *MockdeletePipelineRunner
+}
+
+// NewMockdeletePipelineRunner creates a new mock instance
+func NewMockdeletePipelineRunner(ctrl *gomock.Controller) *MockdeletePipelineRunner {
+	mock := &MockdeletePipelineRunner{ctrl: ctrl}
+	mock.recorder = &MockdeletePipelineRunnerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdeletePipelineRunner) EXPECT() *MockdeletePipelineRunnerMockRecorder {
+	return m.recorder
+}
+
+// Run mocks base method
+func (m *MockdeletePipelineRunner) Run() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Run")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Run indicates an expected call of Run
+func (mr *MockdeletePipelineRunnerMockRecorder) Run() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockdeletePipelineRunner)(nil).Run))
+}
+
+// MockdeleteEnvRunner is a mock of deleteEnvRunner interface
+type MockdeleteEnvRunner struct {
+	ctrl     *gomock.Controller
+	recorder *MockdeleteEnvRunnerMockRecorder
+}
+
+// MockdeleteEnvRunnerMockRecorder is the mock recorder for MockdeleteEnvRunner
+type MockdeleteEnvRunnerMockRecorder struct {
+	mock *MockdeleteEnvRunner
+}
+
+// NewMockdeleteEnvRunner creates a new mock instance
+func NewMockdeleteEnvRunner(ctrl *gomock.Controller) *MockdeleteEnvRunner {
+	mock := &MockdeleteEnvRunner{ctrl: ctrl}
+	mock.recorder = &MockdeleteEnvRunnerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdeleteEnvRunner) EXPECT() *MockdeleteEnvRunnerMockRecorder {
+	return m.recorder
+}
+
+// Ask mocks base method
+func (m *MockdeleteEnvRunner) Ask() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ask")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ask indicates an expected call of Ask
+func (mr *MockdeleteEnvRunnerMockRecorder) Ask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ask", reflect.TypeOf((*MockdeleteEnvRunner)(nil).Ask))
+}
+
+// Execute mocks base method
+func (m *MockdeleteEnvRunner) Execute() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Execute indicates an expected call of Execute
+func (mr *MockdeleteEnvRunnerMockRecorder) Execute() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockdeleteEnvRunner)(nil).Execute))
+}

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1021,6 +1021,43 @@ func (mr *MockstoreReaderMockRecorder) GetApplication(projectName, applicationNa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplication", reflect.TypeOf((*MockstoreReader)(nil).GetApplication), projectName, applicationName)
 }
 
+// MockworkspaceDeleter is a mock of workspaceDeleter interface
+type MockworkspaceDeleter struct {
+	ctrl     *gomock.Controller
+	recorder *MockworkspaceDeleterMockRecorder
+}
+
+// MockworkspaceDeleterMockRecorder is the mock recorder for MockworkspaceDeleter
+type MockworkspaceDeleterMockRecorder struct {
+	mock *MockworkspaceDeleter
+}
+
+// NewMockworkspaceDeleter creates a new mock instance
+func NewMockworkspaceDeleter(ctrl *gomock.Controller) *MockworkspaceDeleter {
+	mock := &MockworkspaceDeleter{ctrl: ctrl}
+	mock.recorder = &MockworkspaceDeleterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockworkspaceDeleter) EXPECT() *MockworkspaceDeleterMockRecorder {
+	return m.recorder
+}
+
+// DeleteAll mocks base method
+func (m *MockworkspaceDeleter) DeleteAll() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAll")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAll indicates an expected call of DeleteAll
+func (mr *MockworkspaceDeleterMockRecorder) DeleteAll() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAll", reflect.TypeOf((*MockworkspaceDeleter)(nil).DeleteAll))
+}
+
 // MockwsAppManifestReader is a mock of wsAppManifestReader interface
 type MockwsAppManifestReader struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -31,8 +31,6 @@ const (
 )
 
 var (
-	errNoPipelineInWorkspace = errors.New("there was no pipeline manifest found in your workspace. Please run `ecs-preview pipeline init` to create an pipeline")
-
 	errPipelineDeleteCancelled = errors.New("pipeline delete cancelled - no changes made")
 )
 
@@ -61,16 +59,6 @@ func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error)
 		return nil, fmt.Errorf("workspace cannot be created: %w", err)
 	}
 
-	data, err := ws.ReadPipelineManifest()
-	if err != nil {
-		return nil, fmt.Errorf("read pipeline manifest: %w", err)
-	}
-
-	pipeline, err := manifest.UnmarshalPipeline(data)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshal pipeline manifest: %w", err)
-	}
-
 	secretsmanager, err := secretsmanager.New()
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create secrets manager: %w", err)
@@ -88,10 +76,6 @@ func newDeletePipelineOpts(vars deletePipelineVars) (*deletePipelineOpts, error)
 		secretsmanager:     secretsmanager,
 		pipelineDeployer:   cloudformation.New(defaultSession),
 		ws:                 ws,
-	}
-	opts.PipelineName = pipeline.Name
-	if secret, ok := (pipeline.Source.Properties["access_token_secret"]).(string); ok {
-		opts.PipelineSecret = secret
 	}
 
 	return opts, nil
@@ -124,8 +108,31 @@ func (o *deletePipelineOpts) Validate() error {
 		return errNoProjectInWorkspace
 	}
 
-	if o.PipelineName == "" {
-		return errNoPipelineInWorkspace
+	if err := o.readPipelineManifest(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *deletePipelineOpts) readPipelineManifest() error {
+	data, err := o.ws.ReadPipelineManifest()
+	if err != nil {
+		if _, ok := err.(*workspace.ErrNoPipelineInWorkspace); ok {
+			return err
+		}
+		return fmt.Errorf("read pipeline manifest: %w", err)
+	}
+
+	pipeline, err := manifest.UnmarshalPipeline(data)
+	if err != nil {
+		return fmt.Errorf("unmarshal pipeline manifest: %w", err)
+	}
+
+	o.PipelineName = pipeline.Name
+
+	if secret, ok := (pipeline.Source.Properties["access_token_secret"]).(string); ok {
+		o.PipelineSecret = secret
 	}
 
 	return nil

--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -118,7 +118,7 @@ func (o *deletePipelineOpts) Validate() error {
 func (o *deletePipelineOpts) readPipelineManifest() error {
 	data, err := o.ws.ReadPipelineManifest()
 	if err != nil {
-		if _, ok := err.(*workspace.ErrNoPipelineInWorkspace); ok {
+		if err == workspace.ErrNoPipelineInWorkspace {
 			return err
 		}
 		return fmt.Errorf("read pipeline manifest: %w", err)

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -32,7 +32,6 @@ type deletePipelineMocks struct {
 }
 
 func TestDeletePipelineOpts_Validate(t *testing.T) {
-	noManifestError := &workspace.ErrNoPipelineInWorkspace{}
 	pipelineData := `
 name: pipeline-badgoose-honker-repo
 version: 1
@@ -68,10 +67,10 @@ stages:
 		"pipeline manifest does not exist": {
 			inProjectName: testProjName,
 			callMocks: func(m deletePipelineMocks) {
-				m.ws.EXPECT().ReadPipelineManifest().Return(nil, noManifestError)
+				m.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace)
 			},
 
-			wantedError: noManifestError,
+			wantedError: workspace.ErrNoPipelineInWorkspace,
 		},
 
 		"project does not exist": {

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -11,6 +11,7 @@ import (
 	awsmocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer/mocks" // TODO refactor
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -22,42 +23,85 @@ const (
 	testPipelineSecret = "honkhonkhonk"
 )
 
+type deletePipelineMocks struct {
+	prompt         *climocks.Mockprompter
+	prog           *climocks.Mockprogress
+	secretsmanager *awsmocks.MockSecretsManager
+	deployer       *climocks.MockpipelineDeployer
+	ws             *climocks.MockwsPipelineDeleter
+}
+
 func TestDeletePipelineOpts_Validate(t *testing.T) {
+	noManifestError := &workspace.ErrNoPipelineInWorkspace{}
+	pipelineData := `
+name: pipeline-badgoose-honker-repo
+version: 1
+
+source:
+  provider: GitHub
+  properties:
+    repository: badgoose/repo
+    access_token_secret: "github-token-badgoose-repo"
+    branch: master
+
+stages:
+    -
+      name: test
+    -
+      name: prod
+`
+
 	testCases := map[string]struct {
-		inProjectName  string
-		inPipelineName string
+		inProjectName string
+		callMocks     func(m deletePipelineMocks)
 
 		wantedError error
 	}{
 		"happy path": {
-			inProjectName:  testProjName,
-			inPipelineName: testPipelineName,
-			wantedError:    nil,
+			inProjectName: testProjName,
+			callMocks: func(m deletePipelineMocks) {
+				m.ws.EXPECT().ReadPipelineManifest().Return([]byte(pipelineData), nil)
+			},
+			wantedError: nil,
 		},
 
 		"pipeline manifest does not exist": {
-			inProjectName:  testProjName,
-			inPipelineName: "",
-			wantedError:    errNoPipelineInWorkspace,
+			inProjectName: testProjName,
+			callMocks: func(m deletePipelineMocks) {
+				m.ws.EXPECT().ReadPipelineManifest().Return(nil, noManifestError)
+			},
+
+			wantedError: noManifestError,
 		},
 
 		"project does not exist": {
-			inProjectName:  "",
-			inPipelineName: testPipelineName,
-			wantedError:    errNoProjectInWorkspace,
+			inProjectName: "",
+			callMocks:     func(m deletePipelineMocks) {},
+
+			wantedError: errNoProjectInWorkspace,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// GIVEN
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockWorkspace := climocks.NewMockwsPipelineDeleter(ctrl)
+			mocks := deletePipelineMocks{
+				ws: mockWorkspace,
+			}
+
+			tc.callMocks(mocks)
+
 			opts := &deletePipelineOpts{
 				deletePipelineVars: deletePipelineVars{
 					GlobalOpts: &GlobalOpts{
 						projectName: tc.inProjectName,
 					},
 				},
-				PipelineName: tc.inPipelineName,
+				ws: mockWorkspace,
 			}
 
 			// WHEN
@@ -77,7 +121,7 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 		inProjectName    string
 		inPipelineName   string
 
-		mockPrompt func(m *climocks.Mockprompter)
+		callMocks func(m deletePipelineMocks)
 
 		wantedError error
 	}{
@@ -86,7 +130,7 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 			inProjectName:    testProjName,
 			inPipelineName:   testPipelineName,
 
-			mockPrompt: func(m *climocks.Mockprompter) {},
+			callMocks: func(m deletePipelineMocks) {},
 
 			wantedError: nil,
 		},
@@ -95,8 +139,8 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 			skipConfirmation: false,
 			inProjectName:    testProjName,
 			inPipelineName:   testPipelineName,
-			mockPrompt: func(m *climocks.Mockprompter) {
-				m.EXPECT().Confirm(
+			callMocks: func(m deletePipelineMocks) {
+				m.prompt.EXPECT().Confirm(
 					fmt.Sprintf(pipelineDeleteConfirmPrompt, testPipelineName, testProjName),
 					pipelineDeleteConfirmHelp,
 				).Times(1).Return(true, nil)
@@ -110,15 +154,21 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 			// GIVEN
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			mockPrompter := climocks.NewMockprompter(ctrl)
-			tc.mockPrompt(mockPrompter)
+
+			mockPrompt := climocks.NewMockprompter(ctrl)
+
+			mocks := deletePipelineMocks{
+				prompt: mockPrompt,
+			}
+
+			tc.callMocks(mocks)
 
 			opts := &deletePipelineOpts{
 				deletePipelineVars: deletePipelineVars{
 					SkipConfirmation: tc.skipConfirmation,
 					GlobalOpts: &GlobalOpts{
 						projectName: tc.inProjectName,
-						prompt:      mockPrompter,
+						prompt:      mockPrompt,
 					},
 				},
 				PipelineName: tc.inPipelineName,
@@ -133,14 +183,6 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 			}
 		})
 	}
-}
-
-type deletePipelineMocks struct {
-	prompt         *climocks.Mockprompter
-	prog           *climocks.Mockprogress
-	secretsmanager *awsmocks.MockSecretsManager
-	deployer       *climocks.MockpipelineDeployer
-	ws             *climocks.MockwsPipelineDeleter
 }
 
 func TestDeletePipelineOpts_Execute(t *testing.T) {

--- a/internal/pkg/cli/project_delete.go
+++ b/internal/pkg/cli/project_delete.go
@@ -183,7 +183,11 @@ func (o *deleteProjOpts) Execute() error {
 	// deleteLocalWorkspace, since the pipeline delete command relies on the
 	// project stackset as well as the workspace directory to still exist.
 	if err := o.deleteProjectPipeline(); err != nil {
-		return err
+		if _, ok := err.(*workspace.ErrNoPipelineInWorkspace); ok {
+			log.Infof("No pipeline manifest found, skipping deletion of pipeline.\n")
+		} else {
+			return err
+		}
 	}
 
 	if err := o.deleteProjectResources(); err != nil {

--- a/internal/pkg/cli/project_delete.go
+++ b/internal/pkg/cli/project_delete.go
@@ -109,10 +109,10 @@ func newDeleteProjOpts(vars deleteProjVars) (*deleteProjOpts, error) {
 				SkipConfirmation: true,
 				GlobalOpts:       NewGlobalOpts(),
 				EnvName:          envName,
+				EnvProfile:       envProfile,
 			}
 
 			deleteEnvOpts, err := newDeleteEnvOpts(vars)
-			deleteEnvOpts.EnvProfile = envProfile
 
 			if err != nil {
 				return nil, err

--- a/internal/pkg/cli/project_delete.go
+++ b/internal/pkg/cli/project_delete.go
@@ -183,9 +183,7 @@ func (o *deleteProjOpts) Execute() error {
 	// deleteLocalWorkspace, since the pipeline delete command relies on the
 	// project stackset as well as the workspace directory to still exist.
 	if err := o.deleteProjectPipeline(); err != nil {
-		if _, ok := err.(*workspace.ErrNoPipelineInWorkspace); ok {
-			log.Infof("No pipeline manifest found, skipping deletion of pipeline.\n")
-		} else {
+		if !errors.Is(err, workspace.ErrNoPipelineInWorkspace) {
 			return err
 		}
 	}

--- a/internal/pkg/cli/project_delete.go
+++ b/internal/pkg/cli/project_delete.go
@@ -49,10 +49,6 @@ type deleteProjOpts struct {
 	spinner             progress
 }
 
-type workspaceDeleter interface {
-	DeleteAll() error
-}
-
 func newDeleteProjOpts(vars deleteProjVars) (*deleteProjOpts, error) {
 	store, err := store.New()
 	if err != nil {

--- a/internal/pkg/cli/project_delete.go
+++ b/internal/pkg/cli/project_delete.go
@@ -27,14 +27,14 @@ const (
 	fmtConfirmProjectDeletePrompt = `Are you sure you want to delete project %s?
 	This will delete your project as well as any apps, environments, and pipelines.`
 	confirmProjectDeleteHelp       = "Deleting a project will remove all associated resources. (apps, envs, pipelines, etc.)"
-	fmtCleanResourcesStart         = "Cleaning up deployment resources."
-	fmtCleanResourcesStop          = "Cleaned up deployment resources."
-	fmtDeleteProjectResourcesStart = "Deleting project resources."
-	fmtDeleteProjectResourcesStop  = "Deleted project resources."
-	fmtDeleteProjectParamsStart    = "Deleting project metadata."
-	fmtDeleteProjectParamsStop     = "Deleted project metadata."
-	fmtDeleteLocalWsStart          = "Deleting local workspace folder."
-	fmtDeleteLocalWsStop           = "Deleted local workspace folder."
+	cleanResourcesStartMsg         = "Cleaning up deployment resources."
+	cleanResourcesStopMsg          = "Cleaned up deployment resources."
+	deleteProjectResourcesStartMsg = "Deleting project resources."
+	deleteProjectResourcesStopMsg  = "Deleted project resources."
+	deleteProjectParamsStartMsg    = "Deleting project metadata."
+	deleteProjectParamsStopMsg     = "Deleted project metadata."
+	deleteLocalWsStartMsg          = "Deleting local workspace folder."
+	deleteLocalWsStopMsg           = "Deleted local workspace folder."
 )
 
 var (
@@ -259,7 +259,7 @@ func (o *deleteProjOpts) emptyS3Bucket() error {
 	if err != nil {
 		return fmt.Errorf("get regional resources for %s: %w", proj.Name, err)
 	}
-	o.spinner.Start(fmtCleanResourcesStart)
+	o.spinner.Start(cleanResourcesStartMsg)
 	for _, projResource := range projResources {
 		sess, err := o.sessProvider.DefaultWithRegion(projResource.Region)
 		if err != nil {
@@ -273,7 +273,7 @@ func (o *deleteProjOpts) emptyS3Bucket() error {
 			return fmt.Errorf("empty bucket %s: %w", projResource.S3Bucket, err)
 		}
 	}
-	o.spinner.Stop(log.Ssuccess(fmtCleanResourcesStop))
+	o.spinner.Stop(log.Ssuccess(cleanResourcesStopMsg))
 	return nil
 }
 
@@ -287,36 +287,36 @@ func (o *deleteProjOpts) deleteProjectPipeline() error {
 }
 
 func (o *deleteProjOpts) deleteProjectResources() error {
-	o.spinner.Start(fmtDeleteProjectResourcesStart)
+	o.spinner.Start(deleteProjectResourcesStartMsg)
 	if err := o.deployer.DeleteProject(o.ProjectName()); err != nil {
 		o.spinner.Stop(log.Serror("Error deleting project resources."))
 		return fmt.Errorf("delete project resources: %w", err)
 	}
-	o.spinner.Stop(log.Ssuccess(fmtDeleteProjectResourcesStop))
+	o.spinner.Stop(log.Ssuccess(deleteProjectResourcesStopMsg))
 
 	return nil
 }
 
 func (o *deleteProjOpts) deleteProjectParams() error {
-	o.spinner.Start(fmtDeleteProjectParamsStart)
+	o.spinner.Start(deleteProjectParamsStartMsg)
 	if err := o.store.DeleteProject(o.ProjectName()); err != nil {
 		o.spinner.Stop(log.Serror("Error deleting project metadata."))
 
 		return err
 	}
-	o.spinner.Stop(log.Ssuccess(fmtDeleteProjectParamsStop))
+	o.spinner.Stop(log.Ssuccess(deleteProjectParamsStopMsg))
 
 	return nil
 }
 
 func (o *deleteProjOpts) deleteLocalWorkspace() error {
-	o.spinner.Start(fmtDeleteLocalWsStart)
+	o.spinner.Start(deleteLocalWsStartMsg)
 	if err := o.ws.DeleteAll(); err != nil {
 		o.spinner.Stop(log.Serror("Error deleting local workspace folder."))
 
 		return fmt.Errorf("delete workspace: %w", err)
 	}
-	o.spinner.Stop(log.Ssuccess(fmtDeleteLocalWsStop))
+	o.spinner.Stop(log.Ssuccess(deleteLocalWsStopMsg))
 
 	return nil
 }

--- a/internal/pkg/cli/project_delete_test.go
+++ b/internal/pkg/cli/project_delete_test.go
@@ -282,27 +282,27 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 					// emptyS3bucket
 					mocks.store.EXPECT().GetProject(mockProjectName).Return(mockProject, nil),
 					mocks.deployer.EXPECT().GetRegionalProjectResources(mockProject).Return(mockResources, nil),
-					mocks.spinner.EXPECT().Start(fmtCleanResourcesStart),
+					mocks.spinner.EXPECT().Start(cleanResourcesStartMsg),
 					mocks.bucketEmptier.EXPECT().EmptyBucket(mockResources[0].S3Bucket).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtCleanResourcesStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(cleanResourcesStopMsg)),
 
 					// deleteProjectPipline
 					mocks.pipelineDeleter.EXPECT().Run().Return(nil),
 
 					// deleteProjectResources
-					mocks.spinner.EXPECT().Start(fmtDeleteProjectResourcesStart),
+					mocks.spinner.EXPECT().Start(deleteProjectResourcesStartMsg),
 					mocks.deployer.EXPECT().DeleteProject(mockProjectName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectResourcesStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteProjectResourcesStopMsg)),
 
 					// deleteProjectParams
-					mocks.spinner.EXPECT().Start(fmtDeleteProjectParamsStart),
+					mocks.spinner.EXPECT().Start(deleteProjectParamsStartMsg),
 					mocks.store.EXPECT().DeleteProject(mockProjectName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectParamsStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteProjectParamsStopMsg)),
 
 					// deleteLocalWorkspace
-					mocks.spinner.EXPECT().Start(fmtDeleteLocalWsStart),
+					mocks.spinner.EXPECT().Start(deleteLocalWsStartMsg),
 					mocks.ws.EXPECT().DeleteAll().Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteLocalWsStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteLocalWsStopMsg)),
 				)
 			},
 			wantedError: nil,
@@ -324,27 +324,27 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 					// emptyS3bucket
 					mocks.store.EXPECT().GetProject(mockProjectName).Return(mockProject, nil),
 					mocks.deployer.EXPECT().GetRegionalProjectResources(mockProject).Return(mockResources, nil),
-					mocks.spinner.EXPECT().Start(fmtCleanResourcesStart),
+					mocks.spinner.EXPECT().Start(cleanResourcesStartMsg),
 					mocks.bucketEmptier.EXPECT().EmptyBucket(mockResources[0].S3Bucket).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtCleanResourcesStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(cleanResourcesStopMsg)),
 
 					// deleteProjectPipline
 					mocks.pipelineDeleter.EXPECT().Run().Return(workspace.ErrNoPipelineInWorkspace),
 
 					// deleteProjectResources
-					mocks.spinner.EXPECT().Start(fmtDeleteProjectResourcesStart),
+					mocks.spinner.EXPECT().Start(deleteProjectResourcesStartMsg),
 					mocks.deployer.EXPECT().DeleteProject(mockProjectName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectResourcesStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteProjectResourcesStopMsg)),
 
 					// deleteProjectParams
-					mocks.spinner.EXPECT().Start(fmtDeleteProjectParamsStart),
+					mocks.spinner.EXPECT().Start(deleteProjectParamsStartMsg),
 					mocks.store.EXPECT().DeleteProject(mockProjectName).Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectParamsStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteProjectParamsStopMsg)),
 
 					// deleteLocalWorkspace
-					mocks.spinner.EXPECT().Start(fmtDeleteLocalWsStart),
+					mocks.spinner.EXPECT().Start(deleteLocalWsStartMsg),
 					mocks.ws.EXPECT().DeleteAll().Return(nil),
-					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteLocalWsStop)),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(deleteLocalWsStopMsg)),
 				)
 			},
 			wantedError: nil,

--- a/internal/pkg/cli/project_delete_test.go
+++ b/internal/pkg/cli/project_delete_test.go
@@ -8,10 +8,19 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
+	awssession "github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	mockProjectName = "mockProjectName"
+	mockError       = errors.New("mockError)")
 )
 
 func TestDeleteProjectOpts_Validate(t *testing.T) {
@@ -25,7 +34,7 @@ func TestDeleteProjectOpts_Validate(t *testing.T) {
 			want:        errNoProjectInWorkspace,
 		},
 		"should return nil if project name is set": {
-			projectName: "mockProjectName",
+			projectName: mockProjectName,
 			want:        nil,
 		},
 	}
@@ -48,8 +57,6 @@ func TestDeleteProjectOpts_Validate(t *testing.T) {
 }
 
 func TestDeleteProjectOpts_Ask(t *testing.T) {
-	mockProjectName := "mockProjectName"
-	mockError := errors.New("mockError)")
 
 	var mockPrompter *mocks.Mockprompter
 
@@ -124,8 +131,56 @@ func TestDeleteProjectOpts_Ask(t *testing.T) {
 }
 
 func TestDeleteProjectOpts_DeleteApps(t *testing.T) {
-	mockProjectName := "mockProjectName"
-	mockError := errors.New("mockError")
+	var mockStore *mocks.MockprojectService
+
+	tests := map[string]struct {
+		setupMocks func(ctrl *gomock.Controller)
+		want       error
+	}{
+		"return error is listing applications fails": {
+			setupMocks: func(ctrl *gomock.Controller) {
+				mockStore = mocks.NewMockprojectService(ctrl)
+
+				mockStore.EXPECT().
+					ListApplications(mockProjectName).
+					Return(nil, mockError)
+			},
+			want: mockError,
+		},
+		"return nil if no apps returned from listing applications": {
+			setupMocks: func(ctrl *gomock.Controller) {
+				mockStore = mocks.NewMockprojectService(ctrl)
+
+				mockStore.EXPECT().
+					ListApplications(mockProjectName).
+					Return(nil, nil)
+			},
+			want: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			test.setupMocks(ctrl)
+			opts := deleteProjOpts{
+				deleteProjVars: deleteProjVars{
+					GlobalOpts: &GlobalOpts{
+						projectName: mockProjectName,
+					},
+				},
+				store: mockStore,
+			}
+
+			got := opts.deleteApps()
+
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestDeleteProjectOpts_EmptyS3Bucket(t *testing.T) {
 
 	var mockStore *mocks.MockprojectService
 
@@ -177,56 +232,159 @@ func TestDeleteProjectOpts_DeleteApps(t *testing.T) {
 	}
 }
 
-func TestDeleteProjectOpts_EmptyS3Bucket(t *testing.T) {
-	mockProjectName := "mockProjectName"
-	mockError := errors.New("mockError")
+type deleteProjectMocks struct {
+	spinner         *mocks.Mockprogress
+	store           *mocks.MockprojectService
+	ws              *mocks.MockworkspaceDeleter
+	sessProvider    *session.Provider
+	deployer        *mocks.Mockdeployer
+	appDeleter      *mocks.MockdeleteAppExecutor
+	envDeleter      *mocks.MockdeleteEnvRunner
+	bucketEmptier   *mocks.MockbucketEmptier
+	pipelineDeleter *mocks.MockdeletePipelineRunner
+}
 
-	var mockStore *mocks.MockprojectService
-
+func TestDeleteProjectOpts_Execute(t *testing.T) {
+	mockApps := []*archer.Application{
+		&archer.Application{
+			Name: "webapp",
+		},
+	}
+	mockEnvs := []*archer.Environment{
+		&archer.Environment{
+			Name: "staging",
+		},
+	}
+	mockProject := &archer.Project{
+		Name: "badgoose",
+	}
+	mockResources := []*archer.ProjectRegionalResources{
+		&archer.ProjectRegionalResources{
+			Region:   "us-west-2",
+			S3Bucket: "goose-bucket",
+		},
+	}
 	tests := map[string]struct {
-		setupMocks func(ctrl *gomock.Controller)
-		want       error
+		projectName string
+		setupMocks  func(mocks deleteProjectMocks)
+
+		wantedError error
 	}{
-		"return error is listing applications fails": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockStore = mocks.NewMockprojectService(ctrl)
+		"happy path": {
 
-				mockStore.EXPECT().
-					ListApplications(mockProjectName).
-					Return(nil, mockError)
-			},
-			want: mockError,
-		},
-		"return nil if no apps returned from listing applications": {
-			setupMocks: func(ctrl *gomock.Controller) {
-				mockStore = mocks.NewMockprojectService(ctrl)
+			projectName: mockProjectName,
+			setupMocks: func(mocks deleteProjectMocks) {
+				gomock.InOrder(
+					// deleteApps
+					mocks.store.EXPECT().ListApplications(mockProjectName).Return(mockApps, nil),
+					mocks.appDeleter.EXPECT().Execute().Return(nil),
 
-				mockStore.EXPECT().
-					ListApplications(mockProjectName).
-					Return(nil, nil)
+					// deleteEnvs
+					mocks.store.EXPECT().ListEnvironments(mockProjectName).Return(mockEnvs, nil),
+					mocks.envDeleter.EXPECT().Ask().Return(nil),
+					mocks.envDeleter.EXPECT().Execute().Return(nil),
+
+					// emptyS3bucket
+					mocks.store.EXPECT().GetProject(mockProjectName).Return(mockProject, nil),
+					mocks.deployer.EXPECT().GetRegionalProjectResources(mockProject).Return(mockResources, nil),
+					mocks.spinner.EXPECT().Start(fmtCleanResourcesStart),
+					mocks.bucketEmptier.EXPECT().EmptyBucket(mockResources[0].S3Bucket).Return(nil),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtCleanResourcesStop)),
+
+					// deleteProjectPipline
+					mocks.pipelineDeleter.EXPECT().Run().Return(nil),
+
+					// deleteProjectResources
+					mocks.spinner.EXPECT().Start(fmtDeleteProjectResourcesStart),
+					mocks.deployer.EXPECT().DeleteProject(mockProjectName).Return(nil),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectResourcesStop)),
+
+					// deleteProjectParams
+					mocks.spinner.EXPECT().Start(fmtDeleteProjectParamsStart),
+					mocks.store.EXPECT().DeleteProject(mockProjectName).Return(nil),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteProjectParamsStop)),
+
+					// deleteLocalWorkspace
+					mocks.spinner.EXPECT().Start(fmtDeleteLocalWsStart),
+					mocks.ws.EXPECT().DeleteAll().Return(nil),
+					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtDeleteLocalWsStop)),
+				)
 			},
-			want: nil,
+			wantedError: nil,
 		},
-		// TODO: add more tests when app deletion workflow is inline mockable (provider pattern?)
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			// GIVEN
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			test.setupMocks(ctrl)
+
+			mockSpinner := mocks.NewMockprogress(ctrl)
+			mockStore := mocks.NewMockprojectService(ctrl)
+			mockWorkspace := mocks.NewMockworkspaceDeleter(ctrl)
+			mockSession := session.NewProvider()
+			mockDeployer := mocks.NewMockdeployer(ctrl)
+
+			mockBucketEmptier := mocks.NewMockbucketEmptier(ctrl)
+			mockGetBucketEmptier := func(session *awssession.Session) bucketEmptier {
+				return mockBucketEmptier
+			}
+
+			// The following three sets of mocks are to avoid having to go through
+			// mocking all the intermediary steps in calling Execute on DeleteAppOpts,
+			// DeleteEnvOpts, and DeletePipelineOpts. It allows us to instead simply
+			// test if the deletion of those resources succeeded or failed.
+			mockDeleteAppExecutor := mocks.NewMockdeleteAppExecutor(ctrl)
+			mockDeleteAppExecutorProvider := func(appName string) (deleteAppExecutor, error) {
+				return mockDeleteAppExecutor, nil
+			}
+
+			mockDeleteEnvRunner := mocks.NewMockdeleteEnvRunner(ctrl)
+			mockDeleteEnvRunnerProvider := func(envName, envProfile string) (deleteEnvRunner, error) {
+				return mockDeleteEnvRunner, nil
+			}
+
+			mockDeletePipelineRunner := mocks.NewMockdeletePipelineRunner(ctrl)
+			mockDeletePipelineRunnerProvider := func() (deletePipelineRunner, error) {
+				return mockDeletePipelineRunner, nil
+			}
+
+			mocks := deleteProjectMocks{
+				spinner:         mockSpinner,
+				store:           mockStore,
+				ws:              mockWorkspace,
+				sessProvider:    mockSession,
+				deployer:        mockDeployer,
+				appDeleter:      mockDeleteAppExecutor,
+				envDeleter:      mockDeleteEnvRunner,
+				bucketEmptier:   mockBucketEmptier,
+				pipelineDeleter: mockDeletePipelineRunner,
+			}
+			test.setupMocks(mocks)
+
 			opts := deleteProjOpts{
 				deleteProjVars: deleteProjVars{
 					GlobalOpts: &GlobalOpts{
 						projectName: mockProjectName,
 					},
 				},
-				store: mockStore,
+				spinner:                      mockSpinner,
+				store:                        mockStore,
+				ws:                           mockWorkspace,
+				sessProvider:                 mockSession,
+				deployer:                     mockDeployer,
+				getBucketEmptier:             mockGetBucketEmptier,
+				deleteAppExecutorProvider:    mockDeleteAppExecutorProvider,
+				deleteEnvRunnerProvider:      mockDeleteEnvRunnerProvider,
+				deletePipelineRunnerProvider: mockDeletePipelineRunnerProvider,
 			}
 
-			got := opts.deleteApps()
+			// WHEN
+			err := opts.Execute()
 
-			require.Equal(t, test.want, got)
+			// THEN
+			require.Equal(t, test.wantedError, err)
 		})
 	}
 }

--- a/internal/pkg/cli/project_delete_test.go
+++ b/internal/pkg/cli/project_delete_test.go
@@ -233,8 +233,8 @@ type deleteProjectMocks struct {
 	ws              *mocks.MockworkspaceDeleter
 	sessProvider    *session.Provider
 	deployer        *mocks.Mockdeployer
-	appDeleter      *mocks.MockdeleteAppExecutor
-	envDeleter      *mocks.MockdeleteEnvRunner
+	appDeleter      *mocks.Mockexecutor
+	envDeleter      *mocks.MockaskExecutor
 	bucketEmptier   *mocks.MockbucketEmptier
 	pipelineDeleter *mocks.MockdeletePipelineRunner
 }
@@ -373,19 +373,19 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 			// mocking all the intermediary steps in calling Execute on DeleteAppOpts,
 			// DeleteEnvOpts, and DeletePipelineOpts. It allows us to instead simply
 			// test if the deletion of those resources succeeded or failed.
-			mockDeleteAppExecutor := mocks.NewMockdeleteAppExecutor(ctrl)
-			mockDeleteAppExecutorProvider := func(appName string) (deleteAppExecutor, error) {
-				return mockDeleteAppExecutor, nil
+			mockExecutor := mocks.NewMockexecutor(ctrl)
+			mockExecutorProvider := func(appName string) (executor, error) {
+				return mockExecutor, nil
 			}
 
-			mockDeleteEnvRunner := mocks.NewMockdeleteEnvRunner(ctrl)
-			mockDeleteEnvRunnerProvider := func(envName, envProfile string) (deleteEnvRunner, error) {
-				return mockDeleteEnvRunner, nil
+			mockAskExecutor := mocks.NewMockaskExecutor(ctrl)
+			mockAskExecutorProvider := func(envName, envProfile string) (askExecutor, error) {
+				return mockAskExecutor, nil
 			}
 
-			mockDeletePipelineRunner := mocks.NewMockdeletePipelineRunner(ctrl)
-			mockDeletePipelineRunnerProvider := func() (deletePipelineRunner, error) {
-				return mockDeletePipelineRunner, nil
+			mockRunner := mocks.NewMockdeletePipelineRunner(ctrl)
+			mockRunnerProvider := func() (deletePipelineRunner, error) {
+				return mockRunner, nil
 			}
 
 			mocks := deleteProjectMocks{
@@ -394,10 +394,10 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 				ws:              mockWorkspace,
 				sessProvider:    mockSession,
 				deployer:        mockDeployer,
-				appDeleter:      mockDeleteAppExecutor,
-				envDeleter:      mockDeleteEnvRunner,
+				appDeleter:      mockExecutor,
+				envDeleter:      mockAskExecutor,
 				bucketEmptier:   mockBucketEmptier,
-				pipelineDeleter: mockDeletePipelineRunner,
+				pipelineDeleter: mockRunner,
 			}
 			test.setupMocks(mocks)
 
@@ -413,9 +413,9 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 				sessProvider:                 mockSession,
 				deployer:                     mockDeployer,
 				getBucketEmptier:             mockGetBucketEmptier,
-				deleteAppExecutorProvider:    mockDeleteAppExecutorProvider,
-				deleteEnvRunnerProvider:      mockDeleteEnvRunnerProvider,
-				deletePipelineRunnerProvider: mockDeletePipelineRunnerProvider,
+				executorProvider:             mockExecutorProvider,
+				askExecutorProvider:          mockAskExecutorProvider,
+				deletePipelineRunnerProvider: mockRunnerProvider,
 			}
 
 			// WHEN

--- a/internal/pkg/cli/project_delete_test.go
+++ b/internal/pkg/cli/project_delete_test.go
@@ -259,7 +259,6 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 			S3Bucket: "goose-bucket",
 		},
 	}
-	noPipelineManifestError := &workspace.ErrNoPipelineInWorkspace{}
 	tests := map[string]struct {
 		projectName string
 		setupMocks  func(mocks deleteProjectMocks)
@@ -330,7 +329,7 @@ func TestDeleteProjectOpts_Execute(t *testing.T) {
 					mocks.spinner.EXPECT().Stop(log.Ssuccess(fmtCleanResourcesStop)),
 
 					// deleteProjectPipline
-					mocks.pipelineDeleter.EXPECT().Run().Return(noPipelineManifestError),
+					mocks.pipelineDeleter.EXPECT().Run().Return(workspace.ErrNoPipelineInWorkspace),
 
 					// deleteProjectResources
 					mocks.spinner.EXPECT().Start(fmtDeleteProjectResourcesStart),

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -44,3 +44,10 @@ type ErrFileExists struct {
 func (e *ErrFileExists) Error() string {
 	return fmt.Sprintf("file %s already exists", e.FileName)
 }
+
+// ErrNoPipelineInWorkspace means there was no pipeline manifest in the workspace dir.
+type ErrNoPipelineInWorkspace struct{}
+
+func (e *ErrNoPipelineInWorkspace) Error() string {
+	return fmt.Sprint("there was no pipeline manifest found in your workspace.")
+}

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -3,7 +3,13 @@
 
 package workspace
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNoPipelineInWorkspace means there was no pipeline manifest in the workspace dir.
+var ErrNoPipelineInWorkspace = errors.New("no pipeline manifest found in the workspace")
 
 // ErrWorkspaceNotFound means we couldn't locate a workspace root.
 type ErrWorkspaceNotFound struct {
@@ -43,11 +49,4 @@ type ErrFileExists struct {
 
 func (e *ErrFileExists) Error() string {
 	return fmt.Sprintf("file %s already exists", e.FileName)
-}
-
-// ErrNoPipelineInWorkspace means there was no pipeline manifest in the workspace dir.
-type ErrNoPipelineInWorkspace struct{}
-
-func (e *ErrNoPipelineInWorkspace) Error() string {
-	return fmt.Sprint("there was no pipeline manifest found in your workspace.")
 }

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -157,7 +157,7 @@ func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
 		return nil, err
 	}
 	if !manifestExists {
-		return nil, &ErrNoPipelineInWorkspace{}
+		return nil, ErrNoPipelineInWorkspace
 	}
 	return ws.read(pipelineFileName)
 }

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -147,6 +147,18 @@ func (ws *Workspace) ReadAppManifest(appName string) ([]byte, error) {
 
 // ReadPipelineManifest returns the contents of the pipeline manifest under ecs-project/pipeline.yml.
 func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
+	pmPath, err := ws.pipelineManifestPath()
+	if err != nil {
+		return nil, err
+	}
+	manifestExists, err := ws.fsUtils.Exists(pmPath)
+
+	if err != nil {
+		return nil, err
+	}
+	if !manifestExists {
+		return nil, &ErrNoPipelineInWorkspace{}
+	}
 	return ws.read(pipelineFileName)
 }
 
@@ -242,6 +254,15 @@ func (ws *Workspace) writeSummary(projectName string) error {
 		return err
 	}
 	return ws.fsUtils.WriteFile(summaryPath, serializedWorkspaceSummary, 0644)
+}
+
+func (ws *Workspace) pipelineManifestPath() (string, error) {
+	manifestPath, err := ws.projectDirPath()
+	if err != nil {
+		return "", err
+	}
+	pipelineManifestPath := filepath.Join(manifestPath, pipelineFileName)
+	return pipelineManifestPath, nil
 }
 
 func (ws *Workspace) summaryPath() (string, error) {

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -579,3 +579,53 @@ func TestWorkspace_ReadAddonsDir(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkspace_ReadPipelineManifest(t *testing.T) {
+	projectDir := "/ecs-project"
+	testCases := map[string]struct {
+		fs            func() afero.Fs
+		expectedError error
+	}{
+		"reads existing pipeline manifest": {
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.MkdirAll("/ecs-project", 0755)
+				manifest, _ := fs.Create("/ecs-project/pipeline.yml")
+				defer manifest.Close()
+				manifest.Write([]byte("hello"))
+				return fs
+			},
+			expectedError: nil,
+		},
+
+		"when no pipeline file exists": {
+			fs: func() afero.Fs {
+				fs := afero.NewMemMapFs()
+				fs.Mkdir(projectDir, 0755)
+				return fs
+			},
+			expectedError: &ErrNoPipelineInWorkspace{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// GIVEN
+			fs := tc.fs()
+			ws := &Workspace{
+				projectDir: projectDir,
+				fsUtils:    &afero.Afero{Fs: fs},
+			}
+
+			// WHEN
+			_, err := ws.ReadPipelineManifest()
+
+			// THEN
+			if tc.expectedError != nil {
+				require.Equal(t, tc.expectedError.Error(), err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/pkg/workspace/workspace_test.go
+++ b/internal/pkg/workspace/workspace_test.go
@@ -604,7 +604,7 @@ func TestWorkspace_ReadPipelineManifest(t *testing.T) {
 				fs.Mkdir(projectDir, 0755)
 				return fs
 			},
-			expectedError: &ErrNoPipelineInWorkspace{},
+			expectedError: ErrNoPipelineInWorkspace,
 		},
 	}
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously, project delete would fail if there was no pipeline.yml file in the workspace directory. However, it is possible that the project does not have a pipeline manifest at all and this should not cause project delete to fail. This change fixes that bug.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
