### PR TITLE
chore(workspace)!: use Application, Service, and Copilot terms

### DIFF
--- a/internal/pkg/cli/app_delete.go
+++ b/internal/pkg/cli/app_delete.go
@@ -317,7 +317,7 @@ func (o *deleteAppOpts) deleteSSMParam() error {
 }
 
 func (o *deleteAppOpts) deleteWorkspaceFile() error {
-	if err := o.workspaceService.DeleteApp(o.AppName); err != nil {
+	if err := o.workspaceService.DeleteService(o.AppName); err != nil {
 		return fmt.Errorf("delete application %s directory: %w", o.AppName, err)
 	}
 

--- a/internal/pkg/cli/app_delete_test.go
+++ b/internal/pkg/cli/app_delete_test.go
@@ -394,7 +394,7 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 					mocks.projectService.EXPECT().DeleteService(mockProjectName, mockAppName).Return(nil),
 
 					// deleteWorkspaceFile
-					mocks.ws.EXPECT().DeleteApp(mockAppName).Return(nil),
+					mocks.ws.EXPECT().DeleteService(mockAppName).Return(nil),
 				)
 			},
 			wantedError: nil,
@@ -424,7 +424,7 @@ func TestDeleteAppOpts_Execute(t *testing.T) {
 					mocks.projectService.EXPECT().DeleteService(mockProjectName, mockAppName).Return(nil),
 
 					// deleteWorkspaceFile
-					mocks.ws.EXPECT().DeleteApp(mockAppName).Return(nil),
+					mocks.ws.EXPECT().DeleteService(mockAppName).Return(nil),
 				)
 			},
 			wantedError: nil,

--- a/internal/pkg/cli/app_deploy.go
+++ b/internal/pkg/cli/app_deploy.go
@@ -169,7 +169,7 @@ func (o *appDeployOpts) RecommendedActions() []string {
 }
 
 func (o *appDeployOpts) validateAppName() error {
-	names, err := o.workspaceService.AppNames()
+	names, err := o.workspaceService.ServiceNames()
 	if err != nil {
 		return fmt.Errorf("list applications in the workspace: %w", err)
 	}
@@ -201,7 +201,7 @@ func (o *appDeployOpts) askAppName() error {
 		return nil
 	}
 
-	names, err := o.workspaceService.AppNames()
+	names, err := o.workspaceService.ServiceNames()
 	if err != nil {
 		return fmt.Errorf("list applications in workspace: %w", err)
 	}
@@ -348,7 +348,7 @@ func (o *appDeployOpts) getAppDockerfilePath() (string, error) {
 		DockerfilePath() string
 	}
 
-	manifestBytes, err := o.workspaceService.ReadAppManifest(o.AppName)
+	manifestBytes, err := o.workspaceService.ReadServiceManifest(o.AppName)
 	if err != nil {
 		return "", fmt.Errorf("read manifest file %s: %w", o.AppName, err)
 	}
@@ -392,7 +392,7 @@ func (o *appDeployOpts) pushAddonsTemplateToS3Bucket() (string, error) {
 }
 
 func (o *appDeployOpts) manifest() (interface{}, error) {
-	raw, err := o.workspaceService.ReadAppManifest(o.AppName)
+	raw, err := o.workspaceService.ReadServiceManifest(o.AppName)
 	if err != nil {
 		return nil, fmt.Errorf("read app %s manifest from workspace: %w", o.AppName, err)
 	}

--- a/internal/pkg/cli/app_deploy_test.go
+++ b/internal/pkg/cli/app_deploy_test.go
@@ -37,7 +37,7 @@ func TestAppDeployOpts_Validate(t *testing.T) {
 			inProjectName: "phonetool",
 			inAppName:     "frontend",
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return(nil, errors.New("some error"))
+				m.EXPECT().ServiceNames().Return(nil, errors.New("some error"))
 			},
 			mockStore: func(m *climocks.MockprojectService) {},
 
@@ -47,7 +47,7 @@ func TestAppDeployOpts_Validate(t *testing.T) {
 			inProjectName: "phonetool",
 			inAppName:     "frontend",
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{}, nil)
+				m.EXPECT().ServiceNames().Return([]string{}, nil)
 			},
 			mockStore: func(m *climocks.MockprojectService) {},
 
@@ -69,7 +69,7 @@ func TestAppDeployOpts_Validate(t *testing.T) {
 			inAppName:     "frontend",
 			inEnvName:     "test",
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
 			},
 			mockStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().GetEnvironment("phonetool", "test").
@@ -130,7 +130,7 @@ func TestAppDeployOpts_Ask(t *testing.T) {
 	}{
 		"no applications in the workspace": {
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{}, nil)
+				m.EXPECT().ServiceNames().Return([]string{}, nil)
 			},
 			mockStore:  func(m *climocks.MockprojectService) {},
 			mockPrompt: func(m *climocks.Mockprompter) {},
@@ -141,7 +141,7 @@ func TestAppDeployOpts_Ask(t *testing.T) {
 			inEnvName:  "test",
 			inImageTag: "latest",
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
 			},
 			mockStore:  func(m *climocks.MockprojectService) {},
 			mockPrompt: func(m *climocks.Mockprompter) {},
@@ -154,7 +154,7 @@ func TestAppDeployOpts_Ask(t *testing.T) {
 			inEnvName:  "test",
 			inImageTag: "latest",
 			mockWs: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "webhook"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "webhook"}, nil)
 			},
 			mockStore: func(m *climocks.MockprojectService) {},
 			mockPrompt: func(m *climocks.Mockprompter) {
@@ -302,7 +302,7 @@ image:
 				mockWorkspace = climocks.NewMockwsAppReader(controller)
 
 				gomock.InOrder(
-					mockWorkspace.EXPECT().ReadAppManifest("appA").Times(1).Return(nil, mockError),
+					mockWorkspace.EXPECT().ReadServiceManifest("appA").Times(1).Return(nil, mockError),
 				)
 			},
 			wantPath: "",
@@ -314,7 +314,7 @@ image:
 				mockWorkspace = climocks.NewMockwsAppReader(controller)
 
 				gomock.InOrder(
-					mockWorkspace.EXPECT().ReadAppManifest("appA").Times(1).Return(mockManifest, nil),
+					mockWorkspace.EXPECT().ReadServiceManifest("appA").Times(1).Return(mockManifest, nil),
 				)
 			},
 			wantPath: "appA",

--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -207,7 +207,7 @@ func (o *initAppOpts) createManifest() (string, error) {
 		return "", err
 	}
 	var manifestExists bool
-	manifestPath, err := o.ws.WriteAppManifest(manifest, o.AppName)
+	manifestPath, err := o.ws.WriteServiceManifest(manifest, o.AppName)
 	if err != nil {
 		e, ok := err.(*workspace.ErrFileExists)
 		if !ok {

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -363,7 +363,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 
 			mockDependencies: func(ctrl *gomock.Controller, opts *initAppOpts) {
 				mockWriter := climocks.NewMockwsAppManifestWriter(ctrl)
-				mockWriter.EXPECT().WriteAppManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
+				mockWriter.EXPECT().WriteServiceManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
 
 				mockAppStore := mocks.NewMockApplicationStore(ctrl)
 				mockAppStore.EXPECT().ListServices("project").Return([]*archer.Application{}, nil)
@@ -409,7 +409,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 
 			mockDependencies: func(ctrl *gomock.Controller, opts *initAppOpts) {
 				mockWriter := climocks.NewMockwsAppManifestWriter(ctrl)
-				mockWriter.EXPECT().WriteAppManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", errors.New("some error"))
+				mockWriter.EXPECT().WriteServiceManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", errors.New("some error"))
 
 				mockAppStore := mocks.NewMockApplicationStore(ctrl)
 				mockAppStore.EXPECT().ListServices("project").Return([]*archer.Application{}, nil)
@@ -462,7 +462,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 
 			mockDependencies: func(ctrl *gomock.Controller, opts *initAppOpts) {
 				mockWriter := climocks.NewMockwsAppManifestWriter(ctrl)
-				mockWriter.EXPECT().WriteAppManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
+				mockWriter.EXPECT().WriteServiceManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
 
 				mockAppStore := mocks.NewMockApplicationStore(ctrl)
 				mockAppStore.EXPECT().ListServices("project").Return([]*archer.Application{}, nil)
@@ -497,7 +497,7 @@ func TestAppInitOpts_Execute(t *testing.T) {
 
 			mockDependencies: func(ctrl *gomock.Controller, opts *initAppOpts) {
 				mockWriter := climocks.NewMockwsAppManifestWriter(ctrl)
-				mockWriter.EXPECT().WriteAppManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
+				mockWriter.EXPECT().WriteServiceManifest(gomock.Any(), opts.AppName).Return("/frontend/manifest.yml", nil)
 
 				mockAppStore := mocks.NewMockApplicationStore(ctrl)
 				mockAppStore.EXPECT().ListServices("project").Return([]*archer.Application{}, nil)

--- a/internal/pkg/cli/app_list.go
+++ b/internal/pkg/cli/app_list.go
@@ -134,7 +134,7 @@ func (opts *listAppOpts) Execute() error {
 	opts.applications = apps
 
 	if opts.ShouldShowLocalApps {
-		localAppNames, err := opts.ws.AppNames()
+		localAppNames, err := opts.ws.ServiceNames()
 		if err != nil {
 			return fmt.Errorf("failed to get local app manifests: %w", err)
 		}

--- a/internal/pkg/cli/app_list_test.go
+++ b/internal/pkg/cli/app_list_test.go
@@ -146,7 +146,7 @@ func TestAppList_Execute(t *testing.T) {
 						{Name: "my-app", Type: "Load Balanced Web App"},
 						{Name: "lb-app", Type: "Load Balanced Web App"},
 					}, nil)
-				mockWorkspace.EXPECT().AppNames().
+				mockWorkspace.EXPECT().ServiceNames().
 					Return([]string{"my-app"}, nil).Times(1)
 			},
 			expectedContent: "Name                Type\n------              ---------------------\nmy-app              Load Balanced Web App\n",

--- a/internal/pkg/cli/app_package.go
+++ b/internal/pkg/cli/app_package.go
@@ -125,7 +125,7 @@ func (o *packageAppOpts) Validate() error {
 		return errNoProjectInWorkspace
 	}
 	if o.AppName != "" {
-		names, err := o.ws.AppNames()
+		names, err := o.ws.ServiceNames()
 		if err != nil {
 			return fmt.Errorf("list applications in workspace: %w", err)
 		}
@@ -202,7 +202,7 @@ func (o *packageAppOpts) askAppName() error {
 		return nil
 	}
 
-	appNames, err := o.ws.AppNames()
+	appNames, err := o.ws.ServiceNames()
 	if err != nil {
 		return fmt.Errorf("list applications in workspace: %w", err)
 	}
@@ -276,7 +276,7 @@ type appCfnTemplates struct {
 
 // getAppTemplates returns the CloudFormation stack's template and its parameters for the application.
 func (o *packageAppOpts) getAppTemplates(env *archer.Environment) (*appCfnTemplates, error) {
-	raw, err := o.ws.ReadAppManifest(o.AppName)
+	raw, err := o.ws.ReadServiceManifest(o.AppName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/app_package_test.go
+++ b/internal/pkg/cli/app_package_test.go
@@ -34,7 +34,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 	}{
 		"invalid workspace": {
 			setupMocks: func() {
-				mockWorkspace.EXPECT().AppNames().Times(0)
+				mockWorkspace.EXPECT().ServiceNames().Times(0)
 				mockProjectService.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 			wantedErrorS: "could not find a project attached to this workspace, please run `project init` first",
@@ -43,7 +43,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inProjectName: "phonetool",
 			inAppName:     "frontend",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().AppNames().Return(nil, errors.New("some error"))
+				mockWorkspace.EXPECT().ServiceNames().Return(nil, errors.New("some error"))
 				mockProjectService.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -53,7 +53,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inProjectName: "phonetool",
 			inAppName:     "frontend",
 			setupMocks: func() {
-				mockWorkspace.EXPECT().AppNames().Return([]string{"backend"}, nil)
+				mockWorkspace.EXPECT().ServiceNames().Return([]string{"backend"}, nil)
 				mockProjectService.EXPECT().GetEnvironment(gomock.Any(), gomock.Any()).Times(0)
 			},
 
@@ -64,7 +64,7 @@ func TestPackageAppOpts_Validate(t *testing.T) {
 			inEnvName:     "test",
 
 			setupMocks: func() {
-				mockWorkspace.EXPECT().AppNames().Times(0)
+				mockWorkspace.EXPECT().ServiceNames().Times(0)
 				mockProjectService.EXPECT().GetEnvironment("phonetool", "test").Return(nil, &store.ErrNoSuchEnvironment{
 					ApplicationName: "phonetool",
 					EnvironmentName: "test",
@@ -130,7 +130,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 	}{
 		"wrap list apps error": {
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return(nil, errors.New("some error"))
+				m.EXPECT().ServiceNames().Return(nil, errors.New("some error"))
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -144,7 +144,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		},
 		"empty workspace error": {
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{}, nil)
+				m.EXPECT().ServiceNames().Return([]string{}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -159,7 +159,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		"wrap list envs error": {
 			inAppName: "frontend",
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().ServiceNames().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return(nil, errors.New("some ssm error"))
@@ -175,7 +175,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		"empty environments error": {
 			inAppName: "frontend",
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().ServiceNames().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return(nil, nil)
@@ -190,7 +190,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		},
 		"prompt for all options": {
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return([]*archer.Environment{
@@ -220,7 +220,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inTag:     "v1.0.0",
 
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -239,7 +239,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inTag:     "v1.0.0",
 
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().ServiceNames().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return([]*archer.Environment{
@@ -266,7 +266,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inTag:     "v1.0.0",
 
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().ServiceNames().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -282,7 +282,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 		},
 		"don't prompt if only one app or one env": {
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend"}, nil)
+				m.EXPECT().ServiceNames().Return([]string{"frontend"}, nil)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Return([]*archer.Environment{
@@ -307,7 +307,7 @@ func TestPackageAppOpts_Ask(t *testing.T) {
 			inAppName: "frontend",
 			inEnvName: "test",
 			expectWS: func(m *climocks.MockwsAppReader) {
-				m.EXPECT().AppNames().Times(0)
+				m.EXPECT().ServiceNames().Times(0)
 			},
 			expectStore: func(m *climocks.MockprojectService) {
 				m.EXPECT().ListEnvironments(gomock.Any()).Times(0)
@@ -414,7 +414,7 @@ func TestPackageAppOpts_Execute(t *testing.T) {
 
 				mockWs := climocks.NewMockwsAppReader(ctrl)
 				mockWs.EXPECT().
-					ReadAppManifest("api").
+					ReadServiceManifest("api").
 					Return([]byte(`name: api
 type: Load Balanced Web App
 image:

--- a/internal/pkg/cli/app_show.go
+++ b/internal/pkg/cli/app_show.go
@@ -213,7 +213,7 @@ func (o *showAppOpts) retrieveProjects() ([]string, error) {
 }
 
 func (o *showAppOpts) retrieveLocalApplication() ([]string, error) {
-	localAppNames, err := o.ws.AppNames()
+	localAppNames, err := o.ws.ServiceNames()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/app_show_test.go
+++ b/internal/pkg/cli/app_show_test.go
@@ -157,7 +157,7 @@ func TestAppShow_Ask(t *testing.T) {
 					m.prompt.EXPECT().SelectOne(applicationShowProjectNamePrompt, applicationShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
 
 					// askAppName
-					m.ws.EXPECT().AppNames().Return(nil, errors.New("some error")),
+					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
 					m.storeSvc.EXPECT().ListServices("my-project").Return([]*archer.Application{
 						{Name: "my-app"},
 						{Name: "archer-app"},
@@ -184,7 +184,7 @@ func TestAppShow_Ask(t *testing.T) {
 					m.prompt.EXPECT().SelectOne(applicationShowProjectNamePrompt, applicationShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
 
 					// askAppName
-					m.ws.EXPECT().AppNames().Return([]string{}, nil),
+					m.ws.EXPECT().ServiceNames().Return([]string{}, nil),
 					m.storeSvc.EXPECT().ListServices("my-project").Return([]*archer.Application{
 						{Name: "my-app"},
 						{Name: "archer-app"},
@@ -212,7 +212,7 @@ func TestAppShow_Ask(t *testing.T) {
 					m.prompt.EXPECT().SelectOne(applicationShowProjectNamePrompt, applicationShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
 
 					// askAppName
-					m.ws.EXPECT().AppNames().Return([]string{"my-app", "archer-app"}, nil),
+					m.ws.EXPECT().ServiceNames().Return([]string{"my-app", "archer-app"}, nil),
 					m.prompt.EXPECT().SelectOne(fmt.Sprintf(applicationShowAppNamePrompt, "my-project"), applicationShowAppNameHelpPrompt, []string{"my-app", "archer-app"}).Return("my-app", nil).Times(1),
 				)
 			},
@@ -227,7 +227,7 @@ func TestAppShow_Ask(t *testing.T) {
 
 			setupMocks: func(m showAppMocks) {
 				gomock.InOrder(
-					m.ws.EXPECT().AppNames().Return(nil, errors.New("some error")),
+					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
 					m.storeSvc.EXPECT().ListServices("my-project").Return([]*archer.Application{
 						{
 							Name: "my-app",
@@ -297,7 +297,7 @@ func TestAppShow_Ask(t *testing.T) {
 					m.prompt.EXPECT().SelectOne(applicationShowProjectNamePrompt, applicationShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
 
 					// askAskName
-					m.ws.EXPECT().AppNames().Return(nil, errors.New("some error")),
+					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
 					m.storeSvc.EXPECT().ListServices("my-project").Return(nil, fmt.Errorf("some error")),
 				)
 			},
@@ -320,7 +320,7 @@ func TestAppShow_Ask(t *testing.T) {
 					m.prompt.EXPECT().SelectOne(applicationShowProjectNamePrompt, applicationShowProjectNameHelpPrompt, []string{"my-project", "archer-project"}).Return("my-project", nil).Times(1),
 
 					// askAppName
-					m.ws.EXPECT().AppNames().Return(nil, errors.New("some error")),
+					m.ws.EXPECT().ServiceNames().Return(nil, errors.New("some error")),
 					m.storeSvc.EXPECT().ListServices("my-project").Return([]*archer.Application{
 						{Name: "my-app"},
 						{Name: "archer-app"},

--- a/internal/pkg/cli/cli.go
+++ b/internal/pkg/cli/cli.go
@@ -72,7 +72,7 @@ func loadProjectName() (string, error) {
 		// the project flag be set.
 		return "", fmt.Errorf("reading from workspace: %w", err)
 	}
-	return summary.ProjectName, nil
+	return summary.Application, nil
 }
 
 type errReservedArg struct {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -109,11 +109,11 @@ type workspaceDeleter interface {
 }
 
 type wsAppManifestReader interface {
-	ReadAppManifest(appName string) ([]byte, error)
+	ReadServiceManifest(appName string) ([]byte, error)
 }
 
 type wsAppManifestWriter interface {
-	WriteAppManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error)
+	WriteServiceManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error)
 }
 
 type wsPipelineManifestReader interface {
@@ -126,11 +126,11 @@ type wsPipelineWriter interface {
 }
 
 type wsAppDeleter interface {
-	DeleteApp(name string) error
+	DeleteService(name string) error
 }
 
 type wsAppReader interface {
-	AppNames() ([]string, error)
+	ServiceNames() ([]string, error)
 	wsAppManifestReader
 }
 
@@ -140,7 +140,7 @@ type wsPipelineDeleter interface {
 }
 
 type wsPipelineReader interface {
-	AppNames() ([]string, error)
+	ServiceNames() ([]string, error)
 	wsPipelineManifestReader
 }
 
@@ -151,10 +151,6 @@ type wsProjectManager interface {
 
 type artifactUploader interface {
 	PutArtifact(bucket, fileName string, data io.Reader) (string, error)
-}
-
-type port interface {
-	Set(number int) error
 }
 
 type bucketEmptier interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -1036,19 +1036,19 @@ func (m *MockwsAppManifestReader) EXPECT() *MockwsAppManifestReaderMockRecorder 
 	return m.recorder
 }
 
-// ReadAppManifest mocks base method
-func (m *MockwsAppManifestReader) ReadAppManifest(appName string) ([]byte, error) {
+// ReadServiceManifest mocks base method
+func (m *MockwsAppManifestReader) ReadServiceManifest(appName string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAppManifest", appName)
+	ret := m.ctrl.Call(m, "ReadServiceManifest", appName)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadAppManifest indicates an expected call of ReadAppManifest
-func (mr *MockwsAppManifestReaderMockRecorder) ReadAppManifest(appName interface{}) *gomock.Call {
+// ReadServiceManifest indicates an expected call of ReadServiceManifest
+func (mr *MockwsAppManifestReaderMockRecorder) ReadServiceManifest(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAppManifest", reflect.TypeOf((*MockwsAppManifestReader)(nil).ReadAppManifest), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsAppManifestReader)(nil).ReadServiceManifest), appName)
 }
 
 // MockwsAppManifestWriter is a mock of wsAppManifestWriter interface
@@ -1074,19 +1074,19 @@ func (m *MockwsAppManifestWriter) EXPECT() *MockwsAppManifestWriterMockRecorder 
 	return m.recorder
 }
 
-// WriteAppManifest mocks base method
-func (m *MockwsAppManifestWriter) WriteAppManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error) {
+// WriteServiceManifest mocks base method
+func (m *MockwsAppManifestWriter) WriteServiceManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteAppManifest", marshaler, appName)
+	ret := m.ctrl.Call(m, "WriteServiceManifest", marshaler, appName)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WriteAppManifest indicates an expected call of WriteAppManifest
-func (mr *MockwsAppManifestWriterMockRecorder) WriteAppManifest(marshaler, appName interface{}) *gomock.Call {
+// WriteServiceManifest indicates an expected call of WriteServiceManifest
+func (mr *MockwsAppManifestWriterMockRecorder) WriteServiceManifest(marshaler, appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAppManifest", reflect.TypeOf((*MockwsAppManifestWriter)(nil).WriteAppManifest), marshaler, appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteServiceManifest", reflect.TypeOf((*MockwsAppManifestWriter)(nil).WriteServiceManifest), marshaler, appName)
 }
 
 // MockwsPipelineManifestReader is a mock of wsPipelineManifestReader interface
@@ -1203,18 +1203,18 @@ func (m *MockwsAppDeleter) EXPECT() *MockwsAppDeleterMockRecorder {
 	return m.recorder
 }
 
-// DeleteApp mocks base method
-func (m *MockwsAppDeleter) DeleteApp(name string) error {
+// DeleteService mocks base method
+func (m *MockwsAppDeleter) DeleteService(name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteApp", name)
+	ret := m.ctrl.Call(m, "DeleteService", name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteApp indicates an expected call of DeleteApp
-func (mr *MockwsAppDeleterMockRecorder) DeleteApp(name interface{}) *gomock.Call {
+// DeleteService indicates an expected call of DeleteService
+func (mr *MockwsAppDeleterMockRecorder) DeleteService(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApp", reflect.TypeOf((*MockwsAppDeleter)(nil).DeleteApp), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockwsAppDeleter)(nil).DeleteService), name)
 }
 
 // MockwsAppReader is a mock of wsAppReader interface
@@ -1240,34 +1240,34 @@ func (m *MockwsAppReader) EXPECT() *MockwsAppReaderMockRecorder {
 	return m.recorder
 }
 
-// AppNames mocks base method
-func (m *MockwsAppReader) AppNames() ([]string, error) {
+// ServiceNames mocks base method
+func (m *MockwsAppReader) ServiceNames() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppNames")
+	ret := m.ctrl.Call(m, "ServiceNames")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AppNames indicates an expected call of AppNames
-func (mr *MockwsAppReaderMockRecorder) AppNames() *gomock.Call {
+// ServiceNames indicates an expected call of ServiceNames
+func (mr *MockwsAppReaderMockRecorder) ServiceNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNames", reflect.TypeOf((*MockwsAppReader)(nil).AppNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsAppReader)(nil).ServiceNames))
 }
 
-// ReadAppManifest mocks base method
-func (m *MockwsAppReader) ReadAppManifest(appName string) ([]byte, error) {
+// ReadServiceManifest mocks base method
+func (m *MockwsAppReader) ReadServiceManifest(appName string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAppManifest", appName)
+	ret := m.ctrl.Call(m, "ReadServiceManifest", appName)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ReadAppManifest indicates an expected call of ReadAppManifest
-func (mr *MockwsAppReaderMockRecorder) ReadAppManifest(appName interface{}) *gomock.Call {
+// ReadServiceManifest indicates an expected call of ReadServiceManifest
+func (mr *MockwsAppReaderMockRecorder) ReadServiceManifest(appName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAppManifest", reflect.TypeOf((*MockwsAppReader)(nil).ReadAppManifest), appName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadServiceManifest", reflect.TypeOf((*MockwsAppReader)(nil).ReadServiceManifest), appName)
 }
 
 // MockwsPipelineDeleter is a mock of wsPipelineDeleter interface
@@ -1345,19 +1345,19 @@ func (m *MockwsPipelineReader) EXPECT() *MockwsPipelineReaderMockRecorder {
 	return m.recorder
 }
 
-// AppNames mocks base method
-func (m *MockwsPipelineReader) AppNames() ([]string, error) {
+// ServiceNames mocks base method
+func (m *MockwsPipelineReader) ServiceNames() ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppNames")
+	ret := m.ctrl.Call(m, "ServiceNames")
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AppNames indicates an expected call of AppNames
-func (mr *MockwsPipelineReaderMockRecorder) AppNames() *gomock.Call {
+// ServiceNames indicates an expected call of ServiceNames
+func (mr *MockwsPipelineReaderMockRecorder) ServiceNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNames", reflect.TypeOf((*MockwsPipelineReader)(nil).AppNames))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsPipelineReader)(nil).ServiceNames))
 }
 
 // ReadPipelineManifest mocks base method
@@ -1463,43 +1463,6 @@ func (m *MockartifactUploader) PutArtifact(bucket, fileName string, data io.Read
 func (mr *MockartifactUploaderMockRecorder) PutArtifact(bucket, fileName, data interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutArtifact", reflect.TypeOf((*MockartifactUploader)(nil).PutArtifact), bucket, fileName, data)
-}
-
-// Mockport is a mock of port interface
-type Mockport struct {
-	ctrl     *gomock.Controller
-	recorder *MockportMockRecorder
-}
-
-// MockportMockRecorder is the mock recorder for Mockport
-type MockportMockRecorder struct {
-	mock *Mockport
-}
-
-// NewMockport creates a new mock instance
-func NewMockport(ctrl *gomock.Controller) *Mockport {
-	mock := &Mockport{ctrl: ctrl}
-	mock.recorder = &MockportMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *Mockport) EXPECT() *MockportMockRecorder {
-	return m.recorder
-}
-
-// Set mocks base method
-func (m *Mockport) Set(number int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", number)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockportMockRecorder) Set(number interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*Mockport)(nil).Set), number)
 }
 
 // MockbucketEmptier is a mock of bucketEmptier interface

--- a/internal/pkg/cli/pipeline_update.go
+++ b/internal/pkg/cli/pipeline_update.go
@@ -97,7 +97,7 @@ func (o *updatePipelineOpts) Validate() error {
 
 func (o *updatePipelineOpts) convertStages(manifestStages []manifest.PipelineStage) ([]deploy.PipelineStage, error) {
 	var stages []deploy.PipelineStage
-	appNames, err := o.ws.AppNames()
+	appNames, err := o.ws.ServiceNames()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cli/pipeline_update_test.go
+++ b/internal/pkg/cli/pipeline_update_test.go
@@ -37,7 +37,7 @@ func TestUpdatePipelineOpts_convertStages(t *testing.T) {
 			},
 			inProjectName: "badgoose",
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				mockEnv := &archer.Environment{
@@ -219,7 +219,7 @@ stages:
 			inRegion:      region,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -251,7 +251,7 @@ stages:
 			inRegion:      region,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -285,7 +285,7 @@ stages:
 			inRegion:      region,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -319,7 +319,7 @@ stages:
 			inRegion:      region,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -402,7 +402,7 @@ stages:
 			inProjectName: projectName,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return(nil, errors.New("some error")).Times(1)
+				m.EXPECT().ServiceNames().Return(nil, errors.New("some error")).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {},
 			mockProgress: func(m *climocks.Mockprogress) {
@@ -422,7 +422,7 @@ stages:
 			inProjectName: projectName,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -446,7 +446,7 @@ stages:
 			inProjectName: projectName,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -471,7 +471,7 @@ stages:
 			inProjectName: projectName,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)
@@ -503,7 +503,7 @@ stages:
 			inProjectName: projectName,
 			mockWorkspace: func(m *climocks.MockwsPipelineReader) {
 				m.EXPECT().ReadPipelineManifest().Return([]byte(content), nil)
-				m.EXPECT().AppNames().Return([]string{"frontend", "backend"}, nil).Times(1)
+				m.EXPECT().ServiceNames().Return([]string{"frontend", "backend"}, nil).Times(1)
 			},
 			mockEnvStore: func(m *archermocks.MockEnvironmentStore) {
 				m.EXPECT().GetEnvironment(projectName, "chicken").Return(mockEnv, nil).Times(1)

--- a/internal/pkg/cli/project_init.go
+++ b/internal/pkg/cli/project_init.go
@@ -98,20 +98,20 @@ func (o *initProjectOpts) Ask() error {
 		if o.ProjectName == "" {
 			log.Infoln(fmt.Sprintf(
 				"Looks like you are using a workspace that's registered to project %s.\nWe'll use that as your project.",
-				color.HighlightResource(summary.ProjectName)))
-			o.ProjectName = summary.ProjectName
+				color.HighlightResource(summary.Application)))
+			o.ProjectName = summary.Application
 			return nil
 		}
-		if o.ProjectName != summary.ProjectName {
+		if o.ProjectName != summary.Application {
 			log.Errorf(`Workspace is already registered with project %s instead of %s.
 			If you'd like to delete the project locally, you can remove the %s directory.
 			If you'd like to delete project and all of its resources, run %s.
 `,
-				summary.ProjectName,
+				summary.Application,
 				o.ProjectName,
-				workspace.ProjectDirectoryName,
+				workspace.CopilotDirName,
 				color.HighlightCode("ecs-preview project delete"))
-			return fmt.Errorf("workspace already registered with %s", summary.ProjectName)
+			return fmt.Errorf("workspace already registered with %s", summary.Application)
 		}
 	}
 
@@ -271,7 +271,7 @@ A project is a collection of containerized applications (or micro-services) that
 			if err := opts.Execute(); err != nil {
 				return err
 			}
-			log.Successf("The directory %s will hold application manifests for project %s.\n", color.HighlightResource(workspace.ProjectDirectoryName), color.HighlightUserInput(opts.ProjectName))
+			log.Successf("The directory %s will hold application manifests for project %s.\n", color.HighlightResource(workspace.CopilotDirName), color.HighlightUserInput(opts.ProjectName))
 			log.Infoln()
 			log.Infoln("Recommended follow-up actions:")
 			for _, followUp := range opts.RecommendedActions() {

--- a/internal/pkg/cli/project_init_test.go
+++ b/internal/pkg/cli/project_init_test.go
@@ -31,7 +31,7 @@ func TestInitProjectOpts_Ask(t *testing.T) {
 		"errors if summary exists and differs from project flag": {
 			inProjectName: "testname",
 			expect: func(opts *initProjectOpts) {
-				opts.ws.(*climocks.MockwsProjectManager).EXPECT().Summary().Return(&workspace.Summary{ProjectName: "metrics"}, nil)
+				opts.ws.(*climocks.MockwsProjectManager).EXPECT().Summary().Return(&workspace.Summary{Application: "metrics"}, nil)
 				opts.projectStore.(*mocks.MockProjectStore).EXPECT().ListApplications().Times(0)
 			},
 			wantedErr: "workspace already registered with metrics",

--- a/internal/pkg/workspace/errors.go
+++ b/internal/pkg/workspace/errors.go
@@ -11,37 +11,6 @@ import (
 // ErrNoPipelineInWorkspace means there was no pipeline manifest in the workspace dir.
 var ErrNoPipelineInWorkspace = errors.New("no pipeline manifest found in the workspace")
 
-// ErrWorkspaceNotFound means we couldn't locate a workspace root.
-type ErrWorkspaceNotFound struct {
-	CurrentDirectory      string
-	ManifestDirectoryName string
-	NumberOfLevelsChecked int
-}
-
-func (e *ErrWorkspaceNotFound) Error() string {
-	return fmt.Sprintf("couldn't find a directory called %s up to %d levels up from %s",
-		e.ManifestDirectoryName,
-		e.NumberOfLevelsChecked,
-		e.CurrentDirectory)
-}
-
-// ErrNoProjectAssociated means we couldn't locate a workspace summary file.
-type ErrNoProjectAssociated struct{}
-
-func (e *ErrNoProjectAssociated) Error() string {
-	return fmt.Sprint("couldn't find a project associated with this workspace")
-}
-
-// ErrWorkspaceHasExistingProject means we tried to create a workspace for a project
-// but it already belongs to another project.
-type ErrWorkspaceHasExistingProject struct {
-	ExistingProjectName string
-}
-
-func (e *ErrWorkspaceHasExistingProject) Error() string {
-	return fmt.Sprintf("this workspace is already registered with project %s", e.ExistingProjectName)
-}
-
 // ErrFileExists means we tried to create an existing file.
 type ErrFileExists struct {
 	FileName string
@@ -49,4 +18,34 @@ type ErrFileExists struct {
 
 func (e *ErrFileExists) Error() string {
 	return fmt.Sprintf("file %s already exists", e.FileName)
+}
+
+// errWorkspaceNotFound means we couldn't locate a workspace root.
+type errWorkspaceNotFound struct {
+	CurrentDirectory      string
+	ManifestDirectoryName string
+	NumberOfLevelsChecked int
+}
+
+func (e *errWorkspaceNotFound) Error() string {
+	return fmt.Sprintf("couldn't find a directory called %s up to %d levels up from %s",
+		e.ManifestDirectoryName,
+		e.NumberOfLevelsChecked,
+		e.CurrentDirectory)
+}
+
+// errNoAssociatedApplication means we couldn't locate a workspace summary file.
+type errNoAssociatedApplication struct{}
+
+func (e *errNoAssociatedApplication) Error() string {
+	return fmt.Sprint("couldn't find an application associated with this workspace")
+}
+
+// errHasExistingApplication means we tried to create a workspace that belongs to another application.
+type errHasExistingApplication struct {
+	existingAppName string
+}
+
+func (e *errHasExistingApplication) Error() string {
+	return fmt.Sprintf("this workspace is already registered with application %s", e.existingAppName)
 }

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -51,8 +51,8 @@ type Workspace struct {
 
 // New returns a workspace, used for reading and writing to user's local workspace.
 func New() (*Workspace, error) {
-	appFs := afero.NewOsFs()
-	fsUtils := &afero.Afero{Fs: appFs}
+	fs := afero.NewOsFs()
+	fsUtils := &afero.Afero{Fs: fs}
 
 	workingDir, err := os.Getwd()
 	if err != nil {

--- a/internal/pkg/workspace/workspace.go
+++ b/internal/pkg/workspace/workspace.go
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package workspace contains functionality to manage a user's local workspace. This includes
-// creating a project directory, reading and writing a summary file
-// to that directory and managing (reading, writing, and listing) infrastructure-as-code files.
-// The typical workspace will be structured like:
+// creating an application directory, reading and writing a summary file to associate the workspace with the application,
+// and managing infrastructure-as-code files. The typical workspace will be structured like:
 //  .
-//  ├── ecs-project                    (project directory)
-//  │   ├── .ecs-workspace             (workspace summary)
-//  │   └── my-app
-//  │   │   └── manifest.yml             (application manifest)
+//  ├── copilot                        (application directory)
+//  │   ├── .workspace                 (workspace summary)
+//  │   └── my-service
+//  │   │   └── manifest.yml           (service manifest)
 //  │   ├── buildspec.yml              (buildspec for the pipeline's build stage)
 //  │   └── pipeline.yml               (pipeline manifest)
-//  └── my-app                         (customer application)
+//  └── my-service-src                 (customer service code)
 package workspace
 
 import (
@@ -27,11 +26,11 @@ import (
 )
 
 const (
-	// ProjectDirectoryName is the name of the directory where generated infrastructure code will be stored.
-	ProjectDirectoryName = "ecs-project"
+	// CopilotDirName is the name of the directory where generated infrastructure code for an application will be stored.
+	CopilotDirName = "copilot"
 
 	addonsDirName             = "addons"
-	workspaceSummaryFileName  = ".ecs-workspace"
+	workspaceSummaryFileName  = ".workspace"
 	maximumParentDirsToSearch = 5
 	pipelineFileName          = "pipeline.yml"
 	manifestFileName          = "manifest.yml"
@@ -40,18 +39,17 @@ const (
 
 // Summary is a description of what's associated with this workspace.
 type Summary struct {
-	ProjectName string `yaml:"project"`
+	Application string `yaml:"application"` // Name of the application.
 }
 
-// Workspace manages a local workspace, including creating and managing manifest files.
+// Workspace typically represents a Git repository where the user has its infrastructure-as-code files as well as source files.
 type Workspace struct {
 	workingDir string
-	projectDir string
+	copilotDir string
 	fsUtils    *afero.Afero
 }
 
-// New returns a workspace, used for reading and writing to
-// user's local workspace.
+// New returns a workspace, used for reading and writing to user's local workspace.
 func New() (*Workspace, error) {
 	appFs := afero.NewOsFs()
 	fsUtils := &afero.Afero{Fs: appFs}
@@ -68,37 +66,35 @@ func New() (*Workspace, error) {
 	return &ws, nil
 }
 
-// Create creates the manifest directory (if it doesn't already exist) in
-// the current working directory, and saves a summary in the manifest
-// directory with the project name.
-func (ws *Workspace) Create(projectName string) error {
-	// Create a manifest directory, if one doesn't exist
-	if createDirErr := ws.createProjectDirectory(); createDirErr != nil {
-		return createDirErr
+// Create creates the copilot directory (if it doesn't already exist) in the current working directory,
+// and saves a summary with the application name.
+func (ws *Workspace) Create(appName string) error {
+	// Create an application directory, if one doesn't exist
+	if err := ws.createCopilotDir(); err != nil {
+		return err
 	}
 
 	// Grab an existing workspace summary, if one exists.
-	existingWorkspaceSummary, existingWorkspaceSummaryErr := ws.Summary()
-
-	if existingWorkspaceSummaryErr == nil {
-		// If a summary exists, but is registered to a different project, throw an error.
-		if existingWorkspaceSummary.ProjectName != projectName {
-			return &ErrWorkspaceHasExistingProject{ExistingProjectName: existingWorkspaceSummary.ProjectName}
+	summary, err := ws.Summary()
+	if err == nil {
+		// If a summary exists, but is registered to a different application, throw an error.
+		if summary.Application != appName {
+			return &errHasExistingApplication{existingAppName: summary.Application}
 		}
 		// Otherwise our work is all done.
 		return nil
 	}
 
 	// If there isn't an existing workspace summary, create it.
-	var noProjectFound *ErrNoProjectAssociated
-	if errors.As(existingWorkspaceSummaryErr, &noProjectFound) {
-		return ws.writeSummary(projectName)
+	var notFound *errNoAssociatedApplication
+	if errors.As(err, &notFound) {
+		return ws.writeSummary(appName)
 	}
 
-	return existingWorkspaceSummaryErr
+	return err
 }
 
-// Summary returns a summary of the workspace - including the project name.
+// Summary returns a summary of the workspace - including the application name.
 func (ws *Workspace) Summary() (*Summary, error) {
 	summaryPath, err := ws.summaryPath()
 	if err != nil {
@@ -113,26 +109,26 @@ func (ws *Workspace) Summary() (*Summary, error) {
 		wsSummary := Summary{}
 		return &wsSummary, yaml.Unmarshal(value, &wsSummary)
 	}
-	return nil, &ErrNoProjectAssociated{}
+	return nil, &errNoAssociatedApplication{}
 }
 
-// AppNames returns the application names in the workspace.
-func (ws *Workspace) AppNames() ([]string, error) {
-	projectPath, err := ws.projectDirPath()
+// ServiceNames returns the names of the services in the workspace.
+func (ws *Workspace) ServiceNames() ([]string, error) {
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return nil, err
 	}
-	files, err := ws.fsUtils.ReadDir(projectPath)
+	files, err := ws.fsUtils.ReadDir(copilotPath)
 	if err != nil {
-		return nil, fmt.Errorf("read directory %s: %w", projectPath, err)
+		return nil, fmt.Errorf("read directory %s: %w", copilotPath, err)
 	}
 	var names []string
 	for _, f := range files {
 		if !f.IsDir() {
 			continue
 		}
-		if exists, _ := ws.fsUtils.Exists(filepath.Join(projectPath, f.Name(), manifestFileName)); !exists {
-			// Swallow the error because we don't want to include any applications that we don't have permissions to read.
+		if exists, _ := ws.fsUtils.Exists(filepath.Join(copilotPath, f.Name(), manifestFileName)); !exists {
+			// Swallow the error because we don't want to include any services that we don't have permissions to read.
 			continue
 		}
 		names = append(names, f.Name())
@@ -140,12 +136,12 @@ func (ws *Workspace) AppNames() ([]string, error) {
 	return names, nil
 }
 
-// ReadAppManifest returns the contents of the application manifest under ecs-project/{appName}/manifest.yml.
-func (ws *Workspace) ReadAppManifest(appName string) ([]byte, error) {
-	return ws.read(appName, manifestFileName)
+// ReadServiceManifest returns the contents of the service manifest under copilot/{name}/manifest.yml.
+func (ws *Workspace) ReadServiceManifest(name string) ([]byte, error) {
+	return ws.read(name, manifestFileName)
 }
 
-// ReadPipelineManifest returns the contents of the pipeline manifest under ecs-project/pipeline.yml.
+// ReadPipelineManifest returns the contents of the pipeline manifest under copilot/pipeline.yml.
 func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
 	pmPath, err := ws.pipelineManifestPath()
 	if err != nil {
@@ -162,16 +158,16 @@ func (ws *Workspace) ReadPipelineManifest() ([]byte, error) {
 	return ws.read(pipelineFileName)
 }
 
-// WriteAppManifest writes the application manifest under the project directory.
-func (ws *Workspace) WriteAppManifest(marshaler encoding.BinaryMarshaler, appName string) (string, error) {
+// WriteServiceManifest writes the service's manifest under the copilot/{name}/ directory.
+func (ws *Workspace) WriteServiceManifest(marshaler encoding.BinaryMarshaler, name string) (string, error) {
 	data, err := marshaler.MarshalBinary()
 	if err != nil {
-		return "", fmt.Errorf("marshal app %s manifest to binary: %w", appName, err)
+		return "", fmt.Errorf("marshal service %s manifest to binary: %w", name, err)
 	}
-	return ws.write(data, appName, manifestFileName)
+	return ws.write(data, name, manifestFileName)
 }
 
-// WritePipelineBuildspec writes the pipeline buildspec under the project directory.
+// WritePipelineBuildspec writes the pipeline buildspec under the copilot/ directory.
 // If successful returns the full path of the file, otherwise returns an empty string and the error.
 func (ws *Workspace) WritePipelineBuildspec(marshaler encoding.BinaryMarshaler) (string, error) {
 	data, err := marshaler.MarshalBinary()
@@ -181,7 +177,7 @@ func (ws *Workspace) WritePipelineBuildspec(marshaler encoding.BinaryMarshaler) 
 	return ws.write(data, buildspecFileName)
 }
 
-// WritePipelineManifest writes the pipeline manifest under the project directory.
+// WritePipelineManifest writes the pipeline manifest under the copilot directory.
 // If successful returns the full path of the file, otherwise returns an empty string and the error.
 func (ws *Workspace) WritePipelineManifest(marshaler encoding.BinaryMarshaler) (string, error) {
 	data, err := marshaler.MarshalBinary()
@@ -191,39 +187,39 @@ func (ws *Workspace) WritePipelineManifest(marshaler encoding.BinaryMarshaler) (
 	return ws.write(data, pipelineFileName)
 }
 
-// DeletePipelineManifest removes the from the project directory.
+// DeletePipelineManifest removes the pipeline manifest from the copilot/ directory.
 func (ws *Workspace) DeletePipelineManifest() error {
-	projectPath, err := ws.projectDirPath()
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return err
 	}
 
-	return ws.fsUtils.Remove(filepath.Join(projectPath, pipelineFileName))
+	return ws.fsUtils.Remove(filepath.Join(copilotPath, pipelineFileName))
 }
 
-// DeleteApp removes the application directory from the project directory.
-func (ws *Workspace) DeleteApp(name string) error {
-	projectPath, err := ws.projectDirPath()
+// DeleteService removes the service directory from the copilot/ directory.
+func (ws *Workspace) DeleteService(name string) error {
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return err
 	}
-	return ws.fsUtils.RemoveAll(filepath.Join(projectPath, name))
+	return ws.fsUtils.RemoveAll(filepath.Join(copilotPath, name))
 }
 
-// DeleteAll removes the local project directory.
+// DeleteAll removes the copilot/ directory and all of its contents.
 func (ws *Workspace) DeleteAll() error {
-	return ws.fsUtils.RemoveAll(ProjectDirectoryName)
+	return ws.fsUtils.RemoveAll(CopilotDirName)
 }
 
-// ReadAddonsDir returns a list of file names under an application's "addons/" directory.
-func (ws *Workspace) ReadAddonsDir(appName string) ([]string, error) {
-	projectDir, err := ws.projectDirPath()
+// ReadAddonsDir returns a list of file names under a service's "addons/" directory.
+func (ws *Workspace) ReadAddonsDir(svcName string) ([]string, error) {
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return nil, err
 	}
 
 	var names []string
-	files, err := ws.fsUtils.ReadDir(filepath.Join(projectDir, appName, addonsDirName))
+	files, err := ws.fsUtils.ReadDir(filepath.Join(copilotPath, svcName, addonsDirName))
 	if err != nil {
 		return nil, err
 	}
@@ -233,19 +229,19 @@ func (ws *Workspace) ReadAddonsDir(appName string) ([]string, error) {
 	return names, nil
 }
 
-// ReadAddonsFile returns the contents of a file under the application's "addons/" directory.
-func (ws *Workspace) ReadAddonsFile(appName, fileName string) ([]byte, error) {
-	return ws.read(appName, addonsDirName, fileName)
+// ReadAddonsFile returns the contents of a file under the service's "addons/" directory.
+func (ws *Workspace) ReadAddonsFile(svcName, fileName string) ([]byte, error) {
+	return ws.read(svcName, addonsDirName, fileName)
 }
 
-func (ws *Workspace) writeSummary(projectName string) error {
+func (ws *Workspace) writeSummary(appName string) error {
 	summaryPath, err := ws.summaryPath()
 	if err != nil {
 		return err
 	}
 
 	workspaceSummary := Summary{
-		ProjectName: projectName,
+		Application: appName,
 	}
 
 	serializedWorkspaceSummary, err := yaml.Marshal(workspaceSummary)
@@ -257,70 +253,70 @@ func (ws *Workspace) writeSummary(projectName string) error {
 }
 
 func (ws *Workspace) pipelineManifestPath() (string, error) {
-	manifestPath, err := ws.projectDirPath()
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return "", err
 	}
-	pipelineManifestPath := filepath.Join(manifestPath, pipelineFileName)
+	pipelineManifestPath := filepath.Join(copilotPath, pipelineFileName)
 	return pipelineManifestPath, nil
 }
 
 func (ws *Workspace) summaryPath() (string, error) {
-	manifestPath, err := ws.projectDirPath()
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return "", err
 	}
-	workspaceSummaryPath := filepath.Join(manifestPath, workspaceSummaryFileName)
+	workspaceSummaryPath := filepath.Join(copilotPath, workspaceSummaryFileName)
 	return workspaceSummaryPath, nil
 }
 
-func (ws *Workspace) createProjectDirectory() error {
+func (ws *Workspace) createCopilotDir() error {
 	// First check to see if a manifest directory already exists
-	existingWorkspace, _ := ws.projectDirPath()
+	existingWorkspace, _ := ws.copilotDirPath()
 	if existingWorkspace != "" {
 		return nil
 	}
-	return ws.fsUtils.Mkdir(ProjectDirectoryName, 0755)
+	return ws.fsUtils.Mkdir(CopilotDirName, 0755)
 }
 
-func (ws *Workspace) projectDirPath() (string, error) {
-	if ws.projectDir != "" {
-		return ws.projectDir, nil
+func (ws *Workspace) copilotDirPath() (string, error) {
+	if ws.copilotDir != "" {
+		return ws.copilotDir, nil
 	}
-	// Are we in the project directory?
-	inEcsDir := filepath.Base(ws.workingDir) == ProjectDirectoryName
-	if inEcsDir {
-		ws.projectDir = ws.workingDir
-		return ws.projectDir, nil
+	// Are we in the application directory?
+	inCopilotDir := filepath.Base(ws.workingDir) == CopilotDirName
+	if inCopilotDir {
+		ws.copilotDir = ws.workingDir
+		return ws.copilotDir, nil
 	}
 
 	searchingDir := ws.workingDir
 	for try := 0; try < maximumParentDirsToSearch; try++ {
-		currentDirectoryPath := filepath.Join(searchingDir, ProjectDirectoryName)
+		currentDirectoryPath := filepath.Join(searchingDir, CopilotDirName)
 		inCurrentDirPath, err := ws.fsUtils.DirExists(currentDirectoryPath)
 		if err != nil {
 			return "", err
 		}
 		if inCurrentDirPath {
-			ws.projectDir = currentDirectoryPath
-			return ws.projectDir, nil
+			ws.copilotDir = currentDirectoryPath
+			return ws.copilotDir, nil
 		}
 		searchingDir = filepath.Dir(searchingDir)
 	}
-	return "", &ErrWorkspaceNotFound{
+	return "", &errWorkspaceNotFound{
 		CurrentDirectory:      ws.workingDir,
-		ManifestDirectoryName: ProjectDirectoryName,
+		ManifestDirectoryName: CopilotDirName,
 		NumberOfLevelsChecked: maximumParentDirsToSearch,
 	}
 }
 
-// write flushes the data to a file under the project directory joined by path elements.
+// write flushes the data to a file under the copilot directory joined by path elements.
 func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
-	projectPath, err := ws.projectDirPath()
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return "", err
 	}
-	pathElems := append([]string{projectPath}, elem...)
+	pathElems := append([]string{copilotPath}, elem...)
 	filename := filepath.Join(pathElems...)
 
 	if err := ws.fsUtils.MkdirAll(filepath.Dir(filename), 0755 /* -rwxr-xr-x */); err != nil {
@@ -339,12 +335,12 @@ func (ws *Workspace) write(data []byte, elem ...string) (string, error) {
 	return filename, nil
 }
 
-// read returns the contents of the file under the project directory joined by path elements.
+// read returns the contents of the file under the copilot directory joined by path elements.
 func (ws *Workspace) read(elem ...string) ([]byte, error) {
-	projectPath, err := ws.projectDirPath()
+	copilotPath, err := ws.copilotDirPath()
 	if err != nil {
 		return nil, err
 	}
-	pathElems := append([]string{projectPath}, elem...)
+	pathElems := append([]string{copilotPath}, elem...)
 	return ws.fsUtils.ReadFile(filepath.Join(pathElems...))
 }


### PR DESCRIPTION
BREAKING CHANGE: The following user-visible changes are introduced:
1. The `ecs-project` directory is renamed to `copilot`.
2. The `.ecs-workspace` summary file is renamed to `.workspace`.
3. Errors include the term "service" and "application".


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
