### PR TITLE
refactor: DeployApp accepts an interface instead of cfn primitives

### DIFF
--- a/internal/pkg/cli/app_deploy_test.go
+++ b/internal/pkg/cli/app_deploy_test.go
@@ -4,11 +4,11 @@
 package cli
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/addons"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -344,23 +344,20 @@ image:
 
 func TestAppDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 	mockError := errors.New("some error")
-	buf := &bytes.Buffer{}
-	fmt.Fprint(buf, "some data")
 	tests := map[string]struct {
-		addonsTemplate *bytes.Buffer
-		inputApp       string
-		inEnvironment  *archer.Environment
-		inProject      *archer.Project
+		inputApp      string
+		inEnvironment *archer.Environment
+		inProject     *archer.Project
 
 		mockProjectResourcesGetter func(m *climocks.MockprojectResourcesGetter)
 		mockS3Svc                  func(m *climocks.MockartifactPutter)
+		mockAddons                 func(m *climocks.Mocktemplater)
 
 		wantPath string
 		wantErr  error
 	}{
 		"should push addons template to S3 bucket": {
-			addonsTemplate: buf,
-			inputApp:       "mockApp",
+			inputApp: "mockApp",
 			inEnvironment: &archer.Environment{
 				Name:   "mockEnv",
 				Region: "us-west-2",
@@ -375,17 +372,18 @@ func TestAppDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 					S3Bucket: "mockBucket",
 				}, nil)
 			},
-
+			mockAddons: func(m *climocks.Mocktemplater) {
+				m.EXPECT().Template().Return("some data", nil)
+			},
 			mockS3Svc: func(m *climocks.MockartifactPutter) {
-				m.EXPECT().PutArtifact("mockBucket", "mockApp.addons.stack.yml", buf).Return("https://mockS3DomainName/mockPath", nil)
+				m.EXPECT().PutArtifact("mockBucket", "mockApp.addons.stack.yml", gomock.Any()).Return("https://mockS3DomainName/mockPath", nil)
 			},
 
 			wantErr:  nil,
 			wantPath: "https://mockS3DomainName/mockPath",
 		},
 		"should return error if fail to get project resources": {
-			addonsTemplate: buf,
-			inputApp:       "mockApp",
+			inputApp: "mockApp",
 			inEnvironment: &archer.Environment{
 				Name:   "mockEnv",
 				Region: "us-west-2",
@@ -393,20 +391,20 @@ func TestAppDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 			inProject: &archer.Project{
 				Name: "mockProject",
 			},
-
 			mockProjectResourcesGetter: func(m *climocks.MockprojectResourcesGetter) {
 				m.EXPECT().GetProjectResourcesByRegion(&archer.Project{
 					Name: "mockProject",
 				}, "us-west-2").Return(nil, mockError)
 			},
-
+			mockAddons: func(m *climocks.Mocktemplater) {
+				m.EXPECT().Template().Return("some data", nil)
+			},
 			mockS3Svc: func(m *climocks.MockartifactPutter) {},
 
 			wantErr: fmt.Errorf("get project resources: some error"),
 		},
 		"should return error if fail to upload to S3 bucket": {
-			addonsTemplate: buf,
-			inputApp:       "mockApp",
+			inputApp: "mockApp",
 			inEnvironment: &archer.Environment{
 				Name:   "mockEnv",
 				Region: "us-west-2",
@@ -422,12 +420,42 @@ func TestAppDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 					S3Bucket: "mockBucket",
 				}, nil)
 			},
-
+			mockAddons: func(m *climocks.Mocktemplater) {
+				m.EXPECT().Template().Return("some data", nil)
+			},
 			mockS3Svc: func(m *climocks.MockartifactPutter) {
-				m.EXPECT().PutArtifact("mockBucket", "mockApp.addons.stack.yml", buf).Return("", mockError)
+				m.EXPECT().PutArtifact("mockBucket", "mockApp.addons.stack.yml", gomock.Any()).Return("", mockError)
 			},
 
 			wantErr: fmt.Errorf("put addons artifact to bucket mockBucket: some error"),
+		},
+		"should return empty url if the application doesn't have any addons": {
+			inputApp: "mockApp",
+			mockAddons: func(m *climocks.Mocktemplater) {
+				m.EXPECT().Template().Return("", &addons.ErrDirNotExist{
+					AppName: "mockApp",
+				})
+			},
+			mockProjectResourcesGetter: func(m *climocks.MockprojectResourcesGetter) {
+				m.EXPECT().GetProjectResourcesByRegion(gomock.Any(), gomock.Any()).Times(0)
+			},
+			mockS3Svc: func(m *climocks.MockartifactPutter) {
+				m.EXPECT().PutArtifact(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantPath: "",
+		},
+		"should fail if addons cannot be retrieved from workspace": {
+			inputApp: "mockApp",
+			mockAddons: func(m *climocks.Mocktemplater) {
+				m.EXPECT().Template().Return("", mockError)
+			},
+			mockProjectResourcesGetter: func(m *climocks.MockprojectResourcesGetter) {
+				m.EXPECT().GetProjectResourcesByRegion(gomock.Any(), gomock.Any()).Times(0)
+			},
+			mockS3Svc: func(m *climocks.MockartifactPutter) {
+				m.EXPECT().PutArtifact(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: fmt.Errorf("retrieve addons template: %w", mockError),
 		},
 	}
 
@@ -439,21 +467,24 @@ func TestAppDeployOpts_pushAddonsTemplateToS3Bucket(t *testing.T) {
 			mockProjectSvc := climocks.NewMockprojectService(ctrl)
 			mockProjectResourcesGetter := climocks.NewMockprojectResourcesGetter(ctrl)
 			mockS3Svc := climocks.NewMockartifactPutter(ctrl)
+			mockAddons := climocks.NewMocktemplater(ctrl)
 			tc.mockProjectResourcesGetter(mockProjectResourcesGetter)
 			tc.mockS3Svc(mockS3Svc)
+			tc.mockAddons(mockAddons)
 
 			opts := appDeployOpts{
 				appDeployVars: appDeployVars{
 					AppName: tc.inputApp,
 				},
-				projectService:     mockProjectSvc,
-				appPackageCfClient: mockProjectResourcesGetter,
-				s3Service:          mockS3Svc,
-				targetEnvironment:  tc.inEnvironment,
-				targetProject:      tc.inProject,
+				projectService:    mockProjectSvc,
+				projectCFSvc:      mockProjectResourcesGetter,
+				addonsSvc:         mockAddons,
+				s3Service:         mockS3Svc,
+				targetEnvironment: tc.inEnvironment,
+				targetProject:     tc.inProject,
 			}
 
-			gotPath, gotErr := opts.pushAddonsTemplateToS3Bucket(tc.addonsTemplate)
+			gotPath, gotErr := opts.pushAddonsTemplateToS3Bucket()
 
 			if gotErr != nil {
 				require.EqualError(t, gotErr, tc.wantErr.Error())

--- a/internal/pkg/deploy/cloudformation/cloudformation.go
+++ b/internal/pkg/deploy/cloudformation/cloudformation.go
@@ -18,7 +18,8 @@ import (
 	"github.com/gobuffalo/packd"
 )
 
-type stackConfiguration interface {
+// StackConfiguration represents the set of methods needed to deploy a cloudformation stack.
+type StackConfiguration interface {
 	StackName() string
 	Template() (string, error)
 	Parameters() []*sdkcloudformation.Parameter
@@ -105,7 +106,7 @@ func (cf CloudFormation) streamResourceEvents(done <-chan struct{}, events chan 
 	}
 }
 
-func toStack(config stackConfiguration) (*cloudformation.Stack, error) {
+func toStack(config StackConfiguration) (*cloudformation.Stack, error) {
 	template, err := config.Template()
 	if err != nil {
 		return nil, err

--- a/internal/pkg/deploy/cloudformation/stack/app.go
+++ b/internal/pkg/deploy/cloudformation/stack/app.go
@@ -34,9 +34,10 @@ const (
 // RuntimeConfig represents configuration that's defined outside of the manifest file
 // that is needed to create a CloudFormation stack.
 type RuntimeConfig struct {
-	ImageRepoURL   string            // ImageRepoURL is the ECR repository URL the container image should be pushed to.
-	ImageTag       string            // ImageTag is the container image's unique tag.
-	AdditionalTags map[string]string // AdditionalTags are labels applied to resources in the application stack.
+	ImageRepoURL      string            // ImageRepoURL is the ECR repository URL the container image should be pushed to.
+	ImageTag          string            // ImageTag is the container image's unique tag.
+	AddonsTemplateURL string            // Optional. S3 object URL for the addons template.
+	AdditionalTags    map[string]string // AdditionalTags are labels applied to resources in the application stack.
 }
 
 type app struct {
@@ -91,7 +92,7 @@ func (a *app) Parameters() []*cloudformation.Parameter {
 		},
 		{
 			ParameterKey:   aws.String(AppAddonsTemplateURLParamKey),
-			ParameterValue: aws.String(""),
+			ParameterValue: aws.String(a.rc.AddonsTemplateURL),
 		},
 	}
 }


### PR DESCRIPTION
All application stacks need to implement the cloudformation.StackConfiguration
interface. By having "DeployApp" accept that interface we can have the
method deploy any type of application.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
