### PR TITLE
test: fix e2e by applying optional flags only if they're provided

### DIFF
--- a/e2e/internal/client/cli.go
+++ b/e2e/internal/client/cli.go
@@ -136,12 +136,19 @@ ecs-preview app init
 	--port $port
 */
 func (cli *CLI) AppInit(opts *AppInitRequest) (string, error) {
+	args := []string{
+		"app",
+		"init",
+		"--name", opts.AppName,
+		"--app-type", opts.AppType,
+		"--dockerfile", opts.Dockerfile,
+	}
+	// Apply optional flags only if a value is provided.
+	if opts.AppPort != "" {
+		args = append(args, "--port", opts.AppPort)
+	}
 	return cli.exec(
-		exec.Command(cli.path, "app", "init",
-			"--name", opts.AppName,
-			"--app-type", opts.AppType,
-			"--dockerfile", opts.Dockerfile,
-			"--port", opts.AppPort))
+		exec.Command(cli.path, args...))
 }
 
 /*AppShow runs:


### PR DESCRIPTION
AppPort is not a required field if we can parse it from the Dockerfile.
This change removes the flag if it's not provided explicitly.
Otherwise the --port value is set to the empty string "" and the CLI blows up.


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
