### PR TITLE
fix: remove project prefix when creating pipeline stack name

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/pipeline.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline.go
@@ -25,7 +25,7 @@ func NewPipelineStackConfig(in *deploy.CreatePipelineInput) *pipelineStackConfig
 }
 
 func (p *pipelineStackConfig) StackName() string {
-	return p.ProjectName + "-" + p.Name
+	return p.Name
 }
 
 func (p *pipelineStackConfig) Template() (string, error) {

--- a/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/pipeline_test.go
@@ -58,8 +58,7 @@ func TestPipelineStackName(t *testing.T) {
 		mockCreatePipelineInput(),
 	)
 
-	require.Equal(t, projectName+"-"+pipelineName,
-		pipeline.StackName(), "unexpected StackName")
+	require.Equal(t, pipelineName, pipeline.StackName(), "unexpected StackName")
 }
 
 func TestPipelineStackConfig_Template(t *testing.T) {


### PR DESCRIPTION
This was creating inconsistencies between the name of the stack in the
pipeline.yml file and the one being deployed

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
