### PR TITLE
build: env show execute--basic structs

### DIFF
--- a/internal/pkg/cli/env_show.go
+++ b/internal/pkg/cli/env_show.go
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-
 package cli
 
 import (
@@ -31,7 +30,7 @@ type showEnvVars struct {
 type showEnvOpts struct {
 	showEnvVars
 
-	w 		 io.Writer
+	w        io.Writer
 	storeSvc storeReader
 }
 
@@ -43,8 +42,8 @@ func newShowEnvOpts(vars showEnvVars) (*showEnvOpts, error) {
 
 	return &showEnvOpts{
 		showEnvVars: vars,
-		storeSvc:        ssmStore,
-		w:               log.OutputWriter,
+		storeSvc:    ssmStore,
+		w:           log.OutputWriter,
 		// initDescriber: make EnvDescriber here
 	}, nil
 }
@@ -88,6 +87,10 @@ func (o *showEnvOpts) askProject() error {
 	}
 	if len(projNames) == 0 {
 		return fmt.Errorf("no project found: run %s please", color.HighlightCode("project init"))
+	}
+	if len(projNames) == 1 {
+		o.projectName = projNames[0]
+		return nil
 	}
 	proj, err := o.prompt.SelectOne(
 		environmentShowProjectNamePrompt,
@@ -164,9 +167,9 @@ func BuildEnvShowCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Hidden: true, //TODO remove when ready for production!
-		Use:   "show",
-		Short: "Shows info about a deployed environment.",
-		Long:  "Shows info about a deployed environment, including region, account ID, and apps.",
+		Use:    "show",
+		Short:  "Shows info about a deployed environment.",
+		Long:   "Shows info about a deployed environment, including region, account ID, and apps.",
 
 		Example: `
   Shows info about the environment "test"

--- a/internal/pkg/cli/env_show.go
+++ b/internal/pkg/cli/env_show.go
@@ -6,8 +6,19 @@ package cli
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
 	"github.com/spf13/cobra"
+)
+
+const (
+	environmentShowProjectNamePrompt     = "Which project's environments would you like to show?"
+	environmentShowProjectNameHelpPrompt = "A project groups all of your applications together."
+	environmentShowEnvNamePrompt         = "Which environment of %s would you like to show?"
+	environmentShowEnvNameHelpPrompt     = "The detail of an environment will be shown (e.g., region, account ID, apps)."
 )
 
 type showEnvVars struct {
@@ -20,7 +31,8 @@ type showEnvVars struct {
 type showEnvOpts struct {
 	showEnvVars
 
-	storeSvc      storeReader
+	w 		 io.Writer
+	storeSvc storeReader
 }
 
 func newShowEnvOpts(vars showEnvVars) (*showEnvOpts, error) {
@@ -30,8 +42,10 @@ func newShowEnvOpts(vars showEnvVars) (*showEnvOpts, error) {
 	}
 
 	return &showEnvOpts{
-		showEnvVars: 	vars,
-		storeSvc:       ssmStore,
+		showEnvVars: vars,
+		storeSvc:        ssmStore,
+		w:               log.OutputWriter,
+		// initDescriber: make EnvDescriber here
 	}, nil
 }
 
@@ -53,12 +67,94 @@ func (o *showEnvOpts) Validate() error {
 
 // Ask asks for fields that are required but not passed in.
 func (o *showEnvOpts) Ask() error {
-	return nil
+	if err := o.askProject(); err != nil {
+		return err
+	}
+	return o.askEnvName()
 }
 
 // Execute shows the environments through the prompt.
 func (o *showEnvOpts) Execute() error {
 	return nil
+}
+
+func (o *showEnvOpts) askProject() error {
+	if o.ProjectName() != "" {
+		return nil
+	}
+	projNames, err := o.retrieveProjects()
+	if err != nil {
+		return err
+	}
+	if len(projNames) == 0 {
+		return fmt.Errorf("no project found: run %s please", color.HighlightCode("project init"))
+	}
+	proj, err := o.prompt.SelectOne(
+		environmentShowProjectNamePrompt,
+		environmentShowProjectNameHelpPrompt,
+		projNames,
+	)
+	if err != nil {
+		return fmt.Errorf("select projects: %w", err)
+	}
+	o.projectName = proj
+
+	return nil
+}
+
+func (o *showEnvOpts) askEnvName() error {
+	//return if env name is set by flag
+	if o.envName != "" {
+		return nil
+	}
+
+	envNames, err := o.retrieveAllEnvironments()
+	if err != nil {
+		return err
+	}
+
+	if len(envNames) == 0 {
+		log.Infof("No environments found in project %s\n.", color.HighlightUserInput(o.ProjectName()))
+		return nil
+	}
+	if len(envNames) == 1 {
+		o.envName = envNames[0]
+		return nil
+	}
+	envName, err := o.prompt.SelectOne(
+		fmt.Sprintf(environmentShowEnvNamePrompt, color.HighlightUserInput(o.ProjectName())), environmentShowEnvNameHelpPrompt, envNames,
+	)
+	if err != nil {
+		return fmt.Errorf("select environment for project %s: %w", o.ProjectName(), err)
+	}
+	o.envName = envName
+
+	return nil
+}
+
+func (o *showEnvOpts) retrieveProjects() ([]string, error) {
+	projs, err := o.storeSvc.ListProjects()
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	projNames := make([]string, len(projs))
+	for ind, proj := range projs {
+		projNames[ind] = proj.Name
+	}
+	return projNames, nil
+}
+
+func (o *showEnvOpts) retrieveAllEnvironments() ([]string, error) {
+	envs, err := o.storeSvc.ListEnvironments(o.ProjectName())
+	if err != nil {
+		return nil, fmt.Errorf("list environments for project %s: %w", o.ProjectName(), err)
+	}
+	envNames := make([]string, len(envs))
+	for ind, env := range envs {
+		envNames[ind] = env.Name
+	}
+
+	return envNames, nil
 }
 
 // BuildEnvShowCmd builds the command for showing environments in a project.

--- a/internal/pkg/cli/env_show.go
+++ b/internal/pkg/cli/env_show.go
@@ -16,7 +16,7 @@ import (
 const (
 	environmentShowProjectNamePrompt     = "Which project's environments would you like to show?"
 	environmentShowProjectNameHelpPrompt = "A project groups all of your applications together."
-	environmentShowEnvNamePrompt         = "Which environment of %s would you like to show?"
+	fmtEnvironmentShowEnvNamePrompt      = "Which environment of %s would you like to show?"
 	environmentShowEnvNameHelpPrompt     = "The detail of an environment will be shown (e.g., region, account ID, apps)."
 )
 
@@ -125,7 +125,7 @@ func (o *showEnvOpts) askEnvName() error {
 		return nil
 	}
 	envName, err := o.prompt.SelectOne(
-		fmt.Sprintf(environmentShowEnvNamePrompt, color.HighlightUserInput(o.ProjectName())), environmentShowEnvNameHelpPrompt, envNames,
+		fmt.Sprintf(fmtEnvironmentShowEnvNamePrompt, color.HighlightUserInput(o.ProjectName())), environmentShowEnvNameHelpPrompt, envNames,
 	)
 	if err != nil {
 		return fmt.Errorf("select environment for project %s: %w", o.ProjectName(), err)

--- a/internal/pkg/cli/env_show_test.go
+++ b/internal/pkg/cli/env_show_test.go
@@ -15,16 +15,16 @@ import (
 )
 
 type showEnvMocks struct {
-	storeSvc	*climocks.MockstoreReader
-	prompt 		*climocks.Mockprompter
+	storeSvc *climocks.MockstoreReader
+	prompt   *climocks.Mockprompter
 	//describer   *climocks.MockwebEnvDescriber
 }
 
 func TestEnvShow_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		inputProject	  string
-		inputEnvironment  string
-		setupMocks   	func(mocks showEnvMocks)
+		inputProject     string
+		inputEnvironment string
+		setupMocks       func(mocks showEnvMocks)
 
 		wantedError error
 	}{
@@ -34,12 +34,12 @@ func TestEnvShow_Validate(t *testing.T) {
 
 			setupMocks: func(m showEnvMocks) {
 				gomock.InOrder(
-				m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
-					Name: "my-project",
-				}, nil),
-				m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(&archer.Environment{
-					Name: "my-env",
-				}, nil),
+					m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
+						Name: "my-project",
+					}, nil),
+					m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(&archer.Environment{
+						Name: "my-env",
+					}, nil),
 				)
 			},
 
@@ -61,10 +61,10 @@ func TestEnvShow_Validate(t *testing.T) {
 
 			setupMocks: func(m showEnvMocks) {
 				gomock.InOrder(
-				m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
-					Name: "my-project",
-				}, nil),
-				m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(nil, errors.New("some error")),
+					m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
+						Name: "my-project",
+					}, nil),
+					m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(nil, errors.New("some error")),
 				)
 			},
 
@@ -110,14 +110,14 @@ func TestEnvShow_Validate(t *testing.T) {
 
 func TestEnvShow_Ask(t *testing.T) {
 	testCases := map[string]struct {
-		inputProject	string
-		inputEnv		string
+		inputProject string
+		inputEnv     string
 
-		setupMocks		func(mocks showEnvMocks) //or m?
+		setupMocks func(mocks showEnvMocks) //or m?
 
-		wantedProject	string
-		wantedEnv		string
-		wantedError		error
+		wantedProject string
+		wantedEnv     string
+		wantedError   error
 	}{
 		"with all flags": {
 			inputProject: "my-project",
@@ -148,6 +148,24 @@ func TestEnvShow_Ask(t *testing.T) {
 						{Name: "archer-env"},
 					}, nil),
 					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("my-env", nil).Times(1),
+				)
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   nil,
+		},
+		"skip selecting if only one project found": {
+			inputProject: "",
+			inputEnv:     "my-env",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{
+						{
+							Name: "my-project",
+						},
+					}, nil),
 				)
 			},
 
@@ -253,7 +271,7 @@ func TestEnvShow_Ask(t *testing.T) {
 						{Name: "my-env"},
 						{Name: "archer-env"},
 					}, nil),
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt,"my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("", fmt.Errorf("some error")).Times(1),
+					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("", fmt.Errorf("some error")).Times(1),
 				)
 			},
 			wantedProject: "my-project",

--- a/internal/pkg/cli/env_show_test.go
+++ b/internal/pkg/cli/env_show_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	"github.com/golang/mock/gomock"
@@ -13,11 +14,17 @@ import (
 	"testing"
 )
 
+type showEnvMocks struct {
+	storeSvc	*climocks.MockstoreReader
+	prompt 		*climocks.Mockprompter
+	//describer   *climocks.MockwebEnvDescriber
+}
+
 func TestEnvShow_Validate(t *testing.T) {
 	testCases := map[string]struct {
 		inputProject	  string
 		inputEnvironment  string
-		mockStoreReader   func(m *climocks.MockstoreReader)
+		setupMocks   	func(mocks showEnvMocks)
 
 		wantedError error
 	}{
@@ -25,13 +32,15 @@ func TestEnvShow_Validate(t *testing.T) {
 			inputProject:     "my-project",
 			inputEnvironment: "my-env",
 
-			mockStoreReader: func(m *climocks.MockstoreReader) {
-				m.EXPECT().GetProject("my-project").Return(&archer.Project{
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+				m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
 					Name: "my-project",
-				}, nil)
-				m.EXPECT().GetEnvironment("my-project", "my-env").Return(&archer.Environment{
+				}, nil),
+				m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(&archer.Environment{
 					Name: "my-env",
-				}, nil)
+				}, nil),
+				)
 			},
 
 			wantedError: nil,
@@ -40,8 +49,8 @@ func TestEnvShow_Validate(t *testing.T) {
 			inputProject:     "my-project",
 			inputEnvironment: "my-env",
 
-			mockStoreReader: func(m *climocks.MockstoreReader) {
-				m.EXPECT().GetProject("my-project").Return(nil, errors.New("some error"))
+			setupMocks: func(m showEnvMocks) {
+				m.storeSvc.EXPECT().GetProject("my-project").Return(nil, errors.New("some error"))
 			},
 
 			wantedError: fmt.Errorf("some error"),
@@ -50,11 +59,13 @@ func TestEnvShow_Validate(t *testing.T) {
 			inputProject:     "my-project",
 			inputEnvironment: "my-env",
 
-			mockStoreReader: func(m *climocks.MockstoreReader) {
-				m.EXPECT().GetProject("my-project").Return(&archer.Project{
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+				m.storeSvc.EXPECT().GetProject("my-project").Return(&archer.Project{
 					Name: "my-project",
-				}, nil)
-				m.EXPECT().GetEnvironment("my-project", "my-env").Return(nil, errors.New("some error"))
+				}, nil),
+				m.storeSvc.EXPECT().GetEnvironment("my-project", "my-env").Return(nil, errors.New("some error")),
+				)
 			},
 
 			wantedError: fmt.Errorf("some error"),
@@ -67,7 +78,12 @@ func TestEnvShow_Validate(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockStoreReader := climocks.NewMockstoreReader(ctrl)
-			tc.mockStoreReader(mockStoreReader)
+
+			mocks := showEnvMocks{
+				storeSvc: mockStoreReader,
+			}
+
+			tc.setupMocks(mocks)
 
 			showEnvs := &showEnvOpts{
 				showEnvVars: showEnvVars{
@@ -87,6 +103,199 @@ func TestEnvShow_Validate(t *testing.T) {
 				require.EqualError(t, err, tc.wantedError.Error())
 			} else {
 				require.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestEnvShow_Ask(t *testing.T) {
+	testCases := map[string]struct {
+		inputProject	string
+		inputEnv		string
+
+		setupMocks		func(mocks showEnvMocks) //or m?
+
+		wantedProject	string
+		wantedEnv		string
+		wantedError		error
+	}{
+		"with all flags": {
+			inputProject: "my-project",
+			inputEnv:     "my-env",
+
+			setupMocks: func(mocks showEnvMocks) {},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   nil,
+		},
+		"retrieve all env names": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					// askProject
+					m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{
+						{Name: "my-project"},
+						{Name: "archer-project"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(environmentShowProjectNamePrompt, environmentShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
+
+					// askEnvName
+					m.storeSvc.EXPECT().ListEnvironments("my-project").Return([]*archer.Environment{
+						{Name: "my-env"},
+						{Name: "archer-env"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("my-env", nil).Times(1),
+				)
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   nil,
+		},
+		"skip selecting if only one env found": {
+			inputProject: "my-project",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					m.storeSvc.EXPECT().ListEnvironments("my-project").Return([]*archer.Environment{
+						{
+							Name: "my-env",
+						},
+					}, nil),
+				)
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   nil,
+		},
+		"returns error when fail to list project": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				m.storeSvc.EXPECT().ListProjects().Return(nil, errors.New("some error"))
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   fmt.Errorf("list projects: some error"),
+		},
+		"returns error when no project found": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{}, nil)
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   fmt.Errorf("no project found: run `project init` please"),
+		},
+		"returns error when fail to select project": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					// askProject
+					m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{
+						{Name: "my-project"},
+						{Name: "archer-project"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(environmentShowProjectNamePrompt, environmentShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("", errors.New("some error")).Times(1),
+				)
+			},
+
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   fmt.Errorf("select projects: some error"),
+		},
+		"returns error when fail to list environments": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					// askProject
+					m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{
+						{Name: "my-project"},
+						{Name: "archer-project"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(environmentShowProjectNamePrompt, environmentShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
+					//askEnvName
+					m.storeSvc.EXPECT().ListEnvironments("my-project").Return(nil, fmt.Errorf("some error")),
+				)
+			},
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   fmt.Errorf("list environments for project my-project: some error"),
+		},
+		"returns error when fail to select environment": {
+			inputProject: "",
+			inputEnv:     "",
+
+			setupMocks: func(m showEnvMocks) {
+				gomock.InOrder(
+					// askProject
+					m.storeSvc.EXPECT().ListProjects().Return([]*archer.Project{
+						{Name: "my-project"},
+						{Name: "archer-project"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(environmentShowProjectNamePrompt, environmentShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
+					//askEnvName
+					m.storeSvc.EXPECT().ListEnvironments("my-project").Return([]*archer.Environment{
+						{Name: "my-env"},
+						{Name: "archer-env"},
+					}, nil),
+					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt,"my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("", fmt.Errorf("some error")).Times(1),
+				)
+			},
+			wantedProject: "my-project",
+			wantedEnv:     "my-env",
+			wantedError:   fmt.Errorf("select environment for project my-project: some error"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockStoreReader := climocks.NewMockstoreReader(ctrl)
+			mockPrompter := climocks.NewMockprompter(ctrl)
+
+			mocks := showEnvMocks{
+				storeSvc: mockStoreReader,
+				prompt:   mockPrompter,
+			}
+
+			tc.setupMocks(mocks)
+
+			showEnvs := &showEnvOpts{
+				showEnvVars: showEnvVars{
+					envName: tc.inputEnv,
+					GlobalOpts: &GlobalOpts{
+						prompt:      mockPrompter,
+						projectName: tc.inputProject,
+					},
+				},
+				storeSvc: mockStoreReader,
+			}
+			// WHEN
+			err := showEnvs.Ask()
+			// THEN
+			if tc.wantedError != nil {
+				require.EqualError(t, err, tc.wantedError.Error())
+			} else {
+				require.Nil(t, err)
+				require.Equal(t, tc.wantedProject, showEnvs.ProjectName(), "expected project name to match")
+				require.Equal(t, tc.wantedEnv, showEnvs.envName, "expected environment name to match")
 			}
 		})
 	}

--- a/internal/pkg/cli/env_show_test.go
+++ b/internal/pkg/cli/env_show_test.go
@@ -147,7 +147,7 @@ func TestEnvShow_Ask(t *testing.T) {
 						{Name: "my-env"},
 						{Name: "archer-env"},
 					}, nil),
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("my-env", nil).Times(1),
+					m.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtEnvironmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("my-env", nil).Times(1),
 				)
 			},
 
@@ -271,7 +271,7 @@ func TestEnvShow_Ask(t *testing.T) {
 						{Name: "my-env"},
 						{Name: "archer-env"},
 					}, nil),
-					m.prompt.EXPECT().SelectOne(fmt.Sprintf(environmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("", fmt.Errorf("some error")).Times(1),
+					m.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtEnvironmentShowEnvNamePrompt, "my-project"), environmentShowEnvNameHelpPrompt, []string{"my-env", "archer-env"}).Return("", fmt.Errorf("some error")).Times(1),
 				)
 			},
 			wantedProject: "my-project",

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -1,0 +1,76 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package describe
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	//"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
+)
+
+type Environment struct {
+	Name       string `json:"name"`
+	Production bool   `json:"production"`
+	Region     string `json:"region"`
+	AccountID  string `json:"accountID"`
+}
+
+type EnvApp struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type EnvTags struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Env struct {
+	About []*Environment `json:"about"`
+	Applications []*EnvApp `json:"applications"`
+	Tags []*EnvTags `json:"tags"`
+}
+
+// EnvDescriber retrieves information about an environment.
+type EnvDescriber struct {
+	env *archer.Environment
+
+	//store           envGetter
+	//ecsClient       map[string]ecsService
+	//stackDescribers map[string]stackDescriber
+	//sessProvider    sessionFromRoleProvider
+}
+
+// NewEnvDescriber instantiates an environment.
+func NewEnvDescriber(project, env string) (*EnvDescriber, error) {
+	svc, err := store.New()
+	if err != nil {
+		return nil, fmt.Errorf("connect to store: %w", err)
+	}
+	meta, err := svc.GetEnvironment(project, env)
+	if err != nil {
+		return nil, err
+	}
+	return &EnvDescriber{
+		env: meta,
+		//store:           svc,
+		//stackDescribers: make(map[string]stackDescriber),
+		//ecsClient:       make(map[string]ecsService),
+		//sessProvider:    session.NewProvider(),
+	}, nil
+}
+
+// JSONString returns the stringified WebApp struct with json format.
+func (w *Environment) JSONString() (string, error) {
+	// TODO
+	return nil
+}
+
+// HumanString returns the stringified WebApp struct with human readable format.
+func (w *Environment) HumanString() string {
+	// TODO
+	return nil
+}

--- a/internal/pkg/describe/env.go
+++ b/internal/pkg/describe/env.go
@@ -5,15 +5,18 @@ package describe
 
 import (
 	"encoding/json"
+	//"encoding/json"
 	"fmt"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
+
 	//"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
 )
 
 type Environment struct {
 	Name       string `json:"name"`
-	Production bool   `json:"production"`
+	Production bool   `json:"production"` // add to instances used elsewhere (ie project_show)?
 	Region     string `json:"region"`
 	AccountID  string `json:"accountID"`
 }
@@ -38,10 +41,10 @@ type Env struct {
 type EnvDescriber struct {
 	env *archer.Environment
 
-	//store           envGetter
-	//ecsClient       map[string]ecsService
-	//stackDescribers map[string]stackDescriber
-	//sessProvider    sessionFromRoleProvider
+	store           envGetter
+	ecsClient       map[string]ecsService
+	stackDescribers map[string]stackDescriber
+	sessProvider    sessionFromRoleProvider
 }
 
 // NewEnvDescriber instantiates an environment.
@@ -56,21 +59,24 @@ func NewEnvDescriber(project, env string) (*EnvDescriber, error) {
 	}
 	return &EnvDescriber{
 		env: meta,
-		//store:           svc,
-		//stackDescribers: make(map[string]stackDescriber),
-		//ecsClient:       make(map[string]ecsService),
-		//sessProvider:    session.NewProvider(),
+		store:           svc,
+		stackDescribers: make(map[string]stackDescriber),
+		ecsClient:       make(map[string]ecsService),
+		sessProvider:    session.NewProvider(),
 	}, nil
 }
 
 // JSONString returns the stringified WebApp struct with json format.
-func (w *Environment) JSONString() (string, error) {
-	// TODO
-	return nil
+func (w *Env) JSONString() (string, error) {
+	b, err := json.Marshal(w)
+	if err != nil {
+		return "", fmt.Errorf("marshal applications: %w", err)
+	}
+	return fmt.Sprintf("%s\n", b), nil
 }
 
 // HumanString returns the stringified WebApp struct with human readable format.
-func (w *Environment) HumanString() string {
+func (w *Env) HumanString() string {
 	// TODO
-	return nil
+	return ""
 }

--- a/internal/pkg/describe/project.go
+++ b/internal/pkg/describe/project.go
@@ -12,12 +12,6 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 )
 
-type Environment struct {
-	Name      string `json:"name"`
-	AccountID string `json:"accountID"`
-	Region    string `json:"region"`
-}
-
 type Application struct {
 	Name string `json:"name"`
 	Type string `json:"type"`


### PR DESCRIPTION
This is the first mini step for env show execute. I've filled in enough code that the `ecs-preview env show` subcommand outputs something, but I have not fleshed out the describer yet. @SoManyHs, I don't have constructors for these structs (as you suggested) because they only hold data with no other dependencies, and are simple to init; this is how structs like these were handled elsewhere in the codebase. Please let me know if you'd like me to do it differently here. Thanks!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
