### PR TITLE
test(describe): fix flaky "app status" tests due to passing time

### DIFF
--- a/internal/pkg/cli/app_status_test.go
+++ b/internal/pkg/cli/app_status_test.go
@@ -8,16 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/archer"
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/cloudwatch"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/ecs"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	climocks "github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/mocks"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/describe"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	humanize "github.com/dustin/go-humanize"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 )
@@ -326,81 +323,11 @@ func TestAppStatus_Ask(t *testing.T) {
 
 func TestAppStatus_Execute(t *testing.T) {
 	mockError := errors.New("some error")
-	startTime, _ := time.Parse(time.RFC3339, "2006-01-02T15:04:05+00:00")
-	stopTime, _ := time.Parse(time.RFC3339, "2006-01-02T16:04:05+00:00")
-	updateTime := time.Unix(1584129030, 0)
-	mockProvisioningAppStatus := &describe.AppStatusDesc{
-		Service: ecs.ServiceStatus{
-			DesiredCount:     1,
-			RunningCount:     0,
-			Status:           "ACTIVE",
-			LastDeploymentAt: startTime.Unix(),
-			TaskDefinition:   "mockTaskDefinition",
-		},
-		Alarms: []cloudwatch.AlarmStatus{
-			{
-				Arn:          "mockAlarmArn",
-				Name:         "mockAlarm",
-				Reason:       "Threshold Crossed",
-				Status:       "OK",
-				Type:         "Metric",
-				UpdatedTimes: updateTime.Unix(),
-			},
-		},
-		Tasks: []ecs.TaskStatus{
-			{
-				Health:     "HEALTHY",
-				LastStatus: "PROVISIONING",
-				ID:         "1234567890123456789",
-			},
-		},
-	}
-	mockAppStatus := &describe.AppStatusDesc{
-		Service: ecs.ServiceStatus{
-			DesiredCount:     1,
-			RunningCount:     1,
-			Status:           "ACTIVE",
-			LastDeploymentAt: startTime.Unix(),
-			TaskDefinition:   "mockTaskDefinition",
-		},
-		Alarms: []cloudwatch.AlarmStatus{
-			{
-				Arn:          "mockAlarmArn",
-				Name:         "mockAlarm",
-				Reason:       "Threshold Crossed",
-				Status:       "OK",
-				Type:         "Metric",
-				UpdatedTimes: updateTime.Unix(),
-			},
-		},
-		Tasks: []ecs.TaskStatus{
-			{
-				Health:     "HEALTHY",
-				LastStatus: "RUNNING",
-				ID:         "1234567890123456789",
-				Images: []ecs.Image{
-					{
-						Digest: "69671a968e8ec3648e2697417750e",
-						ID:     "mockImageID1",
-					},
-					{
-						ID:     "mockImageID2",
-						Digest: "ca27a44e25ce17fea7b07940ad793",
-					},
-				},
-				StartedAt:     startTime.Unix(),
-				StoppedAt:     stopTime.Unix(),
-				StoppedReason: "some reason",
-			},
-		},
-	}
+	mockAppStatus := &describe.AppStatusDesc{}
 	testCases := map[string]struct {
-		shouldOutputJSON bool
-
+		shouldOutputJSON    bool
 		mockStatusDescriber func(m *climocks.MockstatusDescriber)
-
-		wantedContent string
-		wantedError   error
+		wantedError         error
 	}{
 		"errors if failed to describe the status of the app": {
 			mockStatusDescriber: func(m *climocks.MockstatusDescriber) {
@@ -414,58 +341,11 @@ func TestAppStatus_Execute(t *testing.T) {
 			mockStatusDescriber: func(m *climocks.MockstatusDescriber) {
 				m.EXPECT().Describe().Return(mockAppStatus, nil)
 			},
-
-			wantedContent: "{\"Service\":{\"desiredCount\":1,\"runningCount\":1,\"status\":\"ACTIVE\",\"lastDeploymentAt\":1136214245,\"taskDefinition\":\"mockTaskDefinition\"},\"tasks\":[{\"health\":\"HEALTHY\",\"id\":\"1234567890123456789\",\"images\":[{\"ID\":\"mockImageID1\",\"Digest\":\"69671a968e8ec3648e2697417750e\"},{\"ID\":\"mockImageID2\",\"Digest\":\"ca27a44e25ce17fea7b07940ad793\"}],\"lastStatus\":\"RUNNING\",\"startedAt\":1136214245,\"stoppedAt\":1136217845,\"stoppedReason\":\"some reason\"}],\"alarms\":[{\"arn\":\"mockAlarmArn\",\"name\":\"mockAlarm\",\"reason\":\"Threshold Crossed\",\"status\":\"OK\",\"type\":\"Metric\",\"updatedTimes\":1584129030}]}\n",
 		},
-		"success with human output": {
+		"success with HumanString": {
 			mockStatusDescriber: func(m *climocks.MockstatusDescriber) {
 				m.EXPECT().Describe().Return(mockAppStatus, nil)
 			},
-
-			wantedContent: fmt.Sprintf(`Service Status
-
-  ACTIVE 1 / 1 running tasks (0 pending)
-
-Last Deployment
-
-  Updated At        %s
-  Task Definition   mockTaskDefinition
-
-Task Status
-
-  ID                Image Digest        Last Status         Health Status       Started At          Stopped At
-  12345678          69671a96,ca27a44e   RUNNING             HEALTHY             %s        %s
-
-Alarms
-
-  Name              Health              Last Updated        Reason
-  mockAlarm         OK                  %s         Threshold Crossed
-`, humanize.Time(startTime), humanize.Time(startTime), humanize.Time(stopTime), humanize.Time(updateTime)),
-		},
-		"success with human output when task is provisioning": {
-			mockStatusDescriber: func(m *climocks.MockstatusDescriber) {
-				m.EXPECT().Describe().Return(mockProvisioningAppStatus, nil)
-			},
-
-			wantedContent: fmt.Sprintf(`Service Status
-
-  ACTIVE 0 / 1 running tasks (1 pending)
-
-Last Deployment
-
-  Updated At        %s
-  Task Definition   mockTaskDefinition
-
-Task Status
-
-  ID                Image Digest        Last Status         Health Status       Started At          Stopped At
-  12345678          -                   PROVISIONING        HEALTHY             -                   -
-
-Alarms
-
-  Name              Health              Last Updated        Reason
-  mockAlarm         OK                  %s         Threshold Crossed
-`, humanize.Time(startTime), humanize.Time(updateTime)),
 		},
 	}
 
@@ -500,7 +380,7 @@ Alarms
 				require.EqualError(t, err, tc.wantedError.Error())
 			} else {
 				require.Nil(t, err)
-				require.Equal(t, tc.wantedContent, b.String(), "expected output content match")
+				require.NotEmpty(t, b.String(), "expected output content to not be empty")
 			}
 		})
 	}

--- a/internal/pkg/describe/status.go
+++ b/internal/pkg/describe/status.go
@@ -16,8 +16,11 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation/stack"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/store"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
-	humanize "github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize"
 )
+
+// humanizeTime is overriden in tests so that its output is constant as time passes.
+var humanizeTime = humanize.Time
 
 type alarmStatusGetter interface {
 	GetAlarmsWithTags(tags map[string]string) ([]cloudwatch.AlarmStatus, error)
@@ -145,7 +148,7 @@ func (w *AppStatusDesc) HumanString() string {
 		w.Service.RunningCount, w.Service.DesiredCount, w.Service.DesiredCount-w.Service.RunningCount)
 	fmt.Fprintf(writer, color.Bold.Sprint("\nLast Deployment\n\n"))
 	writer.Flush()
-	fmt.Fprintf(writer, "  %s\t%s\n", "Updated At", humanize.Time(time.Unix(w.Service.LastDeploymentAt, 0)))
+	fmt.Fprintf(writer, "  %s\t%s\n", "Updated At", humanizeTime(time.Unix(w.Service.LastDeploymentAt, 0)))
 	fmt.Fprintf(writer, "  %s\t%s\n", "Task Definition", w.Service.TaskDefinition)
 	fmt.Fprintf(writer, color.Bold.Sprint("\nTask Status\n\n"))
 	writer.Flush()
@@ -157,7 +160,7 @@ func (w *AppStatusDesc) HumanString() string {
 	writer.Flush()
 	fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\n", "Name", "Health", "Last Updated", "Reason")
 	for _, alarm := range w.Alarms {
-		updatedTimeSince := humanize.Time(time.Unix(alarm.UpdatedTimes, 0))
+		updatedTimeSince := humanizeTime(time.Unix(alarm.UpdatedTimes, 0))
 		fmt.Fprintf(writer, "  %s\t%s\t%s\t%s\n", alarm.Name, alarm.Status, updatedTimeSince, alarm.Reason)
 	}
 	writer.Flush()


### PR DESCRIPTION
The `humanize.Time` function outputs time in human friendly ways
(ex: "1 day ago"). Our test cases were expecting the string "1 month ago",
but a few hours ago the output from `humanize.Time` changed to "2 months ago" so the tests in master started failing.

This change hard-codes `time.Now` for the test, so that humanize.Time
always returns the same value.
We also moved the test from "cli/app_status_test.go" to "describe/status_test.go".


*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
