### PR TITLE
chore: rename JSON field to "app" from "App" for a service

### DIFF
--- a/internal/pkg/cli/app_show_test.go
+++ b/internal/pkg/cli/app_show_test.go
@@ -200,7 +200,7 @@ func TestShowAppOpts_Execute(t *testing.T) {
 				}, nil)
 			},
 
-			wantedContent: "{\"name\":\"my-app\",\"uri\":\"example.com\",\"environments\":[{\"app\":\"\",\"name\":\"test\",\"region\":\"us-west-2\",\"accountID\":\"123456789\",\"prod\":false,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"},{\"app\":\"\",\"name\":\"prod\",\"region\":\"us-west-1\",\"accountID\":\"123456789\",\"prod\":true,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"}],\"services\":[{\"App\":\"\",\"name\":\"my-svc\",\"type\":\"lb-web-svc\"}]}\n",
+			wantedContent: "{\"name\":\"my-app\",\"uri\":\"example.com\",\"environments\":[{\"app\":\"\",\"name\":\"test\",\"region\":\"us-west-2\",\"accountID\":\"123456789\",\"prod\":false,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"},{\"app\":\"\",\"name\":\"prod\",\"region\":\"us-west-1\",\"accountID\":\"123456789\",\"prod\":true,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"}],\"services\":[{\"app\":\"\",\"name\":\"my-svc\",\"type\":\"lb-web-svc\"}]}\n",
 		},
 		"correctly shows human output": {
 			setupMocks: func(m showAppMocks) {

--- a/internal/pkg/cli/env_show_test.go
+++ b/internal/pkg/cli/env_show_test.go
@@ -250,7 +250,7 @@ func TestEnvShow_Execute(t *testing.T) {
 					m.EXPECT().Describe().Return(mockEnv, nil))
 			},
 
-			wantedContent: "{\"environment\":{\"app\":\"my-app\",\"name\":\"test\",\"region\":\"us-west-2\",\"accountID\":\"123456789\",\"prod\":false,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"},\"services\":[{\"App\":\"my-app\",\"name\":\"my-svc\",\"type\":\"lb-web-svc\"},{\"App\":\"my-app\",\"name\":\"copilot-svc\",\"type\":\"lb-web-svc\"}],\"tags\":{\"tag1\":\"value1\",\"tag2\":\"value2\"}}\n",
+			wantedContent: "{\"environment\":{\"app\":\"my-app\",\"name\":\"test\",\"region\":\"us-west-2\",\"accountID\":\"123456789\",\"prod\":false,\"registryURL\":\"\",\"executionRoleARN\":\"\",\"managerRoleARN\":\"\"},\"services\":[{\"app\":\"my-app\",\"name\":\"my-svc\",\"type\":\"lb-web-svc\"},{\"app\":\"my-app\",\"name\":\"copilot-svc\",\"type\":\"lb-web-svc\"}],\"tags\":{\"tag1\":\"value1\",\"tag2\":\"value2\"}}\n",
 		},
 		"correctly shows human output": {
 			inputEnv:         "test",

--- a/internal/pkg/cli/svc_list_test.go
+++ b/internal/pkg/cli/svc_list_test.go
@@ -49,7 +49,7 @@ func TestListSvcOpts_Execute(t *testing.T) {
 						{Name: "lb-svc"},
 					}, nil)
 			},
-			expectedContent: "{\"services\":[{\"App\":\"\",\"name\":\"my-svc\",\"type\":\"\"},{\"App\":\"\",\"name\":\"lb-svc\",\"type\":\"\"}]}\n",
+			expectedContent: "{\"services\":[{\"app\":\"\",\"name\":\"my-svc\",\"type\":\"\"},{\"app\":\"\",\"name\":\"lb-svc\",\"type\":\"\"}]}\n",
 		},
 		"with human outputs": {
 			opts: listSvcOpts{

--- a/internal/pkg/config/service.go
+++ b/internal/pkg/config/service.go
@@ -27,7 +27,7 @@ const (
 
 // Service represents a deployable long running service or task.
 type Service struct {
-	App  string `json:"App"`  // Name of the app this service belongs to.
+	App  string `json:"app"`  // Name of the app this service belongs to.
 	Name string `json:"name"` // Name of the service, which must be unique within a app.
 	Type string `json:"type"` // Type of the service (ex: Load Balanced Web Server, etc)
 }


### PR DESCRIPTION
The field starts with a capital letter right now, which is unlike any other fields in our configurations.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
