### PR TITLE
fix: delete correct pipeline stack

### DIFF
--- a/internal/pkg/cli/pipeline_delete.go
+++ b/internal/pkg/cli/pipeline_delete.go
@@ -180,15 +180,10 @@ func (o *deletePipelineOpts) deleteSecret() error {
 	return nil
 }
 
-func (o *deletePipelineOpts) stackName() string {
-	return o.ProjectName() + "-" + o.PipelineName // based on stack.pipelineStackConfig.StackName()
-}
-
 func (o *deletePipelineOpts) deleteStack() error {
 	o.prog.Start(fmt.Sprintf(fmtDeletePipelineStart, o.PipelineName, o.ProjectName()))
-	stackName := o.stackName()
 
-	if err := o.pipelineDeployer.DeletePipeline(stackName); err != nil {
+	if err := o.pipelineDeployer.DeletePipeline(o.PipelineName); err != nil {
 		o.prog.Stop(log.Serrorf(fmtDeletePipelineFailed, o.PipelineName, o.ProjectName(), err))
 		return err
 	}

--- a/internal/pkg/cli/pipeline_delete_test.go
+++ b/internal/pkg/cli/pipeline_delete_test.go
@@ -186,8 +186,6 @@ func TestDeletePipelineOpts_Ask(t *testing.T) {
 
 func TestDeletePipelineOpts_Execute(t *testing.T) {
 	testError := errors.New("some error")
-	stackName := testProjName + "-" + testPipelineName
-
 	testCases := map[string]struct {
 		deleteSecret     bool
 		inProjectName    string
@@ -209,7 +207,7 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 					// no confirmation prompt for deleting secret
 					mocks.secretsmanager.EXPECT().DeleteSecret(testPipelineSecret).Return(nil),
 					mocks.prog.EXPECT().Start(fmt.Sprintf(fmtDeletePipelineStart, testPipelineName, testProjName)),
-					mocks.deployer.EXPECT().DeletePipeline(stackName).Return(nil),
+					mocks.deployer.EXPECT().DeletePipeline(testPipelineName).Return(nil),
 					mocks.prog.EXPECT().Stop(log.Ssuccessf(fmtDeletePipelineComplete, testPipelineName, testProjName)),
 					mocks.ws.EXPECT().DeletePipelineManifest().Return(nil),
 				)
@@ -231,7 +229,7 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 					).Times(1).Return(true, nil),
 					mocks.secretsmanager.EXPECT().DeleteSecret(testPipelineSecret).Return(nil),
 					mocks.prog.EXPECT().Start(fmt.Sprintf(fmtDeletePipelineStart, testPipelineName, testProjName)),
-					mocks.deployer.EXPECT().DeletePipeline(stackName).Return(nil),
+					mocks.deployer.EXPECT().DeletePipeline(testPipelineName).Return(nil),
 					mocks.prog.EXPECT().Stop(log.Ssuccessf(fmtDeletePipelineComplete, testPipelineName, testProjName)),
 					mocks.ws.EXPECT().DeletePipelineManifest().Return(nil),
 				)
@@ -255,7 +253,7 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 					// does not delete secret
 					mocks.secretsmanager.EXPECT().DeleteSecret(testPipelineSecret).Times(0),
 					mocks.prog.EXPECT().Start(fmt.Sprintf(fmtDeletePipelineStart, testPipelineName, testProjName)),
-					mocks.deployer.EXPECT().DeletePipeline(stackName).Times(1).Return(nil),
+					mocks.deployer.EXPECT().DeletePipeline(testPipelineName).Times(1).Return(nil),
 					mocks.prog.EXPECT().Stop(log.Ssuccessf(fmtDeletePipelineComplete, testPipelineName, testProjName)),
 					mocks.ws.EXPECT().DeletePipelineManifest().Return(nil),
 				)
@@ -273,7 +271,7 @@ func TestDeletePipelineOpts_Execute(t *testing.T) {
 				gomock.InOrder(
 					mocks.secretsmanager.EXPECT().DeleteSecret(testPipelineSecret).Return(nil),
 					mocks.prog.EXPECT().Start(fmt.Sprintf(fmtDeletePipelineStart, testPipelineName, testProjName)),
-					mocks.deployer.EXPECT().DeletePipeline(stackName).Times(1).Return(testError),
+					mocks.deployer.EXPECT().DeletePipeline(testPipelineName).Times(1).Return(testError),
 					mocks.prog.EXPECT().Stop(log.Serrorf(fmtDeletePipelineFailed, testPipelineName, testProjName, testError)),
 					mocks.ws.EXPECT().DeletePipelineManifest().Times(0),
 				)


### PR DESCRIPTION
Due to 62e5515b, we no longer need to append the ProjectName to the
pipeline name to find the name of the stack.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
