### PR TITLE
fix: has secrets was returning true when there were 0 secrets

### DIFF
--- a/internal/pkg/template/service.go
+++ b/internal/pkg/template/service.go
@@ -100,7 +100,7 @@ func toSnakeCase(s string) string {
 }
 
 func hasSecrets(opts ServiceOpts) bool {
-	if opts.Secrets != nil {
+	if len(opts.Secrets) > 0 {
 		return true
 	}
 	if opts.NestedStack != nil && (len(opts.NestedStack.SecretOutputs) > 0) {

--- a/internal/pkg/template/service_test.go
+++ b/internal/pkg/template/service_test.go
@@ -101,8 +101,14 @@ func TestHasSecrets(t *testing.T) {
 		in     ServiceOpts
 		wanted bool
 	}{
-		"no secrets": {
+		"nil secrets": {
 			in:     ServiceOpts{},
+			wanted: false,
+		},
+		"no secrets": {
+			in: ServiceOpts{
+				Secrets: map[string]string{},
+			},
 			wanted: false,
 		},
 		"service has secrets": {


### PR DESCRIPTION
This fix addresses an issue where sometimes secrets is nil and
sometimes it is an empty map. When there are overrides present,
secrets is not nil. This change checks to see if the *length* of
secrets is not 0.

Fixes #963

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
