### PR TITLE
chore(cli): copilot renaming for env subcommands

### DIFF
--- a/internal/pkg/cli/env_delete.go
+++ b/internal/pkg/cli/env_delete.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/profile"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/aws/session"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/selector"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/deploy/cloudformation/stack"
@@ -27,13 +28,13 @@ const (
 	fmtEnvDeleteProfilePrompt  = "Which named profile should we use to delete %s?"
 	envDeleteProfileHelpPrompt = "This is usually the same AWS CLI named profile used to create the environment."
 
-	fmtDeleteEnvPrompt = "Are you sure you want to delete environment %s from project %s?"
+	fmtDeleteEnvPrompt = "Are you sure you want to delete environment %s from application %s?"
 )
 
 const (
-	fmtDeleteEnvStart    = "Deleting environment %s from project %s."
-	fmtDeleteEnvFailed   = "Failed to delete environment %s from project %s: %v."
-	fmtDeleteEnvComplete = "Deleted environment %s from project %s."
+	fmtDeleteEnvStart    = "Deleting environment %s from application %s."
+	fmtDeleteEnvFailed   = "Failed to delete environment %s from application %s: %v."
+	fmtDeleteEnvComplete = "Deleted environment %s from application %s."
 )
 
 var (
@@ -59,6 +60,7 @@ type deleteEnvOpts struct {
 	deployClient  environmentDeployer
 	profileConfig profileNames
 	prog          progress
+	sel           configSelector
 
 	// initProfileClients is overriden in tests.
 	initProfileClients func(*deleteEnvOpts) error
@@ -67,7 +69,7 @@ type deleteEnvOpts struct {
 func newDeleteEnvOpts(vars deleteEnvVars) (*deleteEnvOpts, error) {
 	store, err := config.NewStore()
 	if err != nil {
-		return nil, fmt.Errorf("connect to ecs-cli metadata store: %w", err)
+		return nil, fmt.Errorf("connect to copilot config store: %w", err)
 	}
 	cfg, err := profile.NewConfig()
 	if err != nil {
@@ -79,6 +81,7 @@ func newDeleteEnvOpts(vars deleteEnvVars) (*deleteEnvOpts, error) {
 		store:         store,
 		profileConfig: cfg,
 		prog:          termprogress.NewSpinner(),
+		sel:           selector.NewConfigSelect(vars.prompt, store),
 		initProfileClients: func(o *deleteEnvOpts) error {
 			profileSess, err := session.NewProvider().FromProfile(o.EnvProfile)
 			if err != nil {
@@ -115,7 +118,7 @@ func (o *deleteEnvOpts) Ask() error {
 	}
 	deleteConfirmed, err := o.prompt.Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, o.EnvName, o.AppName()), "")
 	if err != nil {
-		return fmt.Errorf("prompt for environment deletion: %w", err)
+		return fmt.Errorf("confirm to delete environment %s: %w", o.EnvName, err)
 	}
 	if !deleteConfirmed {
 		return errEnvDeleteCancelled
@@ -124,7 +127,7 @@ func (o *deleteEnvOpts) Ask() error {
 	return nil
 }
 
-// Execute deletes the environment from the project by first deleting the stack and then removing the entry from the store.
+// Execute deletes the environment from the application by first deleting the stack and then removing the entry from the store.
 // If an operation fails, it moves on to the next one instead of halting the execution.
 // The environment is removed from the store only if other delete operations succeed.
 // Execute assumes that Validate is invoked first.
@@ -132,7 +135,7 @@ func (o *deleteEnvOpts) Execute() error {
 	if err := o.initProfileClients(o); err != nil {
 		return err
 	}
-	if err := o.validateNoRunningApps(); err != nil {
+	if err := o.validateNoRunningServices(); err != nil {
 		return err
 	}
 
@@ -156,13 +159,13 @@ func (o *deleteEnvOpts) validateEnvName() error {
 	return nil
 }
 
-func (o *deleteEnvOpts) validateNoRunningApps() error {
+func (o *deleteEnvOpts) validateNoRunningServices() error {
 	stacks, err := o.rgClient.GetResources(&resourcegroupstaggingapi.GetResourcesInput{
 		ResourceTypeFilters: []*string{aws.String("cloudformation")},
 		TagFilters: []*resourcegroupstaggingapi.TagFilter{
 			{
 				Key:    aws.String(stack.ServiceTagKey),
-				Values: []*string{}, // Matches any application stack.
+				Values: []*string{}, // Matches any service stack.
 			},
 			{
 				Key:    aws.String(stack.EnvTagKey),
@@ -175,19 +178,19 @@ func (o *deleteEnvOpts) validateNoRunningApps() error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("find application cloudformation stacks: %w", err)
+		return fmt.Errorf("find service cloudformation stacks: %w", err)
 	}
 	if len(stacks.ResourceTagMappingList) > 0 {
-		var appNames []string
+		var svcNames []string
 		for _, cfnStack := range stacks.ResourceTagMappingList {
 			for _, t := range cfnStack.Tags {
 				if *t.Key != stack.ServiceTagKey {
 					continue
 				}
-				appNames = append(appNames, *t.Value)
+				svcNames = append(svcNames, *t.Value)
 			}
 		}
-		return fmt.Errorf("applications: '%s' still exist within the environment %s", strings.Join(appNames, ", "), o.EnvName)
+		return fmt.Errorf("service '%s' still exist within the environment %s", strings.Join(svcNames, ", "), o.EnvName)
 	}
 	return nil
 }
@@ -196,28 +199,11 @@ func (o *deleteEnvOpts) askEnvName() error {
 	if o.EnvName != "" {
 		return nil
 	}
-
-	envs, err := o.store.ListEnvironments(o.AppName())
+	env, err := o.sel.Environment(envDeleteNamePrompt, "", o.AppName())
 	if err != nil {
-		return fmt.Errorf("list environments under project %s: %w", o.AppName(), err)
+		return fmt.Errorf("select environment to delete: %w", err)
 	}
-	var names []string
-	for _, env := range envs {
-		names = append(names, env.Name)
-	}
-	if len(names) == 0 {
-		return fmt.Errorf("couldn't find any environment in the project %s", o.AppName())
-	}
-	if len(names) == 1 {
-		o.EnvName = names[0]
-		log.Infof("Only found one environment, defaulting to: %s\n", color.HighlightUserInput(o.EnvName))
-		return nil
-	}
-	name, err := o.prompt.SelectOne(envDeleteNamePrompt, "", names)
-	if err != nil {
-		return fmt.Errorf("prompt for environment name: %w", err)
-	}
-	o.EnvName = name
+	o.EnvName = env
 	return nil
 }
 
@@ -241,22 +227,10 @@ func (o *deleteEnvOpts) askProfile() error {
 		envDeleteProfileHelpPrompt,
 		names)
 	if err != nil {
-		return fmt.Errorf("prompt to get the profile name: %w", err)
+		return fmt.Errorf("get the profile name: %w", err)
 	}
 	o.EnvProfile = profile
 	return nil
-}
-
-func (o *deleteEnvOpts) shouldDelete(projName, envName string) (bool, error) {
-	if o.SkipConfirmation {
-		return true, nil
-	}
-
-	shouldDelete, err := o.prompt.Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, envName, projName), "")
-	if err != nil {
-		return false, fmt.Errorf("prompt for environment deletion: %w", err)
-	}
-	return shouldDelete, nil
 }
 
 // deleteStack returns true if the stack was deleted successfully. Otherwise, returns false.
@@ -272,7 +246,7 @@ func (o *deleteEnvOpts) deleteStack() bool {
 
 func (o *deleteEnvOpts) deleteFromStore() {
 	if err := o.store.DeleteEnvironment(o.AppName(), o.EnvName); err != nil {
-		log.Infof("Failed to remove environment %s from project %s store: %v\n", o.EnvName, o.AppName(), err)
+		log.Infof("Failed to remove environment %s from application %s store: %v\n", o.EnvName, o.AppName(), err)
 	}
 }
 
@@ -283,13 +257,13 @@ func BuildEnvDeleteCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Deletes an environment from your project.",
+		Short: "Deletes an environment from your application.",
 		Example: `
   Delete the "test" environment.
-  /code $ ecs-preview env delete --name test --profile default
+  /code $ copilot env delete --name test --profile default
 
   Delete the "test" environment without prompting.
-	/code $ ecs-preview env delete --name test --profile default --yes`,
+  /code $ copilot env delete --name test --profile default --yes`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newDeleteEnvOpts(vars)
 			if err != nil {

--- a/internal/pkg/cli/env_delete_test.go
+++ b/internal/pkg/cli/env_delete_test.go
@@ -21,38 +21,38 @@ import (
 
 func TestDeleteEnvOpts_Validate(t *testing.T) {
 	const (
-		testProjName = "phonetool"
-		testEnvName  = "test"
+		testAppName = "phonetool"
+		testEnvName = "test"
 	)
 	testCases := map[string]struct {
-		inProjectName string
-		inEnv         string
-		mockStore     func(ctrl *gomock.Controller) *mocks.MockenvironmentStore
+		inAppName string
+		inEnv     string
+		mockStore func(ctrl *gomock.Controller) *mocks.MockenvironmentStore
 
 		wantedError error
 	}{
 		"failed to retrieve environment from store": {
-			inProjectName: testProjName,
-			inEnv:         testEnvName,
+			inAppName: testAppName,
+			inEnv:     testEnvName,
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
 				envStore := mocks.NewMockenvironmentStore(ctrl)
-				envStore.EXPECT().GetEnvironment(testProjName, testEnvName).Return(nil, &config.ErrNoSuchEnvironment{
-					ApplicationName: testProjName,
+				envStore.EXPECT().GetEnvironment(testAppName, testEnvName).Return(nil, &config.ErrNoSuchEnvironment{
+					ApplicationName: testAppName,
 					EnvironmentName: testEnvName,
 				})
 				return envStore
 			},
 			wantedError: &config.ErrNoSuchEnvironment{
-				ApplicationName: testProjName,
+				ApplicationName: testAppName,
 				EnvironmentName: testEnvName,
 			},
 		},
 		"environment exists": {
-			inProjectName: testProjName,
-			inEnv:         testEnvName,
+			inAppName: testAppName,
+			inEnv:     testEnvName,
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
 				envStore := mocks.NewMockenvironmentStore(ctrl)
-				envStore.EXPECT().GetEnvironment(testProjName, testEnvName).Return(&config.Environment{}, nil)
+				envStore.EXPECT().GetEnvironment(testAppName, testEnvName).Return(&config.Environment{}, nil)
 				return envStore
 			},
 		},
@@ -66,7 +66,7 @@ func TestDeleteEnvOpts_Validate(t *testing.T) {
 			opts := &deleteEnvOpts{
 				deleteEnvVars: deleteEnvVars{
 					EnvName:    tc.inEnv,
-					GlobalOpts: &GlobalOpts{appName: tc.inProjectName},
+					GlobalOpts: &GlobalOpts{appName: tc.inAppName},
 				},
 				store: tc.mockStore(ctrl),
 			}
@@ -84,9 +84,8 @@ func TestDeleteEnvOpts_Validate(t *testing.T) {
 
 func TestDeleteEnvOpts_Ask(t *testing.T) {
 	const (
-		testProject  = "phonetool"
-		testEnv1     = "test"
-		testEnv2     = "prod"
+		testApp      = "phonetool"
+		testEnv      = "test"
 		testProfile1 = "default1"
 		testProfile2 = "default2"
 	)
@@ -104,107 +103,59 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 		"prompts for all required flags": {
 			inSkipConfirmation: false,
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
-				mockEnvStore := mocks.NewMockenvironmentStore(ctrl)
-				mockEnvStore.EXPECT().ListEnvironments(testProject).Return([]*config.Environment{
-					{
-						Name: testEnv1,
-					},
-					{
-						Name: testEnv2,
-					},
-				}, nil)
+				mockSelector := mocks.NewMockconfigSelector(ctrl)
+				mockSelector.EXPECT().Environment(envDeleteNamePrompt, "", testApp).Return(testEnv, nil)
 
 				mockCfg := mocks.NewMockprofileNames(ctrl)
 				mockCfg.EXPECT().Names().Return([]string{testProfile1, testProfile2})
 
 				mockPrompter := mocks.NewMockprompter(ctrl)
-				mockPrompter.EXPECT().SelectOne(envDeleteNamePrompt, "", []string{testEnv1, testEnv2}).Return(testEnv1, nil)
-				mockPrompter.EXPECT().SelectOne(fmt.Sprintf(fmtEnvDeleteProfilePrompt, color.HighlightUserInput(testEnv1)),
+				mockPrompter.EXPECT().SelectOne(fmt.Sprintf(fmtEnvDeleteProfilePrompt, color.HighlightUserInput(testEnv)),
 					envDeleteProfileHelpPrompt, []string{testProfile1, testProfile2}).Return(testProfile1, nil)
-				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv1, testProject), gomock.Any()).Return(true, nil)
+				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any()).Return(true, nil)
 
-				o.store = mockEnvStore
+				o.sel = mockSelector
 				o.profileConfig = mockCfg
 				o.GlobalOpts.prompt = mockPrompter
 			},
-			wantedEnvName:    testEnv1,
+			wantedEnvName:    testEnv,
 			wantedEnvProfile: testProfile1,
 		},
-		"skip prompting if only one environment or profile available": {
+		"skip prompting if only one profile available": {
 			inSkipConfirmation: true,
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
-				mockEnvStore := mocks.NewMockenvironmentStore(ctrl)
-				mockEnvStore.EXPECT().ListEnvironments(testProject).Return([]*config.Environment{
-					{
-						Name: testEnv1,
-					},
-				}, nil)
+				mockSelector := mocks.NewMockconfigSelector(ctrl)
+				mockSelector.EXPECT().Environment(envDeleteNamePrompt, "", testApp).Return(testEnv, nil)
 
 				mockCfg := mocks.NewMockprofileNames(ctrl)
 				mockCfg.EXPECT().Names().Return([]string{testProfile1})
 
 				mockPrompter := mocks.NewMockprompter(ctrl)
 
-				o.store = mockEnvStore
+				o.sel = mockSelector
 				o.profileConfig = mockCfg
 				o.GlobalOpts.prompt = mockPrompter
 			},
-			wantedEnvName:    testEnv1,
+			wantedEnvName:    testEnv,
 			wantedEnvProfile: testProfile1,
 		},
 		"wraps error from prompting for confirmation": {
 			inSkipConfirmation: false,
-			inEnvName:          testEnv1,
+			inEnvName:          testEnv,
 			inEnvProfile:       testProfile1,
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
 
 				mockPrompter := mocks.NewMockprompter(ctrl)
-				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv1, testProject), gomock.Any()).Return(false, errors.New("some error"))
+				mockPrompter.EXPECT().Confirm(fmt.Sprintf(fmtDeleteEnvPrompt, testEnv, testApp), gomock.Any()).Return(false, errors.New("some error"))
 
 				o.GlobalOpts.prompt = mockPrompter
 			},
 
-			wantedError: errors.New("prompt for environment deletion: some error"),
-		},
-		"wraps error from prompting for env name": {
-			inSkipConfirmation: true,
-			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
-				mockEnvStore := mocks.NewMockenvironmentStore(ctrl)
-				mockEnvStore.EXPECT().ListEnvironments(testProject).Return([]*config.Environment{
-					{
-						Name: testEnv1,
-					},
-					{
-						Name: testEnv2,
-					},
-				}, nil)
-
-				mockPrompter := mocks.NewMockprompter(ctrl)
-				mockPrompter.EXPECT().SelectOne(envDeleteNamePrompt, "", gomock.Any()).Return("", errors.New("some error"))
-
-				o.store = mockEnvStore
-				o.GlobalOpts.prompt = mockPrompter
-			},
-
-			wantedError: errors.New("prompt for environment name: some error"),
-		},
-		"wraps error if no environment found": {
-			inSkipConfirmation: true,
-			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
-				mockEnvStore := mocks.NewMockenvironmentStore(ctrl)
-				mockEnvStore.EXPECT().ListEnvironments(testProject).Return([]*config.Environment{}, nil)
-
-				mockPrompter := mocks.NewMockprompter(ctrl)
-
-				o.store = mockEnvStore
-				o.GlobalOpts.prompt = mockPrompter
-			},
-
-			wantedError: errors.New("couldn't find any environment in the project phonetool"),
+			wantedError: errors.New("confirm to delete environment test: some error"),
 		},
 		"wraps error from prompting from profile": {
 			inSkipConfirmation: true,
-			inEnvName:          testEnv1,
+			inEnvName:          testEnv,
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
 				mockCfg := mocks.NewMockprofileNames(ctrl)
 				mockCfg.EXPECT().Names().Return([]string{testProfile1, testProfile2})
@@ -216,11 +167,11 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 				o.GlobalOpts.prompt = mockPrompter
 			},
 
-			wantedError: errors.New("prompt to get the profile name: some error"),
+			wantedError: errors.New("get the profile name: some error"),
 		},
 		"errors when no named profile exists": {
 			inSkipConfirmation: true,
-			inEnvName:          testEnv1,
+			inEnvName:          testEnv,
 			mockDependencies: func(ctrl *gomock.Controller, o *deleteEnvOpts) {
 				mockCfg := mocks.NewMockprofileNames(ctrl)
 				mockCfg.EXPECT().Names().Return([]string{})
@@ -242,7 +193,7 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 					EnvName:    tc.inEnvName,
 					EnvProfile: tc.inEnvProfile,
 					GlobalOpts: &GlobalOpts{
-						appName: testProject,
+						appName: testApp,
 					},
 					SkipConfirmation: tc.inSkipConfirmation,
 				},
@@ -266,8 +217,8 @@ func TestDeleteEnvOpts_Ask(t *testing.T) {
 
 func TestDeleteEnvOpts_Execute(t *testing.T) {
 	const (
-		testProject = "phonetool"
-		testEnv     = "test"
+		testApp = "phonetool"
+		testEnv = "test"
 	)
 	testError := errors.New("some error")
 
@@ -294,7 +245,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
 				return nil
 			},
-			wantedError: errors.New("find application cloudformation stacks: some error"),
+			wantedError: errors.New("find service cloudformation stacks: some error"),
 		},
 		"environment has running applications": {
 			mockRG: func(ctrl *gomock.Controller) *mocks.MockresourceGetter {
@@ -326,7 +277,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
 				return nil
 			},
-			wantedError: errors.New("applications: 'frontend, backend' still exist within the environment test"),
+			wantedError: errors.New("service 'frontend, backend' still exist within the environment test"),
 		},
 		"error from delete stack": {
 			mockRG: func(ctrl *gomock.Controller) *mocks.MockresourceGetter {
@@ -337,13 +288,13 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 			},
 			mockProg: func(ctrl *gomock.Controller) *mocks.Mockprogress {
 				prog := mocks.NewMockprogress(ctrl)
-				prog.EXPECT().Start(fmt.Sprintf(fmtDeleteEnvStart, testEnv, testProject))
-				prog.EXPECT().Stop(log.Serrorf(fmtDeleteEnvFailed, testEnv, testProject, testError))
+				prog.EXPECT().Start(fmt.Sprintf(fmtDeleteEnvStart, testEnv, testApp))
+				prog.EXPECT().Stop(log.Serrorf(fmtDeleteEnvFailed, testEnv, testApp, testError))
 				return prog
 			},
 			mockDeploy: func(ctrl *gomock.Controller) *mocks.MockenvironmentDeployer {
 				deploy := mocks.NewMockenvironmentDeployer(ctrl)
-				deploy.EXPECT().DeleteEnvironment(testProject, testEnv).Return(testError)
+				deploy.EXPECT().DeleteEnvironment(testApp, testEnv).Return(testError)
 				return deploy
 			},
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
@@ -359,18 +310,18 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 			},
 			mockProg: func(ctrl *gomock.Controller) *mocks.Mockprogress {
 				prog := mocks.NewMockprogress(ctrl)
-				prog.EXPECT().Start(fmt.Sprintf(fmtDeleteEnvStart, testEnv, testProject))
-				prog.EXPECT().Stop(log.Ssuccessf(fmtDeleteEnvComplete, testEnv, testProject))
+				prog.EXPECT().Start(fmt.Sprintf(fmtDeleteEnvStart, testEnv, testApp))
+				prog.EXPECT().Stop(log.Ssuccessf(fmtDeleteEnvComplete, testEnv, testApp))
 				return prog
 			},
 			mockDeploy: func(ctrl *gomock.Controller) *mocks.MockenvironmentDeployer {
 				deploy := mocks.NewMockenvironmentDeployer(ctrl)
-				deploy.EXPECT().DeleteEnvironment(testProject, testEnv).Return(nil)
+				deploy.EXPECT().DeleteEnvironment(testApp, testEnv).Return(nil)
 				return deploy
 			},
 			mockStore: func(ctrl *gomock.Controller) *mocks.MockenvironmentStore {
 				store := mocks.NewMockenvironmentStore(ctrl)
-				store.EXPECT().DeleteEnvironment(testProject, testEnv).Return(nil)
+				store.EXPECT().DeleteEnvironment(testApp, testEnv).Return(nil)
 				return store
 			},
 		},
@@ -385,7 +336,7 @@ func TestDeleteEnvOpts_Execute(t *testing.T) {
 				deleteEnvVars: deleteEnvVars{
 					EnvName: testEnv,
 					GlobalOpts: &GlobalOpts{
-						appName: testProject,
+						appName: testApp,
 					},
 				},
 				store:        tc.mockStore(ctrl),

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -22,26 +22,26 @@ import (
 
 func TestInitEnvOpts_Validate(t *testing.T) {
 	testCases := map[string]struct {
-		inEnvName     string
-		inProjectName string
+		inEnvName string
+		inAppName string
 
 		wantedErr string
 	}{
 		"valid environment creation": {
-			inEnvName:     "test-pdx",
-			inProjectName: "phonetool",
+			inEnvName: "test-pdx",
+			inAppName: "phonetool",
 		},
 		"invalid environment name": {
-			inEnvName:     "123env",
-			inProjectName: "phonetool",
+			inEnvName: "123env",
+			inAppName: "phonetool",
 
 			wantedErr: fmt.Sprintf("environment name 123env is invalid: %s", errValueBadFormat),
 		},
 		"new workspace": {
-			inEnvName:     "test-pdx",
-			inProjectName: "",
+			inEnvName: "test-pdx",
+			inAppName: "",
 
-			wantedErr: "no project found: run `project init` or `cd` into your workspace please",
+			wantedErr: "no application found: run `app init` or `cd` into your workspace please",
 		},
 	}
 
@@ -51,7 +51,7 @@ func TestInitEnvOpts_Validate(t *testing.T) {
 			opts := &initEnvOpts{
 				initEnvVars: initEnvVars{
 					EnvName:    tc.inEnvName,
-					GlobalOpts: &GlobalOpts{appName: tc.inProjectName},
+					GlobalOpts: &GlobalOpts{appName: tc.inAppName},
 				},
 			}
 
@@ -76,7 +76,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 	testCases := map[string]struct {
 		inputEnv     string
 		inputProfile string
-		inputProject string
+		inputApp     string
 
 		setupMocks func(*mocks.Mockprompter, *mocks.MockprofileNames)
 
@@ -127,7 +127,7 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 					EnvProfile: tc.inputProfile,
 					GlobalOpts: &GlobalOpts{
 						prompt:  mockPrompter,
-						appName: tc.inputProject,
+						appName: tc.inputApp,
 					},
 				},
 				profileConfig: mockCfg,
@@ -150,9 +150,9 @@ func TestInitEnvOpts_Ask(t *testing.T) {
 
 func TestInitEnvOpts_Execute(t *testing.T) {
 	testCases := map[string]struct {
-		inProjectName string
-		inEnvName     string
-		inProd        bool
+		inAppName string
+		inEnvName string
+		inProd    bool
 
 		expectstore    func(m *mocks.Mockstore)
 		expectDeployer func(m *mocks.Mockdeployer)
@@ -161,9 +161,9 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 
 		wantedErrorS string
 	}{
-		"returns project exists error": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+		"returns app exists error": {
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(nil, errors.New("some error"))
@@ -172,8 +172,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "some error",
 		},
 		"returns identity get error": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -184,8 +184,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "get identity: some identity error",
 		},
 		"errors if environment change set cannot be accepted": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -203,8 +203,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "some deploy error",
 		},
 		"streams failed events": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -251,8 +251,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "some stream error",
 		},
 		"failed to get environment stack": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().CreateEnvironment(gomock.Any()).Times(0)
@@ -288,8 +288,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "get environment struct for test: some error",
 		},
 		"failed to create stack set instance": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().CreateEnvironment(gomock.Any()).Times(0)
@@ -302,8 +302,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
 				m.EXPECT().Start(fmt.Sprintf(fmtStreamEnvStart, "test"))
 				m.EXPECT().Stop(log.Ssuccessf(fmtStreamEnvComplete, "test"))
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToProjectStart, "1234", "mars-1", "phonetool"))
-				m.EXPECT().Stop(log.Serrorf(fmtAddEnvToProjectFailed, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Stop(log.Serrorf(fmtAddEnvToAppFailed, "1234", "mars-1", "phonetool"))
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DeployEnvironment(gomock.Any()).Return(nil)
@@ -330,11 +330,11 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				}, nil)
 				m.EXPECT().AddEnvToApp(&config.Application{Name: "phonetool"}, env).Return(errors.New("some cfn error"))
 			},
-			wantedErrorS: "deploy env test to project phonetool: some cfn error",
+			wantedErrorS: "deploy env test to application phonetool: some cfn error",
 		},
 		"returns error from CreateEnvironment": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{
@@ -354,8 +354,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
 				m.EXPECT().Start(fmt.Sprintf(fmtStreamEnvStart, "test"))
 				m.EXPECT().Stop(log.Ssuccessf(fmtStreamEnvComplete, "test"))
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToProjectStart, "1234", "mars-1", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToProjectComplete, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "mars-1", "phonetool"))
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DeployEnvironment(gomock.Any()).Return(nil)
@@ -384,9 +384,9 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			wantedErrorS: "store environment: some create error",
 		},
 		"success": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
-			inProd:        true,
+			inAppName: "phonetool",
+			inEnvName: "test",
+			inProd:    true,
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -405,8 +405,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
 				m.EXPECT().Start(fmt.Sprintf(fmtStreamEnvStart, "test"))
 				m.EXPECT().Stop(log.Ssuccessf(fmtStreamEnvComplete, "test"))
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToProjectStart, "1234", "mars-1", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToProjectComplete, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "mars-1", "phonetool"))
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DeployEnvironment(gomock.Any()).Return(nil)
@@ -436,8 +436,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 		},
 		"skips creating stack if environment stack already exists": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool"}, nil)
@@ -454,8 +454,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			expectProgress: func(m *mocks.Mockprogress) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
 				m.EXPECT().Stop("")
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToProjectStart, "1234", "mars-1", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToProjectComplete, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "mars-1", "phonetool"))
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DeployEnvironment(&deploy.CreateEnvironmentInput{
@@ -473,9 +473,9 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().AddEnvToApp(gomock.Any(), gomock.Any()).Return(nil)
 			},
 		},
-		"failed to delegate DNS (project has Domain and env and project are different)": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+		"failed to delegate DNS (app has Domain and env and apps are different)": {
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
@@ -492,9 +492,9 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 			wantedErrorS: "granting DNS permissions: some error",
 		},
-		"success with DNS Delegation (project has Domain and env and project are different)": {
-			inProjectName: "phonetool",
-			inEnvName:     "test",
+		"success with DNS Delegation (app has Domain and env and app are different)": {
+			inAppName: "phonetool",
+			inEnvName: "test",
 
 			expectstore: func(m *mocks.Mockstore) {
 				m.EXPECT().GetApplication("phonetool").Return(&config.Application{Name: "phonetool", AccountID: "1234", Domain: "amazon.com"}, nil)
@@ -514,8 +514,8 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
 				m.EXPECT().Start(fmt.Sprintf(fmtStreamEnvStart, "test"))
 				m.EXPECT().Stop(log.Ssuccessf(fmtStreamEnvComplete, "test"))
-				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToProjectStart, "1234", "mars-1", "phonetool"))
-				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToProjectComplete, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
+				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "mars-1", "phonetool"))
 			},
 			expectDeployer: func(m *mocks.Mockdeployer) {
 				m.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(nil)
@@ -571,15 +571,15 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			opts := &initEnvOpts{
 				initEnvVars: initEnvVars{
 					EnvName:      tc.inEnvName,
-					GlobalOpts:   &GlobalOpts{appName: tc.inProjectName},
+					GlobalOpts:   &GlobalOpts{appName: tc.inAppName},
 					IsProduction: tc.inProd,
 				},
-				store:        mockstore,
-				envDeployer:  mockDeployer,
-				projDeployer: mockDeployer,
-				identity:     mockIdentity,
-				envIdentity:  mockIdentity,
-				prog:         mockProgress,
+				store:       mockstore,
+				envDeployer: mockDeployer,
+				appDeployer: mockDeployer,
+				identity:    mockIdentity,
+				envIdentity: mockIdentity,
+				prog:        mockProgress,
 				initProfileClients: func(o *initEnvOpts) error {
 					return nil
 				},
@@ -598,18 +598,18 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 	}
 }
 
-func TestInitEnvOpts_delegateDNSFromProject(t *testing.T) {
+func TestInitEnvOpts_delegateDNSFromApp(t *testing.T) {
 	testCases := map[string]struct {
-		project        *config.Application
+		app            *config.Application
 		expectDeployer func(m *mocks.Mockdeployer)
 		expectIdentity func(m *mocks.MockidentityService)
 		expectProgress func(m *mocks.Mockprogress)
 		wantedErr      string
 	}{
-		"should call DelegateDNSPermissions when project and env are in different accounts": {
-			project: &config.Application{
+		"should call DelegateDNSPermissions when app and env are in different accounts": {
+			app: &config.Application{
 				AccountID: "1234",
-				Name:      "crossaccountproject",
+				Name:      "crossaccountapp",
 				Domain:    "amazon.com",
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -623,10 +623,10 @@ func TestInitEnvOpts_delegateDNSFromProject(t *testing.T) {
 				m.EXPECT().DelegateDNSPermissions(gomock.Any(), "4567").Return(nil)
 			},
 		},
-		"should skip updating when project and env are in same account": {
-			project: &config.Application{
+		"should skip updating when app and env are in same account": {
+			app: &config.Application{
 				AccountID: "1234",
-				Name:      "crossaccountproject",
+				Name:      "crossaccountapp",
 				Domain:    "amazon.com",
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -640,9 +640,9 @@ func TestInitEnvOpts_delegateDNSFromProject(t *testing.T) {
 			},
 		},
 		"should return errors from identity": {
-			project: &config.Application{
+			app: &config.Application{
 				AccountID: "1234",
-				Name:      "crossaccountproject",
+				Name:      "crossaccountapp",
 				Domain:    "amazon.com",
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -657,9 +657,9 @@ func TestInitEnvOpts_delegateDNSFromProject(t *testing.T) {
 			wantedErr: "getting environment account ID for DNS Delegation: error",
 		},
 		"should return errors from DelegateDNSPermissions": {
-			project: &config.Application{
+			app: &config.Application{
 				AccountID: "1234",
-				Name:      "crossaccountproject",
+				Name:      "crossaccountapp",
 				Domain:    "amazon.com",
 			},
 			expectIdentity: func(m *mocks.MockidentityService) {
@@ -697,15 +697,15 @@ func TestInitEnvOpts_delegateDNSFromProject(t *testing.T) {
 			}
 			opts := &initEnvOpts{
 				initEnvVars: initEnvVars{
-					GlobalOpts: &GlobalOpts{appName: tc.project.Name},
+					GlobalOpts: &GlobalOpts{appName: tc.app.Name},
 				},
-				envIdentity:  mockIdentity,
-				projDeployer: mockDeployer,
-				prog:         mockProgress,
+				envIdentity: mockIdentity,
+				appDeployer: mockDeployer,
+				prog:        mockProgress,
 			}
 
 			// WHEN
-			err := opts.delegateDNSFromProject(tc.project)
+			err := opts.delegateDNSFromApp(tc.app)
 
 			// THEN
 			if tc.wantedErr != "" {

--- a/internal/pkg/cli/env_list.go
+++ b/internal/pkg/cli/env_list.go
@@ -10,15 +10,15 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/selector"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
-	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
-	"github.com/fatih/color"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/spf13/cobra"
 )
 
 const (
-	environmentListProjectNamePrompt = "Which project's environments would you like to list?"
-	environmentListProjectNameHelper = "A project groups all of your environments together."
+	envListAppNamePrompt = "Which application is the environment in?"
+	envListAppNameHelper = "An application is a collection of related services."
 )
 
 type listEnvVars struct {
@@ -28,44 +28,32 @@ type listEnvVars struct {
 
 type listEnvOpts struct {
 	listEnvVars
-
 	store store
+	sel   configSelector
 
 	w io.Writer
 }
 
 func newListEnvOpts(vars listEnvVars) (*listEnvOpts, error) {
-	ssmStore, err := config.NewStore()
+	store, err := config.NewStore()
 	if err != nil {
 		return nil, err
 	}
 
 	return &listEnvOpts{
 		listEnvVars: vars,
-		store:       ssmStore,
+		store:       store,
+		sel:         selector.NewConfigSelect(vars.prompt, store),
 		w:           os.Stdout,
 	}, nil
 }
 
-func (o *listEnvOpts) selectProject() (string, error) {
-	projs, err := o.store.ListApplications()
-	if err != nil {
-		return "", err
+// Validate returns an error if the values passed by flags are invalid.
+func (o *listEnvOpts) Validate() error {
+	if o.AppName() == "" {
+		return fmt.Errorf("no application found: run %s or %s into your workspace please", color.HighlightCode("app init"), color.HighlightCode("cd"))
 	}
-	var projStrs []string
-	for _, projStr := range projs {
-		projStrs = append(projStrs, projStr.Name)
-	}
-	if len(projStrs) == 0 {
-		log.Infoln("There are no projects to select.")
-		return "", nil
-	}
-	proj, err := o.prompt.SelectOne(
-		environmentListProjectNamePrompt,
-		environmentListProjectNameHelper,
-		projStrs,
-	)
-	return proj, err
+	return nil
 }
 
 // Ask asks for fields that are required but not passed in.
@@ -73,18 +61,17 @@ func (o *listEnvOpts) Ask() error {
 	if o.AppName() != "" {
 		return nil
 	}
-	projectName, err := o.selectProject()
+	app, err := o.sel.Application(envListAppNamePrompt, envListAppNameHelper)
 	if err != nil {
-		return fmt.Errorf("failed to get project name: %w", err)
+		return fmt.Errorf("select application: %w", err)
 	}
-	o.appName = projectName
-
+	o.appName = app
 	return nil
 }
 
 // Execute lists the environments through the prompt.
 func (o *listEnvOpts) Execute() error {
-	// Ensure the project actually exists before we try to list its environments.
+	// Ensure the application actually exists before we try to list its environments.
 	if _, err := o.store.GetApplication(o.AppName()); err != nil {
 		return err
 	}
@@ -111,10 +98,9 @@ func (o *listEnvOpts) Execute() error {
 
 func (o *listEnvOpts) humanOutput(envs []*config.Environment) string {
 	b := &strings.Builder{}
-	prodColor := color.New(color.FgYellow, color.Bold).SprintFunc()
 	for _, env := range envs {
 		if env.Prod {
-			fmt.Fprintf(b, "%s (prod)\n", prodColor(env.Name))
+			fmt.Fprintf(b, "%s (prod)\n", color.ProdColor(env.Name))
 		} else {
 			fmt.Fprintln(b, env.Name)
 		}
@@ -133,20 +119,23 @@ func (o *listEnvOpts) jsonOutput(envs []*config.Environment) (string, error) {
 	return fmt.Sprintf("%s\n", b), nil
 }
 
-// BuildEnvListCmd builds the command for listing environments in a project.
+// BuildEnvListCmd builds the command for listing environments in an application.
 func BuildEnvListCmd() *cobra.Command {
 	vars := listEnvVars{
 		GlobalOpts: NewGlobalOpts(),
 	}
 	cmd := &cobra.Command{
 		Use:   "ls",
-		Short: "Lists all the environments in a project",
+		Short: "Lists all the environments in an application",
 		Example: `
-  Lists all the environments for the test project
-  /code $ ecs-preview env ls --project test`,
+  Lists all the environments for the frontend application
+  /code $ copilot env ls -a frontend`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newListEnvOpts(vars)
 			if err != nil {
+				return err
+			}
+			if err := opts.Validate(); err != nil {
 				return err
 			}
 			if err := opts.Ask(); err != nil {

--- a/internal/pkg/cli/env_list.go
+++ b/internal/pkg/cli/env_list.go
@@ -100,7 +100,7 @@ func (o *listEnvOpts) humanOutput(envs []*config.Environment) string {
 	b := &strings.Builder{}
 	for _, env := range envs {
 		if env.Prod {
-			fmt.Fprintf(b, "%s (prod)\n", color.ProdColor(env.Name))
+			fmt.Fprintf(b, "%s (prod)\n", color.Prod(env.Name))
 		} else {
 			fmt.Fprintln(b, env.Name)
 		}
@@ -126,9 +126,9 @@ func BuildEnvListCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "ls",
-		Short: "Lists all the environments in an application",
+		Short: "Lists all the environments in an application.",
 		Example: `
-  Lists all the environments for the frontend application
+  Lists all the environments for the frontend application.
   /code $ copilot env ls -a frontend`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newListEnvOpts(vars)

--- a/internal/pkg/cli/env_show.go
+++ b/internal/pkg/cli/env_show.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/cli/selector"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/describe"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
@@ -15,10 +16,10 @@ import (
 )
 
 const (
-	environmentShowProjectNamePrompt     = "Which project's environments would you like to show?"
-	environmentShowProjectNameHelpPrompt = "A project groups all of your applications together."
-	fmtEnvironmentShowEnvNamePrompt      = "Which environment of %s would you like to show?"
-	environmentShowEnvNameHelpPrompt     = "The detail of an environment will be shown (e.g., region, account ID, apps)."
+	envShowAppNamePrompt     = "Which application is the environment in?"
+	envShowAppNameHelpPrompt = "An application is a collection of related services."
+	envShowNamePrompt        = "Which environment of %s would you like to show?"
+	envShowHelpPrompt        = "The detail of an environment will be shown (e.g., region, account ID, services)."
 )
 
 type showEnvVars struct {
@@ -34,23 +35,25 @@ type showEnvOpts struct {
 	w                io.Writer
 	store            store
 	describer        envDescriber
+	sel              configSelector
 	initEnvDescriber func(*showEnvOpts) error
 }
 
 func newShowEnvOpts(vars showEnvVars) (*showEnvOpts, error) {
-	ssmStore, err := config.NewStore()
+	store, err := config.NewStore()
 	if err != nil {
-		return nil, fmt.Errorf("connect to environment datastore: %w", err)
+		return nil, fmt.Errorf("connect to copilot config store: %w", err)
 	}
 
 	return &showEnvOpts{
 		showEnvVars: vars,
-		store:       ssmStore,
+		store:       store,
 		w:           log.OutputWriter,
+		sel:         selector.NewConfigSelect(vars.prompt, store),
 		initEnvDescriber: func(o *showEnvOpts) error {
 			d, err := describe.NewEnvDescriber(o.AppName(), o.envName)
 			if err != nil {
-				return fmt.Errorf("creating describer for environment %s in project %s: %w", o.envName, o.AppName(), err)
+				return fmt.Errorf("creating describer for environment %s in application %s: %w", o.envName, o.AppName(), err)
 			}
 			o.describer = d
 			return nil
@@ -76,7 +79,7 @@ func (o *showEnvOpts) Validate() error {
 
 // Ask asks for fields that are required but not passed in.
 func (o *showEnvOpts) Ask() error {
-	if err := o.askProject(); err != nil {
+	if err := o.askApp(); err != nil {
 		return err
 	}
 	return o.askEnvName()
@@ -104,31 +107,15 @@ func (o *showEnvOpts) Execute() error {
 	return nil
 }
 
-func (o *showEnvOpts) askProject() error {
+func (o *showEnvOpts) askApp() error {
 	if o.AppName() != "" {
 		return nil
 	}
-	projNames, err := o.retrieveProjects()
+	app, err := o.sel.Application(envShowAppNamePrompt, envShowAppNameHelpPrompt)
 	if err != nil {
-		return err
+		return fmt.Errorf("select application: %w", err)
 	}
-	if len(projNames) == 0 {
-		return fmt.Errorf("no project found: run %s please", color.HighlightCode("project init"))
-	}
-	if len(projNames) == 1 {
-		o.appName = projNames[0]
-		return nil
-	}
-	proj, err := o.prompt.SelectOne(
-		environmentShowProjectNamePrompt,
-		environmentShowProjectNameHelpPrompt,
-		projNames,
-	)
-	if err != nil {
-		return fmt.Errorf("select projects: %w", err)
-	}
-	o.appName = proj
-
+	o.appName = app
 	return nil
 }
 
@@ -137,57 +124,16 @@ func (o *showEnvOpts) askEnvName() error {
 	if o.envName != "" {
 		return nil
 	}
-
-	envNames, err := o.retrieveAllEnvironments()
+	env, err := o.sel.Environment(fmt.Sprintf(envShowNamePrompt, color.HighlightUserInput(o.AppName())), envShowHelpPrompt, o.AppName())
 	if err != nil {
-		return err
+		return fmt.Errorf("select environment for application %s: %w", o.AppName(), err)
 	}
-
-	if len(envNames) == 0 {
-		log.Infof("No environments found in project %s\n.", color.HighlightUserInput(o.AppName()))
-		return nil
-	}
-	if len(envNames) == 1 {
-		o.envName = envNames[0]
-		return nil
-	}
-	envName, err := o.prompt.SelectOne(
-		fmt.Sprintf(fmtEnvironmentShowEnvNamePrompt, color.HighlightUserInput(o.AppName())), environmentShowEnvNameHelpPrompt, envNames,
-	)
-	if err != nil {
-		return fmt.Errorf("select environment for project %s: %w", o.AppName(), err)
-	}
-	o.envName = envName
+	o.envName = env
 
 	return nil
 }
 
-func (o *showEnvOpts) retrieveProjects() ([]string, error) {
-	projs, err := o.store.ListApplications()
-	if err != nil {
-		return nil, fmt.Errorf("list projects: %w", err)
-	}
-	projNames := make([]string, len(projs))
-	for ind, proj := range projs {
-		projNames[ind] = proj.Name
-	}
-	return projNames, nil
-}
-
-func (o *showEnvOpts) retrieveAllEnvironments() ([]string, error) {
-	envs, err := o.store.ListEnvironments(o.AppName())
-	if err != nil {
-		return nil, fmt.Errorf("list environments for project %s: %w", o.AppName(), err)
-	}
-	envNames := make([]string, len(envs))
-	for ind, env := range envs {
-		envNames[ind] = env.Name
-	}
-
-	return envNames, nil
-}
-
-// BuildEnvShowCmd builds the command for showing environments in a project.
+// BuildEnvShowCmd builds the command for showing environments in an application.
 func BuildEnvShowCmd() *cobra.Command {
 	vars := showEnvVars{
 		GlobalOpts: NewGlobalOpts(),
@@ -196,7 +142,7 @@ func BuildEnvShowCmd() *cobra.Command {
 		Hidden: true, //TODO remove when ready for production!
 		Use:    "show",
 		Short:  "Shows info about a deployed environment.",
-		Long:   "Shows info about a deployed environment, including region, account ID, and apps.",
+		Long:   "Shows info about a deployed environment, including region, account ID, and services.",
 
 		Example: `
   Shows info about the environment "test"
@@ -219,6 +165,5 @@ func BuildEnvShowCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&vars.envName, nameFlag, nameFlagShort, "", envFlagDescription)
 	cmd.Flags().BoolVar(&vars.shouldOutputJSON, jsonFlag, false, jsonFlagDescription)
 	cmd.Flags().BoolVar(&vars.shouldOutputResources, resourcesFlag, false, envResourcesFlagDescription)
-	cmd.Flags().StringVarP(&vars.appName, appFlag, appFlagShort, "", appFlagDescription)
 	return cmd
 }

--- a/internal/pkg/cli/env_show.go
+++ b/internal/pkg/cli/env_show.go
@@ -145,7 +145,7 @@ func BuildEnvShowCmd() *cobra.Command {
 		Long:   "Shows info about a deployed environment, including region, account ID, and services.",
 
 		Example: `
-  Shows info about the environment "test"
+  Shows info about the environment "test".
   /code $ ecs-preview env show -n test`,
 		RunE: runCmdE(func(cmd *cobra.Command, args []string) error {
 			opts, err := newShowEnvOpts(vars)

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -130,7 +130,7 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 			IsProduction: false,
 		},
 		store:         ssm,
-		projDeployer:  deployer,
+		appDeployer:   deployer,
 		profileConfig: cfg,
 		prog:          spin,
 		identity:      id,

--- a/internal/pkg/term/color/color.go
+++ b/internal/pkg/term/color/color.go
@@ -16,14 +16,15 @@ import (
 // Refer to https://en.wikipedia.org/wiki/ANSI_escape_code to validate if colors would
 // be visible on white or black screen backgrounds.
 var (
-	Grey       = color.New(color.FgWhite)
-	Red        = color.New(color.FgHiRed)
-	Green      = color.New(color.FgHiGreen)
-	Yellow     = color.New(color.FgHiYellow)
-	Cyan       = color.New(color.FgCyan)
-	HiCyan     = color.New(color.FgHiCyan)
-	Bold       = color.New(color.Bold)
-	BoldItalic = color.New(color.Bold).Add(color.Italic)
+	Grey         = color.New(color.FgWhite)
+	Red          = color.New(color.FgHiRed)
+	Green        = color.New(color.FgHiGreen)
+	Yellow       = color.New(color.FgHiYellow)
+	Cyan         = color.New(color.FgCyan)
+	HiCyan       = color.New(color.FgHiCyan)
+	Bold         = color.New(color.Bold)
+	BoldItalic   = color.New(color.Bold).Add(color.Italic)
+	BoldFgYellow = color.New(color.FgYellow).Add(color.Bold)
 )
 
 const colorEnvVar = "COLOR"
@@ -70,4 +71,9 @@ func HighlightResource(s string) string {
 // HighlightCode wraps the string with the ` character, colors it to denote it's a code block, and returns it.
 func HighlightCode(s string) string {
 	return HiCyan.Sprintf("`%s`", s)
+}
+
+// ProdColor colors the string to mark it is a prod environment.
+func ProdColor(s string) string {
+	return BoldFgYellow.Sprint(s)
 }

--- a/internal/pkg/term/color/color.go
+++ b/internal/pkg/term/color/color.go
@@ -73,7 +73,7 @@ func HighlightCode(s string) string {
 	return HiCyan.Sprintf("`%s`", s)
 }
 
-// ProdColor colors the string to mark it is a prod environment.
-func ProdColor(s string) string {
+// Prod colors the string to mark it is a prod environment.
+func Prod(s string) string {
 	return BoldFgYellow.Sprint(s)
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->
Copilot renaming for env subcommands including
- `env delete`
- `env init`
- `env list`
- `env show`
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
