### PR TITLE
fix: add build tag to description.go to make it work on windows

### DIFF
--- a/cmd/copilot/description.go
+++ b/cmd/copilot/description.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
The same constant is defined in `description_windows.go` which results in the error when building the windows binary:
```
cmd/copilot/description_windows.go:7:2: shortDescription redeclared in this block
        previous declaration at cmd/copilot/description.go:7:21
make: *** [compile-windows] Error 2
```
By adding a build tag to `description.go` saying that it should be used for all platforms except windows, the cli builds.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
