### PR TITLE
refactor: rename cloudwatch pkg internal interface

### DIFF
--- a/internal/pkg/aws/cloudwatch/cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch.go
@@ -23,13 +23,13 @@ const (
 	metricAlarmType        = "Metric"
 )
 
-type cloudWatchClient interface {
+type api interface {
 	DescribeAlarms(input *cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error)
 }
 
 // CloudWatch wraps an Amazon CloudWatch client.
 type CloudWatch struct {
-	cwClient cloudWatchClient
+	cwClient api
 	rgClient resourcegroups.ResourceGroupsClient
 }
 

--- a/internal/pkg/aws/cloudwatch/cloudwatch_test.go
+++ b/internal/pkg/aws/cloudwatch/cloudwatch_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 type cloudWatchMocks struct {
-	cw *cwmocks.MockcloudWatchClient
+	cw *cwmocks.Mockapi
 	rg *rgmocks.MockResourceGroupsClient
 }
 
@@ -181,7 +181,7 @@ func TestCloudWatch_GetAlarmsWithTags(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			mockcwClient := cwmocks.NewMockcloudWatchClient(ctrl)
+			mockcwClient := cwmocks.NewMockapi(ctrl)
 			mockrgClient := rgmocks.NewMockResourceGroupsClient(ctrl)
 			mocks := cloudWatchMocks{
 				cw: mockcwClient,

--- a/internal/pkg/aws/cloudwatch/mocks/mock_cloudwatch.go
+++ b/internal/pkg/aws/cloudwatch/mocks/mock_cloudwatch.go
@@ -10,31 +10,31 @@ import (
 	reflect "reflect"
 )
 
-// MockcloudWatchClient is a mock of cloudWatchClient interface
-type MockcloudWatchClient struct {
+// Mockapi is a mock of api interface
+type Mockapi struct {
 	ctrl     *gomock.Controller
-	recorder *MockcloudWatchClientMockRecorder
+	recorder *MockapiMockRecorder
 }
 
-// MockcloudWatchClientMockRecorder is the mock recorder for MockcloudWatchClient
-type MockcloudWatchClientMockRecorder struct {
-	mock *MockcloudWatchClient
+// MockapiMockRecorder is the mock recorder for Mockapi
+type MockapiMockRecorder struct {
+	mock *Mockapi
 }
 
-// NewMockcloudWatchClient creates a new mock instance
-func NewMockcloudWatchClient(ctrl *gomock.Controller) *MockcloudWatchClient {
-	mock := &MockcloudWatchClient{ctrl: ctrl}
-	mock.recorder = &MockcloudWatchClientMockRecorder{mock}
+// NewMockapi creates a new mock instance
+func NewMockapi(ctrl *gomock.Controller) *Mockapi {
+	mock := &Mockapi{ctrl: ctrl}
+	mock.recorder = &MockapiMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockcloudWatchClient) EXPECT() *MockcloudWatchClientMockRecorder {
+func (m *Mockapi) EXPECT() *MockapiMockRecorder {
 	return m.recorder
 }
 
 // DescribeAlarms mocks base method
-func (m *MockcloudWatchClient) DescribeAlarms(input *cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error) {
+func (m *Mockapi) DescribeAlarms(input *cloudwatch.DescribeAlarmsInput) (*cloudwatch.DescribeAlarmsOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAlarms", input)
 	ret0, _ := ret[0].(*cloudwatch.DescribeAlarmsOutput)
@@ -43,7 +43,7 @@ func (m *MockcloudWatchClient) DescribeAlarms(input *cloudwatch.DescribeAlarmsIn
 }
 
 // DescribeAlarms indicates an expected call of DescribeAlarms
-func (mr *MockcloudWatchClientMockRecorder) DescribeAlarms(input interface{}) *gomock.Call {
+func (mr *MockapiMockRecorder) DescribeAlarms(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAlarms", reflect.TypeOf((*MockcloudWatchClient)(nil).DescribeAlarms), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAlarms", reflect.TypeOf((*Mockapi)(nil).DescribeAlarms), input)
 }


### PR DESCRIPTION
Follow-up to https://github.com/aws/amazon-ecs-cli-v2/pull/865
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
