### PR TITLE
chore(e2e): add e2e test for app show for service discovery

### DIFF
--- a/e2e/init/init_test.go
+++ b/e2e/init/init_test.go
@@ -89,6 +89,12 @@ var _ = Describe("init flow", func() {
 			}, "30s", "1s").Should(Equal(200))
 		})
 
+		It("should return a valid service discovery namespace", func() {
+			Expect(len(app.ServiceDiscoveries)).To(Equal(1))
+			Expect(app.ServiceDiscoveries[0].Environment).To(Equal([]string{"test"}))
+			Expect(app.ServiceDiscoveries[0].Namespace).To(Equal(fmt.Sprintf("%s.%s.local:80", appName, projectName)))
+		})
+
 		It("should return the correct environment variables", func() {
 			Expect(len(app.Variables)).To(Equal(5))
 			expectedVars := map[string]string{

--- a/e2e/internal/client/outputs.go
+++ b/e2e/internal/client/outputs.go
@@ -6,12 +6,13 @@ import (
 )
 
 type AppShowOutput struct {
-	AppName   string                  `json:"appName"`
-	Type      string                  `json:"type"`
-	Project   string                  `json:"project"`
-	Configs   []AppShowConfigurations `json:"configurations"`
-	Routes    []AppShowRoutes         `json:"routes"`
-	Variables []AppShowVariables      `json:"variables"`
+	AppName            string                      `json:"appName"`
+	Type               string                      `json:"type"`
+	Project            string                      `json:"project"`
+	Configs            []AppShowConfigurations     `json:"configurations"`
+	ServiceDiscoveries []AppShowServiceDiscoveries `json:"serviceDiscovery"`
+	Routes             []AppShowRoutes             `json:"routes"`
+	Variables          []AppShowVariables          `json:"variables"`
 }
 
 type AppShowConfigurations struct {
@@ -25,6 +26,11 @@ type AppShowConfigurations struct {
 type AppShowRoutes struct {
 	Environment string `json:"environment"`
 	URL         string `json:"url"`
+}
+
+type AppShowServiceDiscoveries struct {
+	Environment []string `json:"environment"`
+	Namespace   string   `json:"namespace"`
 }
 
 type AppShowVariables struct {


### PR DESCRIPTION
<!-- Provide summary of changes -->
After #876 we start showing service discovery endpoint for `app show`. So we need to add e2e test for it as well.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
