### PR TITLE
chore(e2e): Force e2e test to extract port from frontend dockerfile

### DIFF
--- a/e2e/multi-app-project/multi_app_project_test.go
+++ b/e2e/multi-app-project/multi_app_project_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Multiple App Project", func() {
 				AppName:    "front-end",
 				AppType:    "Load Balanced Web App",
 				Dockerfile: "./front-end/Dockerfile",
-				AppPort:    "80",
 			})
 
 			_, backEndInitErr = cli.AppInit(&client.AppInitRequest{


### PR DESCRIPTION
<!-- Provide summary of changes -->
Removed the provided port from the end to end test frontend app init params to force copilot to extract the port from the EXPOSE statement in the e2e frontend dockerfile. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Related to #747

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
