### PR TITLE
fix(env): initialize profile sessions before checking for dns delegation

### DIFF
--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -137,13 +137,15 @@ func (o *initEnvOpts) Execute() error {
 		// Ensure the project actually exists before we do a deployment.
 		return err
 	}
+
+	if err = o.initProfileClients(o); err != nil {
+		return err
+	}
+
 	if project.RequiresDNSDelegation() {
 		if err := o.delegateDNSFromProject(project); err != nil {
 			return fmt.Errorf("granting DNS permissions: %w", err)
 		}
-	}
-	if err = o.initProfileClients(o); err != nil {
-		return err
 	}
 
 	// 1. Start creating the CloudFormation stack for the environment.


### PR DESCRIPTION
Tiny fix to env init. 

When I went to create an env in a project with DNS, I got a segfault. Turns out that we were checking the project for DNS requirements before we initialized any of the sessions via the call to initProfileClients().

No tests added because this wasn't caught by mock tests. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
