### PR TITLE
chore(cli): app deploy can get the uri of multiple app types

### DIFF
--- a/internal/pkg/aws/cloudformation/changeset.go
+++ b/internal/pkg/aws/cloudformation/changeset.go
@@ -180,7 +180,7 @@ func (cs *changeSet) createAndExecute(conf *stackConfig) error {
 		// We make a call to describe the change set to see if that is indeed the case and handle it gracefully.
 		descr, descrErr := cs.describe()
 		if descrErr != nil {
-			return descrErr
+			return fmt.Errorf("check if changeset is empty: %v: %w", err, descrErr)
 		}
 		// The change set was empty - so we clean it up.
 		// We have to clean up the change set because there's a limit on the number

--- a/templates/applications/backend-app/cf.yml
+++ b/templates/applications/backend-app/cf.yml
@@ -13,6 +13,12 @@ Parameters:
     Type: String
   ContainerPort:
     Type: Number
+  TaskCPU:
+    Type: String
+  TaskMemory:
+    Type: String
+  TaskCount:
+    Type: Number
   AddonsTemplateURL:
     Description: 'URL of the addons nested stack template within the S3 bucket.'
     Type: String


### PR DESCRIPTION
Once we merge https://github.com/aws/amazon-ecs-cli-v2/pull/876, it should be a single line update to add the constructor for a BackendAppDescriber.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
