### PR TITLE
chore: add selector struct

### DIFF
--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -11,6 +11,7 @@ import (
 	codepipeline "github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/codepipeline"
 	ecr "github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/ecr"
 	ecs "github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/ecs"
+	config "github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
 	deploy "github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy"
 	describe "github.com/aws/amazon-ecs-cli-v2/internal/pkg/describe"
 	command "github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/command"
@@ -98,6 +99,544 @@ func (m *MockactionCommand) RecommendedActions() []string {
 func (mr *MockactionCommandMockRecorder) RecommendedActions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecommendedActions", reflect.TypeOf((*MockactionCommand)(nil).RecommendedActions))
+}
+
+// MockserviceLister is a mock of serviceLister interface
+type MockserviceLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockserviceListerMockRecorder
+}
+
+// MockserviceListerMockRecorder is the mock recorder for MockserviceLister
+type MockserviceListerMockRecorder struct {
+	mock *MockserviceLister
+}
+
+// NewMockserviceLister creates a new mock instance
+func NewMockserviceLister(ctrl *gomock.Controller) *MockserviceLister {
+	mock := &MockserviceLister{ctrl: ctrl}
+	mock.recorder = &MockserviceListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockserviceLister) EXPECT() *MockserviceListerMockRecorder {
+	return m.recorder
+}
+
+// ListServices mocks base method
+func (m *MockserviceLister) ListServices(appName string) ([]*archer.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServices", appName)
+	ret0, _ := ret[0].([]*archer.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServices indicates an expected call of ListServices
+func (mr *MockserviceListerMockRecorder) ListServices(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockserviceLister)(nil).ListServices), appName)
+}
+
+// MockappLister is a mock of appLister interface
+type MockappLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockappListerMockRecorder
+}
+
+// MockappListerMockRecorder is the mock recorder for MockappLister
+type MockappListerMockRecorder struct {
+	mock *MockappLister
+}
+
+// NewMockappLister creates a new mock instance
+func NewMockappLister(ctrl *gomock.Controller) *MockappLister {
+	mock := &MockappLister{ctrl: ctrl}
+	mock.recorder = &MockappListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockappLister) EXPECT() *MockappListerMockRecorder {
+	return m.recorder
+}
+
+// ListApps mocks base method
+func (m *MockappLister) ListApps() ([]*archer.Project, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListApps")
+	ret0, _ := ret[0].([]*archer.Project)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListApps indicates an expected call of ListApps
+func (mr *MockappListerMockRecorder) ListApps() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApps", reflect.TypeOf((*MockappLister)(nil).ListApps))
+}
+
+// MockapplicationStore is a mock of applicationStore interface
+type MockapplicationStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationStoreMockRecorder
+}
+
+// MockapplicationStoreMockRecorder is the mock recorder for MockapplicationStore
+type MockapplicationStoreMockRecorder struct {
+	mock *MockapplicationStore
+}
+
+// NewMockapplicationStore creates a new mock instance
+func NewMockapplicationStore(ctrl *gomock.Controller) *MockapplicationStore {
+	mock := &MockapplicationStore{ctrl: ctrl}
+	mock.recorder = &MockapplicationStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockapplicationStore) EXPECT() *MockapplicationStoreMockRecorder {
+	return m.recorder
+}
+
+// ListApplications mocks base method
+func (m *MockapplicationStore) ListApplications() ([]*config.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListApplications")
+	ret0, _ := ret[0].([]*config.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListApplications indicates an expected call of ListApplications
+func (mr *MockapplicationStoreMockRecorder) ListApplications() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockapplicationStore)(nil).ListApplications))
+}
+
+// GetApplication mocks base method
+func (m *MockapplicationStore) GetApplication(appName string) (*config.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplication", appName)
+	ret0, _ := ret[0].(*config.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplication indicates an expected call of GetApplication
+func (mr *MockapplicationStoreMockRecorder) GetApplication(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplication", reflect.TypeOf((*MockapplicationStore)(nil).GetApplication), appName)
+}
+
+// CreateApplication mocks base method
+func (m *MockapplicationStore) CreateApplication(app *config.Application) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateApplication", app)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateApplication indicates an expected call of CreateApplication
+func (mr *MockapplicationStoreMockRecorder) CreateApplication(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockapplicationStore)(nil).CreateApplication), app)
+}
+
+// DeleteApplication mocks base method
+func (m *MockapplicationStore) DeleteApplication(name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteApplication", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteApplication indicates an expected call of DeleteApplication
+func (mr *MockapplicationStoreMockRecorder) DeleteApplication(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApplication", reflect.TypeOf((*MockapplicationStore)(nil).DeleteApplication), name)
+}
+
+// MockapplicationLister is a mock of applicationLister interface
+type MockapplicationLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationListerMockRecorder
+}
+
+// MockapplicationListerMockRecorder is the mock recorder for MockapplicationLister
+type MockapplicationListerMockRecorder struct {
+	mock *MockapplicationLister
+}
+
+// NewMockapplicationLister creates a new mock instance
+func NewMockapplicationLister(ctrl *gomock.Controller) *MockapplicationLister {
+	mock := &MockapplicationLister{ctrl: ctrl}
+	mock.recorder = &MockapplicationListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockapplicationLister) EXPECT() *MockapplicationListerMockRecorder {
+	return m.recorder
+}
+
+// ListApplications mocks base method
+func (m *MockapplicationLister) ListApplications() ([]*config.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListApplications")
+	ret0, _ := ret[0].([]*config.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListApplications indicates an expected call of ListApplications
+func (mr *MockapplicationListerMockRecorder) ListApplications() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListApplications", reflect.TypeOf((*MockapplicationLister)(nil).ListApplications))
+}
+
+// MockapplicationCreator is a mock of applicationCreator interface
+type MockapplicationCreator struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationCreatorMockRecorder
+}
+
+// MockapplicationCreatorMockRecorder is the mock recorder for MockapplicationCreator
+type MockapplicationCreatorMockRecorder struct {
+	mock *MockapplicationCreator
+}
+
+// NewMockapplicationCreator creates a new mock instance
+func NewMockapplicationCreator(ctrl *gomock.Controller) *MockapplicationCreator {
+	mock := &MockapplicationCreator{ctrl: ctrl}
+	mock.recorder = &MockapplicationCreatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockapplicationCreator) EXPECT() *MockapplicationCreatorMockRecorder {
+	return m.recorder
+}
+
+// CreateApplication mocks base method
+func (m *MockapplicationCreator) CreateApplication(app *config.Application) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateApplication", app)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateApplication indicates an expected call of CreateApplication
+func (mr *MockapplicationCreatorMockRecorder) CreateApplication(app interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockapplicationCreator)(nil).CreateApplication), app)
+}
+
+// MockapplicationGetter is a mock of applicationGetter interface
+type MockapplicationGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationGetterMockRecorder
+}
+
+// MockapplicationGetterMockRecorder is the mock recorder for MockapplicationGetter
+type MockapplicationGetterMockRecorder struct {
+	mock *MockapplicationGetter
+}
+
+// NewMockapplicationGetter creates a new mock instance
+func NewMockapplicationGetter(ctrl *gomock.Controller) *MockapplicationGetter {
+	mock := &MockapplicationGetter{ctrl: ctrl}
+	mock.recorder = &MockapplicationGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockapplicationGetter) EXPECT() *MockapplicationGetterMockRecorder {
+	return m.recorder
+}
+
+// GetApplication mocks base method
+func (m *MockapplicationGetter) GetApplication(appName string) (*config.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplication", appName)
+	ret0, _ := ret[0].(*config.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplication indicates an expected call of GetApplication
+func (mr *MockapplicationGetterMockRecorder) GetApplication(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplication", reflect.TypeOf((*MockapplicationGetter)(nil).GetApplication), appName)
+}
+
+// MockapplicationDeleter is a mock of applicationDeleter interface
+type MockapplicationDeleter struct {
+	ctrl     *gomock.Controller
+	recorder *MockapplicationDeleterMockRecorder
+}
+
+// MockapplicationDeleterMockRecorder is the mock recorder for MockapplicationDeleter
+type MockapplicationDeleterMockRecorder struct {
+	mock *MockapplicationDeleter
+}
+
+// NewMockapplicationDeleter creates a new mock instance
+func NewMockapplicationDeleter(ctrl *gomock.Controller) *MockapplicationDeleter {
+	mock := &MockapplicationDeleter{ctrl: ctrl}
+	mock.recorder = &MockapplicationDeleterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockapplicationDeleter) EXPECT() *MockapplicationDeleterMockRecorder {
+	return m.recorder
+}
+
+// DeleteApplication mocks base method
+func (m *MockapplicationDeleter) DeleteApplication(name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteApplication", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteApplication indicates an expected call of DeleteApplication
+func (mr *MockapplicationDeleterMockRecorder) DeleteApplication(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteApplication", reflect.TypeOf((*MockapplicationDeleter)(nil).DeleteApplication), name)
+}
+
+// MockenvironmentStore is a mock of environmentStore interface
+type MockenvironmentStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentStoreMockRecorder
+}
+
+// MockenvironmentStoreMockRecorder is the mock recorder for MockenvironmentStore
+type MockenvironmentStoreMockRecorder struct {
+	mock *MockenvironmentStore
+}
+
+// NewMockenvironmentStore creates a new mock instance
+func NewMockenvironmentStore(ctrl *gomock.Controller) *MockenvironmentStore {
+	mock := &MockenvironmentStore{ctrl: ctrl}
+	mock.recorder = &MockenvironmentStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockenvironmentStore) EXPECT() *MockenvironmentStoreMockRecorder {
+	return m.recorder
+}
+
+// ListEnvironments mocks base method
+func (m *MockenvironmentStore) ListEnvironments(appName string) ([]*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironments", appName)
+	ret0, _ := ret[0].([]*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironments indicates an expected call of ListEnvironments
+func (mr *MockenvironmentStoreMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockenvironmentStore)(nil).ListEnvironments), appName)
+}
+
+// GetEnvironment mocks base method
+func (m *MockenvironmentStore) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnvironment", appName, environmentName)
+	ret0, _ := ret[0].(*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEnvironment indicates an expected call of GetEnvironment
+func (mr *MockenvironmentStoreMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockenvironmentStore)(nil).GetEnvironment), appName, environmentName)
+}
+
+// CreateEnvironment mocks base method
+func (m *MockenvironmentStore) CreateEnvironment(env *config.Environment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEnvironment", env)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateEnvironment indicates an expected call of CreateEnvironment
+func (mr *MockenvironmentStoreMockRecorder) CreateEnvironment(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockenvironmentStore)(nil).CreateEnvironment), env)
+}
+
+// DeleteEnvironment mocks base method
+func (m *MockenvironmentStore) DeleteEnvironment(appName, environmentName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEnvironment", appName, environmentName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEnvironment indicates an expected call of DeleteEnvironment
+func (mr *MockenvironmentStoreMockRecorder) DeleteEnvironment(appName, environmentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvironment", reflect.TypeOf((*MockenvironmentStore)(nil).DeleteEnvironment), appName, environmentName)
+}
+
+// MockenvironmentLister is a mock of environmentLister interface
+type MockenvironmentLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentListerMockRecorder
+}
+
+// MockenvironmentListerMockRecorder is the mock recorder for MockenvironmentLister
+type MockenvironmentListerMockRecorder struct {
+	mock *MockenvironmentLister
+}
+
+// NewMockenvironmentLister creates a new mock instance
+func NewMockenvironmentLister(ctrl *gomock.Controller) *MockenvironmentLister {
+	mock := &MockenvironmentLister{ctrl: ctrl}
+	mock.recorder = &MockenvironmentListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockenvironmentLister) EXPECT() *MockenvironmentListerMockRecorder {
+	return m.recorder
+}
+
+// ListEnvironments mocks base method
+func (m *MockenvironmentLister) ListEnvironments(appName string) ([]*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListEnvironments", appName)
+	ret0, _ := ret[0].([]*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListEnvironments indicates an expected call of ListEnvironments
+func (mr *MockenvironmentListerMockRecorder) ListEnvironments(appName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockenvironmentLister)(nil).ListEnvironments), appName)
+}
+
+// MockenvironmentGetter is a mock of environmentGetter interface
+type MockenvironmentGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentGetterMockRecorder
+}
+
+// MockenvironmentGetterMockRecorder is the mock recorder for MockenvironmentGetter
+type MockenvironmentGetterMockRecorder struct {
+	mock *MockenvironmentGetter
+}
+
+// NewMockenvironmentGetter creates a new mock instance
+func NewMockenvironmentGetter(ctrl *gomock.Controller) *MockenvironmentGetter {
+	mock := &MockenvironmentGetter{ctrl: ctrl}
+	mock.recorder = &MockenvironmentGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockenvironmentGetter) EXPECT() *MockenvironmentGetterMockRecorder {
+	return m.recorder
+}
+
+// GetEnvironment mocks base method
+func (m *MockenvironmentGetter) GetEnvironment(appName, environmentName string) (*config.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnvironment", appName, environmentName)
+	ret0, _ := ret[0].(*config.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEnvironment indicates an expected call of GetEnvironment
+func (mr *MockenvironmentGetterMockRecorder) GetEnvironment(appName, environmentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockenvironmentGetter)(nil).GetEnvironment), appName, environmentName)
+}
+
+// MockenvironmentCreator is a mock of environmentCreator interface
+type MockenvironmentCreator struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentCreatorMockRecorder
+}
+
+// MockenvironmentCreatorMockRecorder is the mock recorder for MockenvironmentCreator
+type MockenvironmentCreatorMockRecorder struct {
+	mock *MockenvironmentCreator
+}
+
+// NewMockenvironmentCreator creates a new mock instance
+func NewMockenvironmentCreator(ctrl *gomock.Controller) *MockenvironmentCreator {
+	mock := &MockenvironmentCreator{ctrl: ctrl}
+	mock.recorder = &MockenvironmentCreatorMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockenvironmentCreator) EXPECT() *MockenvironmentCreatorMockRecorder {
+	return m.recorder
+}
+
+// CreateEnvironment mocks base method
+func (m *MockenvironmentCreator) CreateEnvironment(env *config.Environment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateEnvironment", env)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateEnvironment indicates an expected call of CreateEnvironment
+func (mr *MockenvironmentCreatorMockRecorder) CreateEnvironment(env interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockenvironmentCreator)(nil).CreateEnvironment), env)
+}
+
+// MockenvironmentDeleter is a mock of environmentDeleter interface
+type MockenvironmentDeleter struct {
+	ctrl     *gomock.Controller
+	recorder *MockenvironmentDeleterMockRecorder
+}
+
+// MockenvironmentDeleterMockRecorder is the mock recorder for MockenvironmentDeleter
+type MockenvironmentDeleterMockRecorder struct {
+	mock *MockenvironmentDeleter
+}
+
+// NewMockenvironmentDeleter creates a new mock instance
+func NewMockenvironmentDeleter(ctrl *gomock.Controller) *MockenvironmentDeleter {
+	mock := &MockenvironmentDeleter{ctrl: ctrl}
+	mock.recorder = &MockenvironmentDeleterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockenvironmentDeleter) EXPECT() *MockenvironmentDeleterMockRecorder {
+	return m.recorder
+}
+
+// DeleteEnvironment mocks base method
+func (m *MockenvironmentDeleter) DeleteEnvironment(appName, environmentName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteEnvironment", appName, environmentName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteEnvironment indicates an expected call of DeleteEnvironment
+func (mr *MockenvironmentDeleterMockRecorder) DeleteEnvironment(appName, environmentName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvironment", reflect.TypeOf((*MockenvironmentDeleter)(nil).DeleteEnvironment), appName, environmentName)
 }
 
 // MockprojectService is a mock of projectService interface
@@ -1215,6 +1754,44 @@ func (m *MockwsAppDeleter) DeleteService(name string) error {
 func (mr *MockwsAppDeleterMockRecorder) DeleteService(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockwsAppDeleter)(nil).DeleteService), name)
+}
+
+// MockwsServiceLister is a mock of wsServiceLister interface
+type MockwsServiceLister struct {
+	ctrl     *gomock.Controller
+	recorder *MockwsServiceListerMockRecorder
+}
+
+// MockwsServiceListerMockRecorder is the mock recorder for MockwsServiceLister
+type MockwsServiceListerMockRecorder struct {
+	mock *MockwsServiceLister
+}
+
+// NewMockwsServiceLister creates a new mock instance
+func NewMockwsServiceLister(ctrl *gomock.Controller) *MockwsServiceLister {
+	mock := &MockwsServiceLister{ctrl: ctrl}
+	mock.recorder = &MockwsServiceListerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockwsServiceLister) EXPECT() *MockwsServiceListerMockRecorder {
+	return m.recorder
+}
+
+// ServiceNames mocks base method
+func (m *MockwsServiceLister) ServiceNames() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceNames")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ServiceNames indicates an expected call of ServiceNames
+func (mr *MockwsServiceListerMockRecorder) ServiceNames() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceNames", reflect.TypeOf((*MockwsServiceLister)(nil).ServiceNames))
 }
 
 // MockwsAppReader is a mock of wsAppReader interface

--- a/internal/pkg/cli/selector.go
+++ b/internal/pkg/cli/selector.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
+)
+
+// selector prompts users to select an app, environments, or service.
+// We can use this instead of repeating our own selectors in our own
+// commands.
+type selector struct {
+	prompt prompter
+}
+
+type selectWorkspaceServiceRequest struct {
+	Prompt string          // instructs users on what to select
+	Help   string          // provides help text on what users are selecting
+	Lister wsServiceLister // lists local services
+}
+
+type selectServiceRequest struct {
+	Prompt string        // instructs users on what to select
+	Help   string        // provides help text on what users are selecting
+	App    string        // the app whose services you'd like to list
+	Lister serviceLister // lists all services for an app
+}
+
+type selectEnvRequest struct {
+	Prompt string            // instructs users on what to select
+	Help   string            // provides help text on what users are selecting
+	App    string            // the app whose envs you'd like to list
+	Lister environmentLister // lists all envs in an app
+}
+
+type selectAppRequest struct {
+	Prompt string            // instructs users on what to select
+	Help   string            // provides help text on what users are selecting
+	Lister applicationLister // lists all apps in an account and region
+}
+
+// WorkspaceService fetches all services in the workspace and then prompts the
+// user select one.
+func (s *selector) SelectWorkspaceService(req *selectWorkspaceServiceRequest) (string, error) {
+	serviceNames, err := s.retrieveWorkspaceServices(req.Lister)
+	if err != nil {
+		return "", fmt.Errorf("list services: %w", err)
+	}
+	if len(serviceNames) == 1 {
+		log.Infof("Only found one service, defaulting to: %s\n", color.HighlightUserInput(serviceNames[0]))
+		return serviceNames[0], nil
+	}
+
+	selectedServiceName, err := s.prompt.SelectOne(req.Prompt, req.Help, serviceNames)
+	if err != nil {
+		return "", fmt.Errorf("select local service: %w", err)
+	}
+	return selectedServiceName, nil
+}
+
+// Service fetches all services in an app and prompts the user select one.
+func (s *selector) SelectService(req *selectServiceRequest) (string, error) {
+	services, err := s.retrieveServices(req.App, req.Lister)
+	if err != nil {
+		return "", fmt.Errorf("get services for app %s: %w", req.App, err)
+	}
+	if len(services) == 0 {
+		log.Infof("Couldn't find any services associated with app %s, try initializing one: %s\n",
+			color.HighlightUserInput(req.App),
+			color.HighlightCode("copilot svc init"))
+		return "", fmt.Errorf("no services found in app %s", req.App)
+	}
+	if len(services) == 1 {
+		log.Infof("Only found one service, defaulting to: %s\n", color.HighlightUserInput(services[0]))
+		return services[0], nil
+	}
+	selectedAppName, err := s.prompt.SelectOne(req.Prompt,
+		req.Help,
+		services)
+	if err != nil {
+		return "", fmt.Errorf("select service: %w", err)
+	}
+	return selectedAppName, nil
+}
+
+// Environment fetches all the environments in an app and prompts the user to select one.
+func (s *selector) SelectEnvironment(req *selectEnvRequest) (string, error) {
+	envs, err := s.retrieveEnvironments(req.App, req.Lister)
+	if err != nil {
+		return "", fmt.Errorf("get environments for app %s from metadata store: %w", req.App, err)
+	}
+	if len(envs) == 0 {
+		log.Infof("Couldn't find any environments associated with app %s, try initializing one: %s\n",
+			color.HighlightUserInput(req.App),
+			color.HighlightCode("copilot env init"))
+		return "", fmt.Errorf("no environments found in app %s", req.App)
+	}
+	if len(envs) == 1 {
+		log.Infof("Only found one environment, defaulting to: %s\n", color.HighlightUserInput(envs[0]))
+		return envs[0], nil
+	}
+	selectedEnvName, err := s.prompt.SelectOne(req.Prompt,
+		req.Help,
+		envs)
+	if err != nil {
+		return "", fmt.Errorf("select environment: %w", err)
+	}
+	return selectedEnvName, nil
+}
+
+// Application fetches all the apps in an account/region and prompts the user to select one.
+func (s *selector) SelectApplication(req *selectAppRequest) (string, error) {
+	appNames, err := s.retrieveApps(req.Lister)
+	if err != nil {
+		return "", err
+	}
+	if len(appNames) == 0 {
+		log.Infof("Couldn't find any apps in this region and account. Try initializing one with %s\n",
+			color.HighlightCode("copilot app init"))
+		return "", fmt.Errorf("no apps found")
+
+	}
+
+	if len(appNames) == 1 {
+		log.Infof("Only found one app, defaulting to: %s\n", color.HighlightUserInput(appNames[0]))
+		return appNames[0], nil
+	}
+
+	proj, err := s.prompt.SelectOne(
+		req.Prompt,
+		req.Help,
+		appNames,
+	)
+
+	if err != nil {
+		return "", fmt.Errorf("select app: %w", err)
+	}
+
+	return proj, nil
+}
+
+func (s *selector) retrieveApps(lister applicationLister) ([]string, error) {
+	apps, err := lister.ListApplications()
+	if err != nil {
+		return nil, fmt.Errorf("list apps: %w", err)
+	}
+	appNames := make([]string, len(apps))
+	for ind, app := range apps {
+		appNames[ind] = app.Name
+	}
+	return appNames, nil
+}
+
+func (s *selector) retrieveEnvironments(App string, lister environmentLister) ([]string, error) {
+	envs, err := lister.ListEnvironments(App)
+	if err != nil {
+		return nil, fmt.Errorf("list environments: %w", err)
+	}
+	envsNames := make([]string, len(envs))
+	for ind, env := range envs {
+		envsNames[ind] = env.Name
+	}
+	return envsNames, nil
+}
+
+func (s *selector) retrieveServices(appName string, lister serviceLister) ([]string, error) {
+	services, err := lister.ListServices(appName)
+	if err != nil {
+		return nil, fmt.Errorf("list services: %w", err)
+	}
+	serviceNames := make([]string, len(services))
+	for ind, service := range services {
+		serviceNames[ind] = service.Name
+	}
+	return serviceNames, nil
+}
+
+func (s *selector) retrieveWorkspaceServices(lister wsServiceLister) ([]string, error) {
+	localServiceNames, err := lister.ServiceNames()
+	if err != nil {
+		return nil, err
+	}
+	if len(localServiceNames) == 0 {
+		return nil, errors.New("no services found in workspace")
+	}
+	return localServiceNames, nil
+}

--- a/internal/pkg/cli/selector_test.go
+++ b/internal/pkg/cli/selector_test.go
@@ -1,0 +1,493 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelector_SelectWorkspaceService(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockServiceLister := mocks.NewMockwsServiceLister(ctrl)
+	mockPrompt := mocks.NewMockprompter(ctrl)
+	defer ctrl.Finish()
+
+	testCases := map[string]struct {
+		mocking func()
+		wantErr error
+		want    string
+	}{
+		"with no workspace services": {
+			mocking: func() {
+
+				mockServiceLister.
+					EXPECT().
+					ServiceNames().
+					Return([]string{}, nil).
+					Times(1)
+
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			wantErr: fmt.Errorf("list services: no services found in workspace"),
+		},
+		"with only one workspace service (skips prompting)": {
+			mocking: func() {
+
+				mockServiceLister.
+					EXPECT().
+					ServiceNames().
+					Return([]string{
+						"service1",
+					}, nil).
+					Times(1)
+
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			want: "service1",
+		},
+		"with multiple workspace services": {
+			mocking: func() {
+
+				mockServiceLister.
+					EXPECT().
+					ServiceNames().
+					Return([]string{
+						"service1",
+						"service2",
+					}, nil).
+					Times(1)
+
+				mockPrompt.
+					EXPECT().
+					SelectOne(
+						gomock.Eq("Select a local service"),
+						gomock.Eq("Help text"),
+						gomock.Eq([]string{"service1", "service2"})).
+					Return("service2", nil).
+					Times(1)
+			},
+			want: "service2",
+		},
+		"with error selecting services": {
+			mocking: func() {
+
+				mockServiceLister.
+					EXPECT().
+					ServiceNames().
+					Return([]string{
+						"service1",
+						"service2",
+					}, nil).
+					Times(1)
+
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"service1", "service2"})).
+					Return("", fmt.Errorf("error selecting")).
+					Times(1)
+			},
+			wantErr: fmt.Errorf("select local service: error selecting"),
+		},
+	}
+
+	slct := selector{prompt: mockPrompt}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+
+			got, err := slct.SelectWorkspaceService(&selectWorkspaceServiceRequest{
+				Prompt: "Select a local service",
+				Help:   "Help text",
+				Lister: mockServiceLister,
+			})
+			if tc.wantErr != nil {
+				require.EqualError(t, tc.wantErr, err.Error())
+			} else {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+// TODO Once the serviceLister interface is updated,
+// stop using archer.Application and instead move to
+// config.Service.
+func TestSelector_Service(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockServiceLister := mocks.NewMockserviceLister(ctrl)
+	mockPrompt := mocks.NewMockprompter(ctrl)
+	defer ctrl.Finish()
+
+	appName := "myapp"
+
+	testCases := map[string]struct {
+		mocking func()
+		wantErr error
+		want    string
+	}{
+		"with no services": {
+			mocking: func() {
+				mockServiceLister.
+					EXPECT().
+					ListServices(gomock.Eq(appName)).
+					Return([]*archer.Application{}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			wantErr: fmt.Errorf("no services found in app myapp"),
+		},
+		"with only one service (skips prompting)": {
+			mocking: func() {
+				mockServiceLister.
+					EXPECT().
+					ListServices(gomock.Eq(appName)).
+					Return([]*archer.Application{
+						&archer.Application{
+							Project: appName,
+							Name:    "service1",
+							Type:    "load balanced web service",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			want: "service1",
+		},
+		"with multiple services": {
+			mocking: func() {
+				mockServiceLister.
+					EXPECT().
+					ListServices(gomock.Eq(appName)).
+					Return([]*archer.Application{
+						&archer.Application{
+							Project: appName,
+							Name:    "service1",
+							Type:    "load balanced web service",
+						},
+						&archer.Application{
+							Project: appName,
+							Name:    "service2",
+							Type:    "backend service",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(
+						gomock.Eq("Select a service"),
+						gomock.Eq("Help text"),
+						gomock.Eq([]string{"service1", "service2"})).
+					Return("service2", nil).
+					Times(1)
+			},
+			want: "service2",
+		},
+		"with error selecting services": {
+			mocking: func() {
+				mockServiceLister.
+					EXPECT().
+					ListServices(gomock.Eq(appName)).
+					Return([]*archer.Application{
+						&archer.Application{
+							Project: appName,
+							Name:    "service1",
+							Type:    "load balanced web service",
+						},
+						&archer.Application{
+							Project: appName,
+							Name:    "service2",
+							Type:    "backend service",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"service1", "service2"})).
+					Return("", fmt.Errorf("error selecting")).
+					Times(1)
+			},
+			wantErr: fmt.Errorf("select service: error selecting"),
+		},
+	}
+
+	slct := selector{prompt: mockPrompt}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+
+			got, err := slct.SelectService(&selectServiceRequest{
+				Prompt: "Select a service",
+				Help:   "Help text",
+				Lister: mockServiceLister,
+				App:    appName,
+			})
+			if tc.wantErr != nil {
+				require.EqualError(t, tc.wantErr, err.Error())
+			} else {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSelector_SelectEnvironment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockEnvLister := mocks.NewMockenvironmentLister(ctrl)
+	mockPrompt := mocks.NewMockprompter(ctrl)
+	defer ctrl.Finish()
+
+	appName := "myapp"
+
+	testCases := map[string]struct {
+		mocking func()
+		wantErr error
+		want    string
+	}{
+		"with no environments": {
+			mocking: func() {
+				mockEnvLister.
+					EXPECT().
+					ListEnvironments(gomock.Eq(appName)).
+					Return([]*config.Environment{}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			wantErr: fmt.Errorf("no environments found in app myapp"),
+		},
+		"with only one environment (skips prompting)": {
+			mocking: func() {
+				mockEnvLister.
+					EXPECT().
+					ListEnvironments(gomock.Eq(appName)).
+					Return([]*config.Environment{
+						&config.Environment{
+							App:  appName,
+							Name: "env1",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			want: "env1",
+		},
+		"with multiple environments": {
+			mocking: func() {
+				mockEnvLister.
+					EXPECT().
+					ListEnvironments(gomock.Eq(appName)).
+					Return([]*config.Environment{
+						&config.Environment{
+							App:  appName,
+							Name: "env1",
+						},
+						&config.Environment{
+							App:  appName,
+							Name: "env2",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(
+						gomock.Eq("Select an environment"),
+						gomock.Eq("Help text"),
+						gomock.Eq([]string{"env1", "env2"})).
+					Return("env2", nil).
+					Times(1)
+			},
+			want: "env2",
+		},
+		"with error selecting environments": {
+			mocking: func() {
+				mockEnvLister.
+					EXPECT().
+					ListEnvironments(gomock.Eq(appName)).
+					Return([]*config.Environment{
+						&config.Environment{
+							App:  appName,
+							Name: "env1",
+						},
+						&config.Environment{
+							App:  appName,
+							Name: "env2",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"env1", "env2"})).
+					Return("", fmt.Errorf("error selecting")).
+					Times(1)
+			},
+			wantErr: fmt.Errorf("select environment: error selecting"),
+		},
+	}
+
+	slct := selector{prompt: mockPrompt}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+
+			got, err := slct.SelectEnvironment(&selectEnvRequest{
+				Prompt: "Select an environment",
+				Help:   "Help text",
+				Lister: mockEnvLister,
+				App:    appName,
+			})
+			if tc.wantErr != nil {
+				require.EqualError(t, tc.wantErr, err.Error())
+			} else {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSelector_SelectApplication(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockAppLister := mocks.NewMockapplicationLister(ctrl)
+	mockPrompt := mocks.NewMockprompter(ctrl)
+	defer ctrl.Finish()
+
+	testCases := map[string]struct {
+		mocking func()
+		wantErr error
+		want    string
+	}{
+		"with no apps": {
+			mocking: func() {
+				mockAppLister.
+					EXPECT().
+					ListApplications().
+					Return([]*config.Application{}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			wantErr: fmt.Errorf("no apps found"),
+		},
+		"with only one app (skips prompting)": {
+			mocking: func() {
+				mockAppLister.
+					EXPECT().
+					ListApplications().
+					Return([]*config.Application{
+						&config.Application{
+							Name: "app1",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).
+					Times(0)
+
+			},
+			want: "app1",
+		},
+		"with multiple apps": {
+			mocking: func() {
+				mockAppLister.
+					EXPECT().
+					ListApplications().
+					Return([]*config.Application{
+						&config.Application{
+							Name: "app1",
+						},
+						&config.Application{
+							Name: "app2",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(
+						gomock.Eq("Select an app"),
+						gomock.Eq("Help text"),
+						gomock.Eq([]string{"app1", "app2"})).
+					Return("app2", nil).
+					Times(1)
+			},
+			want: "app2",
+		},
+		"with error selecting apps": {
+			mocking: func() {
+				mockAppLister.
+					EXPECT().
+					ListApplications().
+					Return([]*config.Application{
+						&config.Application{
+							Name: "app1",
+						},
+						&config.Application{
+							Name: "app2",
+						},
+					}, nil).
+					Times(1)
+				mockPrompt.
+					EXPECT().
+					SelectOne(gomock.Any(), gomock.Any(), gomock.Eq([]string{"app1", "app2"})).
+					Return("", fmt.Errorf("error selecting")).
+					Times(1)
+			},
+			wantErr: fmt.Errorf("select app: error selecting"),
+		},
+	}
+
+	slct := selector{prompt: mockPrompt}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tc.mocking()
+
+			got, err := slct.SelectApplication(&selectAppRequest{
+				Prompt: "Select an app",
+				Help:   "Help text",
+				Lister: mockAppLister,
+			})
+			if tc.wantErr != nil {
+				require.EqualError(t, tc.wantErr, err.Error())
+			} else {
+				require.Equal(t, tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Selector is a centralized struct that holds the logic
for asking a user to select an app, service, and env.

It uses all the new config* structs, except for services,
since the servicelister returns apps.

Resolves #842 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
