### PR TITLE
refactor: use ResourceGroups to retrieve pipelines

### DIFF
--- a/internal/pkg/aws/codepipeline/codepipeline.go
+++ b/internal/pkg/aws/codepipeline/codepipeline.go
@@ -6,11 +6,11 @@ package codepipeline
 
 import (
 	"fmt"
-	"strings"
 
 	rg "github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/resourcegroups"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cp "github.com/aws/aws-sdk-go/service/codepipeline"
 )
@@ -92,12 +92,11 @@ func (c *CodePipeline) ListPipelinesForProject(projectName string) ([]string, er
 	return pipelineNames, nil
 }
 
-func (c *CodePipeline) getPipelineName(arn string) (string, error) {
-	i := strings.LastIndex(arn, ":")
-	if i == -1 {
-		return "", fmt.Errorf("cannot parse pipeline ARN: %s", arn)
+func (c *CodePipeline) getPipelineName(resourceArn string) (string, error) {
+	parsedArn, err := arn.Parse(resourceArn)
+	if err != nil {
+		return "", fmt.Errorf("parse pipeline ARN: %s", resourceArn)
 	}
-	name := arn[i+1:]
 
-	return name, nil
+	return parsedArn.Resource, nil
 }

--- a/internal/pkg/aws/codepipeline/codepipeline.go
+++ b/internal/pkg/aws/codepipeline/codepipeline.go
@@ -6,20 +6,27 @@ package codepipeline
 
 import (
 	"fmt"
+	"strings"
+
+	rg "github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/resourcegroups"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cp "github.com/aws/aws-sdk-go/service/codepipeline"
 )
 
+const (
+	pipelineResourceType = "AWS::CodePipeline::Pipeline"
+)
+
 type api interface {
 	GetPipeline(*cp.GetPipelineInput) (*cp.GetPipelineOutput, error)
-	ListPipelines(*cp.ListPipelinesInput) (*cp.ListPipelinesOutput, error)
 }
 
 // CodePipeline wraps the AWS CodePipeline client.
 type CodePipeline struct {
-	client api
+	client   api
+	rgClient rg.ResourceGroupsClient
 }
 
 // Pipeline contains information about the pipeline
@@ -39,7 +46,8 @@ type ArtifactStore cp.ArtifactStore
 // New returns a CodePipeline client configured against the input session.
 func New(s *session.Session) *CodePipeline {
 	return &CodePipeline{
-		client: cp.New(s),
+		client:   cp.New(s),
+		rgClient: rg.New(s),
 	}
 }
 
@@ -60,20 +68,36 @@ func (c *CodePipeline) GetPipeline(pipelineName string) (*Pipeline, error) {
 	return pipeline, nil
 }
 
-// ListPipelines retrieves summaries of all pipelines for a project
-func (c *CodePipeline) ListPipelines() ([]string, error) {
-	input := &cp.ListPipelinesInput{}
-	resp, err := c.client.ListPipelines(input)
+// ListPipelines retrieves the names of all pipelines for a project
+func (c *CodePipeline) ListPipelinesForProject(projectName string) ([]string, error) {
+	var pipelineNames []string
+
+	tags := map[string]string{
+		"ecs-project": projectName,
+	}
+
+	arns, err := c.rgClient.GetResourcesByTags(pipelineResourceType, tags)
 	if err != nil {
-		return nil, fmt.Errorf("list pipelines: %w", err)
+		return nil, err
 	}
 
-	var pipelines []string
-
-	for _, ps := range resp.Pipelines {
-		p := aws.StringValue(ps.Name)
-		pipelines = append(pipelines, p)
+	for _, arn := range arns {
+		name, err := c.getPipelineName(arn)
+		if err != nil {
+			return nil, err
+		}
+		pipelineNames = append(pipelineNames, name)
 	}
 
-	return pipelines, nil
+	return pipelineNames, nil
+}
+
+func (c *CodePipeline) getPipelineName(arn string) (string, error) {
+	i := strings.LastIndex(arn, ":")
+	if i == -1 {
+		return "", fmt.Errorf("cannot parse pipeline ARN: %s", arn)
+	}
+	name := arn[i+1:]
+
+	return name, nil
 }

--- a/internal/pkg/aws/codepipeline/codepipeline_test.go
+++ b/internal/pkg/aws/codepipeline/codepipeline_test.go
@@ -132,7 +132,7 @@ func TestCodePipeline_ListPipelinesForProject(t *testing.T) {
 				m.rg.EXPECT().GetResourcesByTags(pipelineResourceType, testTags).Return([]string{badArn}, nil)
 			},
 			expectedOut:   nil,
-			expectedError: fmt.Errorf("cannot parse pipeline ARN: %s", badArn),
+			expectedError: fmt.Errorf("parse pipeline ARN: %s", badArn),
 		},
 	}
 

--- a/internal/pkg/aws/codepipeline/mocks/mock_codepipeline.go
+++ b/internal/pkg/aws/codepipeline/mocks/mock_codepipeline.go
@@ -47,18 +47,3 @@ func (mr *MockapiMockRecorder) GetPipeline(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipeline", reflect.TypeOf((*Mockapi)(nil).GetPipeline), arg0)
 }
-
-// ListPipelines mocks base method
-func (m *Mockapi) ListPipelines(arg0 *codepipeline.ListPipelinesInput) (*codepipeline.ListPipelinesOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPipelines", arg0)
-	ret0, _ := ret[0].(*codepipeline.ListPipelinesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListPipelines indicates an expected call of ListPipelines
-func (mr *MockapiMockRecorder) ListPipelines(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelines", reflect.TypeOf((*Mockapi)(nil).ListPipelines), arg0)
-}

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -236,7 +236,7 @@ type envDescriber interface {
 
 type pipelineGetter interface {
 	GetPipeline(pipelineName string) (*codepipeline.Pipeline, error)
-	ListPipelines() ([]string, error)
+	ListPipelinesForProject(projectName string) ([]string, error)
 }
 
 type executor interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2526,19 +2526,19 @@ func (mr *MockpipelineGetterMockRecorder) GetPipeline(pipelineName interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPipeline", reflect.TypeOf((*MockpipelineGetter)(nil).GetPipeline), pipelineName)
 }
 
-// ListPipelines mocks base method
-func (m *MockpipelineGetter) ListPipelines() ([]string, error) {
+// ListPipelinesForProject mocks base method
+func (m *MockpipelineGetter) ListPipelinesForProject(projectName string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPipelines")
+	ret := m.ctrl.Call(m, "ListPipelinesForProject", projectName)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListPipelines indicates an expected call of ListPipelines
-func (mr *MockpipelineGetterMockRecorder) ListPipelines() *gomock.Call {
+// ListPipelinesForProject indicates an expected call of ListPipelinesForProject
+func (mr *MockpipelineGetterMockRecorder) ListPipelinesForProject(projectName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelines", reflect.TypeOf((*MockpipelineGetter)(nil).ListPipelines))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPipelinesForProject", reflect.TypeOf((*MockpipelineGetter)(nil).ListPipelinesForProject), projectName)
 }
 
 // Mockexecutor is a mock of executor interface

--- a/internal/pkg/cli/pipeline_show.go
+++ b/internal/pkg/cli/pipeline_show.go
@@ -147,7 +147,7 @@ func (o *showPipelineOpts) askPipelineName() error {
 		return nil
 	}
 
-	if !errors.Is(err, workspace.ErrNoPipelineInWorkspace) {
+	if errors.Is(err, workspace.ErrNoPipelineInWorkspace) {
 		log.Infof("No pipeline manifest in workspace for project %s, looking for deployed pipelines\n", color.HighlightUserInput(o.ProjectName()))
 	}
 
@@ -163,7 +163,10 @@ func (o *showPipelineOpts) askPipelineName() error {
 	}
 
 	if len(pipelineNames) == 1 {
-		o.pipelineName = pipelineNames[0]
+		pipelineName = pipelineNames[0]
+		log.Infof("Found pipeline: %s\n.", color.HighlightUserInput(pipelineName))
+		o.pipelineName = pipelineName
+
 		return nil
 	}
 
@@ -181,7 +184,7 @@ func (o *showPipelineOpts) askPipelineName() error {
 }
 
 func (o *showPipelineOpts) retrieveAllPipelines() ([]string, error) {
-	pipelines, err := o.pipelineSvc.ListPipelines()
+	pipelines, err := o.pipelineSvc.ListPipelinesForProject(o.ProjectName())
 	if err != nil {
 		return nil, fmt.Errorf("list pipelines: %w", err)
 	}
@@ -204,7 +207,7 @@ func (o *showPipelineOpts) getPipelineNameFromManifest() (string, error) {
 
 // Execute writes the pipeline manifest file.
 func (o *showPipelineOpts) Execute() error {
-	// TODO Placeholder
+	fmt.Printf("Pipeline to show: %+v\n", o.pipelineName) // TODO Placeholder
 	return nil
 }
 

--- a/internal/pkg/cli/pipeline_show_test.go
+++ b/internal/pkg/cli/pipeline_show_test.go
@@ -173,7 +173,7 @@ stages:
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
-					mocks.pipelineSvc.EXPECT().ListPipelines().Return(mockPipelines, nil),
+					mocks.pipelineSvc.EXPECT().ListPipelinesForProject(mockProjectName).Return(mockPipelines, nil),
 					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockProjectName)), pipelineShowPipelineNameHelpPrompt, mockPipelines).Return(mockPipelineName, nil),
 				)
 			},
@@ -199,7 +199,7 @@ stages:
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
-					mocks.pipelineSvc.EXPECT().ListPipelines().Return([]string{mockPipelineName}, nil),
+					mocks.pipelineSvc.EXPECT().ListPipelinesForProject(mockProjectName).Return([]string{mockPipelineName}, nil),
 				)
 			},
 			expectedProject:  mockProjectName,
@@ -212,7 +212,7 @@ stages:
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
-					mocks.pipelineSvc.EXPECT().ListPipelines().Return([]string{}, nil),
+					mocks.pipelineSvc.EXPECT().ListPipelinesForProject(mockProjectName).Return([]string{}, nil),
 				)
 			},
 
@@ -261,7 +261,7 @@ stages:
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
-					mocks.pipelineSvc.EXPECT().ListPipelines().Return(nil, mockError),
+					mocks.pipelineSvc.EXPECT().ListPipelinesForProject(mockProjectName).Return(nil, mockError),
 				)
 			},
 			expectedErr: fmt.Errorf("list pipelines: %w", mockError),
@@ -271,7 +271,7 @@ stages:
 			setupMocks: func(mocks showPipelineMocks) {
 				gomock.InOrder(
 					mocks.ws.EXPECT().ReadPipelineManifest().Return(nil, workspace.ErrNoPipelineInWorkspace),
-					mocks.pipelineSvc.EXPECT().ListPipelines().Return(mockPipelines, nil),
+					mocks.pipelineSvc.EXPECT().ListPipelinesForProject(mockProjectName).Return(mockPipelines, nil),
 					mocks.prompt.EXPECT().SelectOne(fmt.Sprintf(fmtPipelineShowPipelineNamePrompt, color.HighlightUserInput(mockProjectName)), pipelineShowPipelineNameHelpPrompt, mockPipelines).Return("", mockError),
 				)
 			},


### PR DESCRIPTION
Previously, using the codepipeline#ListPipelines API would return all
pipelines in a user's account. This change uses ResourcesGroups to
filter pipelines by tags, so as to only return pipelines associated with
a given project (soon to be called application).

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
