### PR TITLE
fix(manifest): BackendService port and healthcheck override issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/mock v1.4.3
 	github.com/google/uuid v1.1.1
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-	github.com/imdario/mergo v0.3.9 // indirect
+	github.com/imdario/mergo v0.3.9
 	github.com/karrick/godirwalk v1.15.6 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/mapstructure v1.3.0 // indirect

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/manifest"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -638,10 +639,10 @@ func TestAppInitOpts_createLoadBalancedAppManifest(t *testing.T) {
 			// THEN
 			if tc.wantedErr == nil {
 				require.Nil(t, err)
-				require.Equal(t, tc.inSvcName, manifest.Service.Name)
-				require.Equal(t, tc.inSvcPort, manifest.Image.Port)
-				require.Equal(t, tc.inDockerfilePath, manifest.Image.ServiceImage.Build)
-				require.Equal(t, tc.wantedPath, manifest.Path)
+				require.Equal(t, tc.inSvcName, aws.StringValue(manifest.Service.Name))
+				require.Equal(t, tc.inSvcPort, aws.Uint16Value(manifest.Image.Port))
+				require.Equal(t, tc.inDockerfilePath, aws.StringValue(manifest.Image.ServiceImage.Build))
+				require.Equal(t, tc.wantedPath, aws.StringValue(manifest.Path))
 			} else {
 				require.EqualError(t, err, tc.wantedErr.Error())
 			}

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -54,7 +54,7 @@ func TestBackendService_Template(t *testing.T) {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, svc *BackendService) {
 				svc.addons = mockTemplater{err: errors.New("some error")}
 			},
-			wantedErr: fmt.Errorf("generate addons template for service %s: %w", testBackendSvcManifest.Name, errors.New("some error")),
+			wantedErr: fmt.Errorf("generate addons template for service %s: %w", aws.StringValue(testBackendSvcManifest.Name), errors.New("some error")),
 		},
 		"failed parsing svc template": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, svc *BackendService) {
@@ -104,7 +104,7 @@ func TestBackendService_Template(t *testing.T) {
 			defer ctrl.Finish()
 			conf := &BackendService{
 				svc: &svc{
-					name: testBackendSvcManifest.Name,
+					name: aws.StringValue(testBackendSvcManifest.Name),
 					env:  testEnvName,
 					app:  testAppName,
 					rc: RuntimeConfig{
@@ -130,7 +130,7 @@ func TestBackendService_Parameters(t *testing.T) {
 	// GIVEN
 	conf := &BackendService{
 		svc: &svc{
-			name: testBackendSvcManifest.Name,
+			name: aws.StringValue(testBackendSvcManifest.Name),
 			env:  testEnvName,
 			app:  testAppName,
 			tc:   testBackendSvcManifest.TaskConfig,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -44,14 +44,17 @@ type LoadBalancedWebService struct {
 // NewLoadBalancedWebService creates a new LoadBalancedWebService stack from a manifest file.
 func NewLoadBalancedWebService(mft *manifest.LoadBalancedWebService, env, app string, rc RuntimeConfig) (*LoadBalancedWebService, error) {
 	parser := template.New()
-	addons, err := addons.New(mft.Name)
+	addons, err := addons.New(aws.StringValue(mft.Name))
 	if err != nil {
 		return nil, fmt.Errorf("new addons: %w", err)
 	}
-	envManifest := mft.ApplyEnv(env) // Apply environment overrides to the manifest values.
+	envManifest, err := mft.ApplyEnv(env) // Apply environment overrides to the manifest values.
+	if err != nil {
+		return nil, fmt.Errorf("apply environment %s override: %s", env, err)
+	}
 	return &LoadBalancedWebService{
 		svc: &svc{
-			name:   mft.Name,
+			name:   aws.StringValue(mft.Name),
 			env:    env,
 			app:    app,
 			tc:     envManifest.TaskConfig,
@@ -105,15 +108,15 @@ func (s *LoadBalancedWebService) Parameters() []*cloudformation.Parameter {
 	return append(s.svc.Parameters(), []*cloudformation.Parameter{
 		{
 			ParameterKey:   aws.String(LBWebServiceContainerPortParamKey),
-			ParameterValue: aws.String(strconv.FormatUint(uint64(s.manifest.Image.Port), 10)),
+			ParameterValue: aws.String(strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.Image.Port)), 10)),
 		},
 		{
 			ParameterKey:   aws.String(LBWebServiceRulePathParamKey),
-			ParameterValue: aws.String(s.manifest.Path),
+			ParameterValue: s.manifest.Path,
 		},
 		{
 			ParameterKey:   aws.String(LBWebServiceHealthCheckPathParamKey),
-			ParameterValue: aws.String(s.manifest.HealthCheckPath),
+			ParameterValue: s.manifest.HealthCheckPath,
 		},
 		{
 			ParameterKey:   aws.String(LBWebServiceHTTPSParamKey),

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc_test.go
@@ -116,7 +116,7 @@ func TestLoadBalancedWebService_Template(t *testing.T) {
 				c.svc.addons = addons
 			},
 			wantedTemplate: "",
-			wantedError:    fmt.Errorf("generate addons template for service %s: %w", testLBWebServiceManifest.Name, errors.New("some error")),
+			wantedError:    fmt.Errorf("generate addons template for service %s: %w", aws.StringValue(testLBWebServiceManifest.Name), errors.New("some error")),
 		},
 		"failed parsing svc template": {
 			mockDependencies: func(t *testing.T, ctrl *gomock.Controller, c *LoadBalancedWebService) {
@@ -204,7 +204,7 @@ Outputs:
 			defer ctrl.Finish()
 			conf := &LoadBalancedWebService{
 				svc: &svc{
-					name: testLBWebServiceManifest.Name,
+					name: aws.StringValue(testLBWebServiceManifest.Name),
 					env:  testEnvName,
 					app:  testAppName,
 					rc: RuntimeConfig{
@@ -246,7 +246,7 @@ func TestLoadBalancedWebService_Parameters(t *testing.T) {
 			// GIVEN
 			conf := &LoadBalancedWebService{
 				svc: &svc{
-					name: testLBWebServiceManifest.Name,
+					name: aws.StringValue(testLBWebServiceManifest.Name),
 					env:  testEnvName,
 					app:  testAppName,
 					tc:   testLBWebServiceManifest.TaskConfig,
@@ -355,7 +355,7 @@ func TestLoadBalancedWebService_SerializedParameters(t *testing.T) {
 			defer ctrl.Finish()
 			c := &LoadBalancedWebService{
 				svc: &svc{
-					name: testLBWebServiceManifest.Name,
+					name: aws.StringValue(testLBWebServiceManifest.Name),
 					env:  testEnvName,
 					app:  testAppName,
 					tc:   testLBWebServiceManifest.TaskConfig,
@@ -385,7 +385,7 @@ func TestLoadBalancedWebService_Tags(t *testing.T) {
 	// GIVEN
 	conf := &LoadBalancedWebService{
 		svc: &svc{
-			name: testLBWebServiceManifest.Name,
+			name: aws.StringValue(testLBWebServiceManifest.Name),
 			env:  testEnvName,
 			app:  testAppName,
 			rc: RuntimeConfig{

--- a/internal/pkg/deploy/cloudformation/stack/svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/svc.go
@@ -83,11 +83,11 @@ func (s *svc) Parameters() []*cloudformation.Parameter {
 		},
 		{
 			ParameterKey:   aws.String(ServiceTaskCPUParamKey),
-			ParameterValue: aws.String(strconv.Itoa(s.tc.CPU)),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(s.tc.CPU))),
 		},
 		{
 			ParameterKey:   aws.String(ServiceTaskMemoryParamKey),
-			ParameterValue: aws.String(strconv.Itoa(s.tc.Memory)),
+			ParameterValue: aws.String(strconv.Itoa(aws.IntValue(s.tc.Memory))),
 		},
 		{
 			ParameterKey:   aws.String(ServiceTaskCountParamKey),

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -30,20 +30,20 @@ func TestNewBackendSvc(t *testing.T) {
 			},
 			wantedManifest: &BackendService{
 				Service: Service{
-					Name: "subscribers",
-					Type: BackendServiceType,
+					Name: aws.String("subscribers"),
+					Type: aws.String(BackendServiceType),
 				},
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
 						ServiceImage: ServiceImage{
-							Build: "./subscribers/Dockerfile",
+							Build: aws.String("./subscribers/Dockerfile"),
 						},
-						Port: 8080,
+						Port: aws.Uint16(8080),
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 512,
+					CPU:    aws.Int(256),
+					Memory: aws.Int(512),
 					Count:  aws.Int(1),
 				},
 			},
@@ -61,15 +61,15 @@ func TestNewBackendSvc(t *testing.T) {
 			},
 			wantedManifest: &BackendService{
 				Service: Service{
-					Name: "subscribers",
-					Type: BackendServiceType,
+					Name: aws.String("subscribers"),
+					Type: aws.String(BackendServiceType),
 				},
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
 						ServiceImage: ServiceImage{
-							Build: "./subscribers/Dockerfile",
+							Build: aws.String("./subscribers/Dockerfile"),
 						},
-						Port: 8080,
+						Port: aws.Uint16(8080),
 					},
 					HealthCheck: &ContainerHealthCheck{
 						Command:     []string{"CMD", "curl -f http://localhost:8080 || exit 1"},
@@ -80,8 +80,8 @@ func TestNewBackendSvc(t *testing.T) {
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 512,
+					CPU:    aws.Int(256),
+					Memory: aws.Int(512),
 					Count:  aws.Int(1),
 				},
 			},
@@ -179,15 +179,15 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 		"environment doesn't exist": {
 			svc: &BackendService{
 				Service: Service{
-					Name: "phonetool",
-					Type: BackendServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(BackendServiceType),
 				},
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
 						ServiceImage: ServiceImage{
-							Build: "./Dockerfile",
+							Build: aws.String("./Dockerfile"),
 						},
-						Port: 8080,
+						Port: aws.Uint16(8080),
 					},
 					HealthCheck: &ContainerHealthCheck{
 						Command:     []string{"hello", "world"},
@@ -198,8 +198,8 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 256,
+					CPU:    aws.Int(256),
+					Memory: aws.Int(256),
 					Count:  aws.Int(1),
 				},
 			},
@@ -207,15 +207,15 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 
 			wanted: &BackendService{
 				Service: Service{
-					Name: "phonetool",
-					Type: BackendServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(BackendServiceType),
 				},
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
 						ServiceImage: ServiceImage{
-							Build: "./Dockerfile",
+							Build: aws.String("./Dockerfile"),
 						},
-						Port: 8080,
+						Port: aws.Uint16(8080),
 					},
 					HealthCheck: &ContainerHealthCheck{
 						Command:     []string{"hello", "world"},
@@ -226,8 +226,8 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 256,
+					CPU:    aws.Int(256),
+					Memory: aws.Int(256),
 					Count:  aws.Int(1),
 				},
 			},
@@ -236,14 +236,14 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 			svc: &BackendService{
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
-						Port: 80,
+						Port: aws.Uint16(80),
 					},
 				},
-				Environments: map[string]backendServiceOverrideConfig{
+				Environments: map[string]*backendServiceOverrideConfig{
 					"test": {
 						Image: imageWithPortAndHealthcheck{
 							ServiceImageWithPort: ServiceImageWithPort{
-								Port: 5000,
+								Port: aws.Uint16(5000),
 							},
 						},
 					},
@@ -254,7 +254,7 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 			wanted: &BackendService{
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
-						Port: 5000,
+						Port: aws.Uint16(5000),
 					},
 				},
 			},
@@ -263,45 +263,41 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 			svc: &BackendService{
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
-						Port: 80,
+						Port: aws.Uint16(80),
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 256,
+					CPU:    aws.Int(256),
+					Memory: aws.Int(256),
 					Count:  aws.Int(1),
 				},
 				Sidecar: Sidecar{
-					Sidecars: map[string]SidecarConfig{
+					Sidecars: map[string]*SidecarConfig{
 						"xray": {
-							Port:  "2000/udp",
-							Image: "123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon",
+							Port:  aws.String("2000/udp"),
+							Image: aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
 						},
 					},
 				},
 				LogConfig: LogConfig{
 					Destination: destinationConfig{
-						Name:           "datadog",
+						Name:           aws.String("datadog"),
 						ExcludePattern: aws.String("*"),
 					},
 				},
-				Environments: map[string]backendServiceOverrideConfig{
+				Environments: map[string]*backendServiceOverrideConfig{
 					"test": {
-						Image: imageWithPortAndHealthcheck{
-							ServiceImageWithPort: ServiceImageWithPort{
-								Port: 5000,
-							},
-						},
 						TaskConfig: TaskConfig{
 							Count: aws.Int(0),
+							CPU:   aws.Int(512),
 							Variables: map[string]string{
 								"LOG_LEVEL": "DEBUG",
 							},
 						},
 						Sidecar: Sidecar{
-							Sidecars: map[string]SidecarConfig{
+							Sidecars: map[string]*SidecarConfig{
 								"xray": {
-									CredParam: "some arn",
+									CredParam: aws.String("some arn"),
 								},
 							},
 						},
@@ -319,29 +315,29 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 			wanted: &BackendService{
 				Image: imageWithPortAndHealthcheck{
 					ServiceImageWithPort: ServiceImageWithPort{
-						Port: 5000,
+						Port: aws.Uint16(80),
 					},
 				},
 				TaskConfig: TaskConfig{
-					CPU:    256,
-					Memory: 256,
+					CPU:    aws.Int(512),
+					Memory: aws.Int(256),
 					Count:  aws.Int(0),
 					Variables: map[string]string{
 						"LOG_LEVEL": "DEBUG",
 					},
 				},
 				Sidecar: Sidecar{
-					Sidecars: map[string]SidecarConfig{
+					Sidecars: map[string]*SidecarConfig{
 						"xray": {
-							Port:      "2000/udp",
-							Image:     "123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon",
-							CredParam: "some arn",
+							Port:      aws.String("2000/udp"),
+							Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+							CredParam: aws.String("some arn"),
 						},
 					},
 				},
 				LogConfig: LogConfig{
 					Destination: destinationConfig{
-						Name:           "datadog",
+						Name:           aws.String("datadog"),
 						IncludePattern: aws.String("*"),
 						ExcludePattern: aws.String("fe/"),
 					},
@@ -352,7 +348,7 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.svc.ApplyEnv(tc.inEnvName)
+			got, _ := tc.svc.ApplyEnv(tc.inEnvName)
 
 			require.Equal(t, tc.wanted, got)
 		})

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -6,6 +6,7 @@ package manifest
 import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/template"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/imdario/mergo"
 )
 
 const (
@@ -39,23 +40,10 @@ type loadBalancedWebServiceOverrideConfig struct {
 
 // RoutingRule holds the path to route requests to the service.
 type RoutingRule struct {
-	Path            string `yaml:"path"`
-	HealthCheckPath string `yaml:"healthcheck"`
+	Path            *string `yaml:"path"`
+	HealthCheckPath *string `yaml:"healthcheck"`
 	// TargetContainer is the container load balancer routes traffic to.
-	TargetContainer string `yaml:"targetContainer"`
-}
-
-func (r RoutingRule) copyAndApply(other RoutingRule) RoutingRule {
-	if other.Path != "" {
-		r.Path = other.Path
-	}
-	if other.HealthCheckPath != "" {
-		r.HealthCheckPath = other.HealthCheckPath
-	}
-	if other.TargetContainer != "" {
-		r.TargetContainer = other.TargetContainer
-	}
-	return r
+	TargetContainer *string `yaml:"targetContainer"`
 }
 
 // LoadBalancedWebServiceProps contains properties for creating a new load balanced fargate service manifest.
@@ -70,16 +58,16 @@ type LoadBalancedWebServiceProps struct {
 func NewLoadBalancedWebService(input *LoadBalancedWebServiceProps) *LoadBalancedWebService {
 	defaultLbManifest := newDefaultLoadBalancedWebService()
 	defaultLbManifest.Service = Service{
-		Name: input.Name,
-		Type: LoadBalancedWebServiceType,
+		Name: aws.String(input.Name),
+		Type: aws.String(LoadBalancedWebServiceType),
 	}
 	defaultLbManifest.Image = ServiceImageWithPort{
 		ServiceImage: ServiceImage{
-			Build: input.Dockerfile,
+			Build: aws.String(input.Dockerfile),
 		},
-		Port: input.Port,
+		Port: aws.Uint16(input.Port),
 	}
-	defaultLbManifest.RoutingRule.Path = input.Path
+	defaultLbManifest.RoutingRule.Path = aws.String(input.Path)
 	defaultLbManifest.parser = template.New()
 	return defaultLbManifest
 }
@@ -90,11 +78,11 @@ func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 		Service: Service{},
 		Image:   ServiceImageWithPort{},
 		RoutingRule: RoutingRule{
-			HealthCheckPath: "/",
+			HealthCheckPath: aws.String("/"),
 		},
 		TaskConfig: TaskConfig{
-			CPU:    256,
-			Memory: 512,
+			CPU:    aws.Int(256),
+			Memory: aws.Int(512),
 			Count:  aws.Int(1),
 		},
 	}
@@ -112,23 +100,26 @@ func (s *LoadBalancedWebService) MarshalBinary() ([]byte, error) {
 
 // DockerfilePath returns the image build path.
 func (s *LoadBalancedWebService) DockerfilePath() string {
-	return s.Image.Build
+	return aws.StringValue(s.Image.Build)
 }
 
 // ApplyEnv returns the service manifest with environment overrides.
 // If the environment passed in does not have any overrides then it returns itself.
-func (s *LoadBalancedWebService) ApplyEnv(envName string) *LoadBalancedWebService {
-	target, ok := s.Environments[envName]
+func (s LoadBalancedWebService) ApplyEnv(envName string) (*LoadBalancedWebService, error) {
+	overrideConfig, ok := s.Environments[envName]
 	if !ok {
-		return s
+		return &s, nil
 	}
-
-	return &LoadBalancedWebService{
-		Service:     s.Service,
-		Image:       target.Image,
-		RoutingRule: s.RoutingRule.copyAndApply(target.RoutingRule),
-		TaskConfig:  s.TaskConfig.copyAndApply(target.TaskConfig),
-		Sidecar:     s.Sidecar.copyAndApply(target.Sidecar),
-		LogConfig:   s.LogConfig.copyAndApply(target.LogConfig),
+	target := LoadBalancedWebService{
+		Image:       overrideConfig.Image,
+		RoutingRule: overrideConfig.RoutingRule,
+		TaskConfig:  overrideConfig.TaskConfig,
+		LogConfig:   overrideConfig.LogConfig,
+		Sidecar:     overrideConfig.Sidecar,
 	}
+	if err := mergo.Merge(&s, target, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue); err != nil {
+		return nil, err
+	}
+	s.Environments = nil
+	return &s, nil
 }

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -71,22 +71,22 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 		"with no existing environments": {
 			in: &LoadBalancedWebService{
 				Service: Service{
-					Name: "phonetool",
-					Type: LoadBalancedWebServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				Image: ServiceImageWithPort{
 					ServiceImage: ServiceImage{
-						Build: "./Dockerfile",
+						Build: aws.String("./Dockerfile"),
 					},
-					Port: 80,
+					Port: aws.Uint16(80),
 				},
 				RoutingRule: RoutingRule{
-					Path:            "/awards/*",
-					HealthCheckPath: "/",
+					Path:            aws.String("/awards/*"),
+					HealthCheckPath: aws.String("/"),
 				},
 				TaskConfig: TaskConfig{
-					CPU:    1024,
-					Memory: 1024,
+					CPU:    aws.Int(1024),
+					Memory: aws.Int(1024),
 					Count:  aws.Int(1),
 				},
 			},
@@ -94,22 +94,22 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 
 			wanted: &LoadBalancedWebService{
 				Service: Service{
-					Name: "phonetool",
-					Type: LoadBalancedWebServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				Image: ServiceImageWithPort{
 					ServiceImage: ServiceImage{
-						Build: "./Dockerfile",
+						Build: aws.String("./Dockerfile"),
 					},
-					Port: 80,
+					Port: aws.Uint16(80),
 				},
 				RoutingRule: RoutingRule{
-					Path:            "/awards/*",
-					HealthCheckPath: "/",
+					Path:            aws.String("/awards/*"),
+					HealthCheckPath: aws.String("/"),
 				},
 				TaskConfig: TaskConfig{
-					CPU:    1024,
-					Memory: 1024,
+					CPU:    aws.Int(1024),
+					Memory: aws.Int(1024),
 					Count:  aws.Int(1),
 				},
 			},
@@ -117,22 +117,22 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 		"with overrides": {
 			in: &LoadBalancedWebService{
 				Service: Service{
-					Name: "phonetool",
-					Type: LoadBalancedWebServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				Image: ServiceImageWithPort{
 					ServiceImage: ServiceImage{
-						Build: "./Dockerfile",
+						Build: aws.String("./Dockerfile"),
 					},
-					Port: 80,
+					Port: aws.Uint16(80),
 				},
 				RoutingRule: RoutingRule{
-					Path:            "/awards/*",
-					HealthCheckPath: "/",
+					Path:            aws.String("/awards/*"),
+					HealthCheckPath: aws.String("/"),
 				},
 				TaskConfig: TaskConfig{
-					CPU:    1024,
-					Memory: 1024,
+					CPU:    aws.Int(1024),
+					Memory: aws.Int(1024),
 					Count:  aws.Int(1),
 					Variables: map[string]string{
 						"LOG_LEVEL":      "DEBUG",
@@ -144,39 +144,39 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 				Sidecar: Sidecar{
-					Sidecars: map[string]SidecarConfig{
+					Sidecars: map[string]*SidecarConfig{
 						"xray": {
-							Port:      "2000",
-							Image:     "123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon",
-							CredParam: "some arn",
+							Port:      aws.String("2000"),
+							Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+							CredParam: aws.String("some arn"),
 						},
 					},
 				},
 				LogConfig: LogConfig{
-					ConfigFile: "mockConfigFile",
+					ConfigFile: aws.String("mockConfigFile"),
 				},
 				Environments: map[string]loadBalancedWebServiceOverrideConfig{
 					"prod-iad": {
 						Image: ServiceImageWithPort{
 							ServiceImage: ServiceImage{
-								Build: "./RealDockerfile",
+								Build: aws.String("./RealDockerfile"),
 							},
-							Port: 5000,
+							Port: aws.Uint16(5000),
 						},
 						RoutingRule: RoutingRule{
-							TargetContainer: "xray",
+							TargetContainer: aws.String("xray"),
 						},
 						TaskConfig: TaskConfig{
-							CPU:   2046,
+							CPU:   aws.Int(2046),
 							Count: aws.Int(0),
 							Variables: map[string]string{
 								"DDB_TABLE_NAME": "awards-prod",
 							},
 						},
 						Sidecar: Sidecar{
-							Sidecars: map[string]SidecarConfig{
+							Sidecars: map[string]*SidecarConfig{
 								"xray": {
-									Port: "2000/udp",
+									Port: aws.String("2000/udp"),
 								},
 							},
 						},
@@ -192,23 +192,23 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 
 			wanted: &LoadBalancedWebService{
 				Service: Service{
-					Name: "phonetool",
-					Type: LoadBalancedWebServiceType,
+					Name: aws.String("phonetool"),
+					Type: aws.String(LoadBalancedWebServiceType),
 				},
 				Image: ServiceImageWithPort{
 					ServiceImage: ServiceImage{
-						Build: "./RealDockerfile",
+						Build: aws.String("./RealDockerfile"),
 					},
-					Port: 5000,
+					Port: aws.Uint16(5000),
 				},
 				RoutingRule: RoutingRule{
-					Path:            "/awards/*",
-					HealthCheckPath: "/",
-					TargetContainer: "xray",
+					Path:            aws.String("/awards/*"),
+					HealthCheckPath: aws.String("/"),
+					TargetContainer: aws.String("xray"),
 				},
 				TaskConfig: TaskConfig{
-					CPU:    2046,
-					Memory: 1024,
+					CPU:    aws.Int(2046),
+					Memory: aws.Int(1024),
 					Count:  aws.Int(0),
 					Variables: map[string]string{
 						"LOG_LEVEL":      "DEBUG",
@@ -220,16 +220,16 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 				Sidecar: Sidecar{
-					Sidecars: map[string]SidecarConfig{
+					Sidecars: map[string]*SidecarConfig{
 						"xray": {
-							Port:      "2000/udp",
-							Image:     "123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon",
-							CredParam: "some arn",
+							Port:      aws.String("2000/udp"),
+							Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+							CredParam: aws.String("some arn"),
 						},
 					},
 				},
 				LogConfig: LogConfig{
-					ConfigFile: "mockConfigFile",
+					ConfigFile: aws.String("mockConfigFile"),
 					SecretOptions: map[string]string{
 						"FOO": "BAR",
 					},
@@ -243,7 +243,7 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 			// GIVEN
 
 			// WHEN
-			conf := tc.in.ApplyEnv(tc.envToApply)
+			conf, _ := tc.in.ApplyEnv(tc.envToApply)
 
 			// THEN
 			require.Equal(t, tc.wanted, conf, "returned configuration should have overrides from the environment")

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -27,19 +27,19 @@ var ServiceTypes = []string{
 
 // Service holds the basic data that every service manifest file needs to have.
 type Service struct {
-	Name string `yaml:"name"`
-	Type string `yaml:"type"` // must be one of the supported manifest types.
+	Name *string `yaml:"name"`
+	Type *string `yaml:"type"` // must be one of the supported manifest types.
 }
 
 // ServiceImage represents the service's container image.
 type ServiceImage struct {
-	Build string `yaml:"build"` // Path to the Dockerfile.
+	Build *string `yaml:"build"` // Path to the Dockerfile.
 }
 
 // ServiceImageWithPort represents a container image with an exposed port.
 type ServiceImageWithPort struct {
 	ServiceImage `yaml:",inline"`
-	Port         uint16 `yaml:"port"`
+	Port         *uint16 `yaml:"port"`
 }
 
 // LogConfig holds configuration for Firelens to route your logs.
@@ -47,175 +47,35 @@ type LogConfig struct {
 	Destination    destinationConfig `yaml:"destination,flow"`
 	EnableMetadata *bool             `yaml:"enableMetadata"`
 	SecretOptions  map[string]string `yaml:"secretOptions"`
-	ConfigFile     string            `yaml:"configFile"`
-	PermissionFile string            `yaml:"permissionFile"`
+	ConfigFile     *string           `yaml:"configFile"`
+	PermissionFile *string           `yaml:"permissionFile"`
 }
 
 type destinationConfig struct {
-	Name           string  `yaml:"name"`
+	Name           *string `yaml:"name"`
 	IncludePattern *string `yaml:"includePattern"` // can be empty string as a valid value
 	ExcludePattern *string `yaml:"excludePattern"`
 }
 
-func (lc LogConfig) copyAndApply(other LogConfig) LogConfig {
-	override := lc.deepcopy()
-	if other.Destination.Name != "" {
-		override.Destination.Name = other.Destination.Name
-	}
-	if other.Destination.ExcludePattern != nil {
-		override.Destination.ExcludePattern = other.Destination.ExcludePattern
-	}
-	if other.Destination.IncludePattern != nil {
-		override.Destination.IncludePattern = other.Destination.IncludePattern
-	}
-	if other.EnableMetadata != nil {
-		override.EnableMetadata = other.EnableMetadata
-	}
-	if other.ConfigFile != "" {
-		override.ConfigFile = other.ConfigFile
-	}
-	if other.PermissionFile != "" {
-		override.PermissionFile = other.PermissionFile
-	}
-	if other.SecretOptions != nil && override.SecretOptions == nil {
-		override.SecretOptions = make(map[string]string)
-	}
-	for k, v := range other.SecretOptions {
-		override.SecretOptions[k] = v
-	}
-	return override
-}
-
-func (lc LogConfig) deepcopy() LogConfig {
-	destination := destinationConfig{
-		ExcludePattern: stringpcopy(lc.Destination.ExcludePattern),
-		IncludePattern: stringpcopy(lc.Destination.IncludePattern),
-		Name:           lc.Destination.Name,
-	}
-	secretOptions := make(map[string]string, len(lc.SecretOptions))
-	for k, v := range lc.SecretOptions {
-		secretOptions[k] = v
-	}
-	if lc.SecretOptions == nil {
-		secretOptions = nil
-	}
-	return LogConfig{
-		Destination:    destination,
-		ConfigFile:     lc.ConfigFile,
-		EnableMetadata: boolpcopy(lc.EnableMetadata),
-		PermissionFile: lc.PermissionFile,
-		SecretOptions:  secretOptions,
-	}
-}
-
 // Sidecar holds configuration for all sidecar containers in a service.
 type Sidecar struct {
-	Sidecars map[string]SidecarConfig `yaml:"sidecars"`
+	Sidecars map[string]*SidecarConfig `yaml:"sidecars"`
 }
 
 // SidecarConfig represents the configurable options for setting up a sidecar container.
 type SidecarConfig struct {
-	Port      string `yaml:"port"`
-	Image     string `yaml:"image"`
-	CredParam string `yaml:"credentialsParameter"`
-}
-
-func (s Sidecar) copyAndApply(other Sidecar) Sidecar {
-	// TODO: abstract away copyandApply and deepCopy.
-	override := s.deepcopy()
-	if other.Sidecars != nil && override.Sidecars == nil {
-		override.Sidecars = make(map[string]SidecarConfig)
-	}
-	for k, v := range other.Sidecars {
-		config := override.Sidecars[k]
-		if v.CredParam != "" {
-			config.CredParam = v.CredParam
-		}
-		if v.Image != "" {
-			config.Image = v.Image
-		}
-		if v.Port != "" {
-			config.Port = v.Port
-		}
-		override.Sidecars[k] = config
-	}
-	return override
-}
-
-func (s Sidecar) deepcopy() Sidecar {
-	config := make(map[string]SidecarConfig, len(s.Sidecars))
-	for k, v := range s.Sidecars {
-		config[k] = SidecarConfig{
-			CredParam: v.CredParam,
-			Image:     v.Image,
-			Port:      v.Port,
-		}
-	}
-	if s.Sidecars == nil {
-		config = nil
-	}
-	return Sidecar{
-		Sidecars: config,
-	}
+	Port      *string `yaml:"port"`
+	Image     *string `yaml:"image"`
+	CredParam *string `yaml:"credentialsParameter"`
 }
 
 // TaskConfig represents the resource boundaries and environment variables for the containers in the task.
 type TaskConfig struct {
-	CPU       int               `yaml:"cpu"`
-	Memory    int               `yaml:"memory"`
+	CPU       *int              `yaml:"cpu"`
+	Memory    *int              `yaml:"memory"`
 	Count     *int              `yaml:"count"` // 0 is a valid value, so we want the default value to be nil.
 	Variables map[string]string `yaml:"variables"`
 	Secrets   map[string]string `yaml:"secrets"`
-}
-
-func (tc TaskConfig) copyAndApply(other TaskConfig) TaskConfig {
-	override := tc.deepcopy()
-	if other.CPU != 0 {
-		override.CPU = other.CPU
-	}
-	if other.Memory != 0 {
-		override.Memory = other.Memory
-	}
-	if other.Count != nil {
-		override.Count = other.Count
-	}
-	if other.Variables != nil && override.Variables == nil {
-		override.Variables = make(map[string]string)
-	}
-	for k, v := range other.Variables {
-		override.Variables[k] = v
-	}
-	if other.Secrets != nil && override.Secrets == nil {
-		override.Secrets = make(map[string]string)
-	}
-	for k, v := range other.Secrets {
-		override.Secrets[k] = v
-	}
-	return override
-}
-
-func (tc TaskConfig) deepcopy() TaskConfig {
-	vars := make(map[string]string, len(tc.Variables))
-	for k, v := range tc.Variables {
-		vars[k] = v
-	}
-	if tc.Variables == nil {
-		vars = nil
-	}
-	secrets := make(map[string]string, len(tc.Secrets))
-	for k, v := range tc.Secrets {
-		secrets[k] = v
-	}
-	if tc.Secrets == nil {
-		secrets = nil
-	}
-	return TaskConfig{
-		CPU:       tc.CPU,
-		Memory:    tc.Memory,
-		Count:     intpcopy(tc.Count),
-		Variables: vars,
-		Secrets:   secrets,
-	}
 }
 
 // ServiceProps contains properties for creating a new service manifest.
@@ -232,8 +92,9 @@ func UnmarshalService(in []byte) (interface{}, error) {
 	if err := yaml.Unmarshal(in, &am); err != nil {
 		return nil, fmt.Errorf("unmarshal to service manifest: %w", err)
 	}
+	typeVal := aws.StringValue(am.Type)
 
-	switch am.Type {
+	switch typeVal {
 	case LoadBalancedWebServiceType:
 		m := newDefaultLoadBalancedWebService()
 		if err := yaml.Unmarshal(in, m); err != nil {
@@ -251,7 +112,7 @@ func UnmarshalService(in []byte) (interface{}, error) {
 		}
 		return m, nil
 	default:
-		return nil, &ErrInvalidSvcManifestType{Type: am.Type}
+		return nil, &ErrInvalidSvcManifestType{Type: typeVal}
 	}
 }
 

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -58,15 +58,15 @@ environments:
 				actualManifest, ok := i.(*LoadBalancedWebService)
 				require.True(t, ok)
 				wantedManifest := &LoadBalancedWebService{
-					Service: Service{Name: "frontend", Type: LoadBalancedWebServiceType},
-					Image:   ServiceImageWithPort{ServiceImage: ServiceImage{Build: "frontend/Dockerfile"}, Port: 80},
+					Service: Service{Name: aws.String("frontend"), Type: aws.String(LoadBalancedWebServiceType)},
+					Image:   ServiceImageWithPort{ServiceImage: ServiceImage{Build: aws.String("frontend/Dockerfile")}, Port: aws.Uint16(80)},
 					RoutingRule: RoutingRule{
-						Path:            "svc",
-						HealthCheckPath: "/",
+						Path:            aws.String("svc"),
+						HealthCheckPath: aws.String("/"),
 					},
 					TaskConfig: TaskConfig{
-						CPU:    512,
-						Memory: 1024,
+						CPU:    aws.Int(512),
+						Memory: aws.Int(1024),
 						Count:  aws.Int(1),
 						Variables: map[string]string{
 							"LOG_LEVEL": "WARN",
@@ -76,11 +76,11 @@ environments:
 						},
 					},
 					Sidecar: Sidecar{
-						Sidecars: map[string]SidecarConfig{
+						Sidecars: map[string]*SidecarConfig{
 							"xray": {
-								Port:      "2000/udp",
-								Image:     "123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon",
-								CredParam: "some arn",
+								Port:      aws.String("2000/udp"),
+								Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+								CredParam: aws.String("some arn"),
 							},
 						},
 					},
@@ -88,11 +88,11 @@ environments:
 						Destination: destinationConfig{
 							ExcludePattern: aws.String("^.*[aeiou]$"),
 							IncludePattern: aws.String("^[a-z][aeiou].*$"),
-							Name:           "cloudwatch",
+							Name:           aws.String("cloudwatch"),
 						},
 						EnableMetadata: aws.Bool(false),
-						ConfigFile:     "./extra.conf",
-						PermissionFile: "./permissions.json",
+						ConfigFile:     aws.String("./extra.conf"),
+						PermissionFile: aws.String("./permissions.json"),
 						SecretOptions: map[string]string{
 							"LOG_TOKEN": "LOG_TOKEN",
 						},
@@ -126,15 +126,15 @@ secrets:
 				require.True(t, ok)
 				wantedManifest := &BackendService{
 					Service: Service{
-						Name: "subscribers",
-						Type: BackendServiceType,
+						Name: aws.String("subscribers"),
+						Type: aws.String(BackendServiceType),
 					},
 					Image: imageWithPortAndHealthcheck{
 						ServiceImageWithPort: ServiceImageWithPort{
 							ServiceImage: ServiceImage{
-								Build: "./subscribers/Dockerfile",
+								Build: aws.String("./subscribers/Dockerfile"),
 							},
-							Port: 8080,
+							Port: aws.Uint16(8080),
 						},
 						HealthCheck: &ContainerHealthCheck{
 							Command:     []string{"CMD-SHELL", "curl http://localhost:5000/ || exit 1"},
@@ -145,8 +145,8 @@ secrets:
 						},
 					},
 					TaskConfig: TaskConfig{
-						CPU:    1024,
-						Memory: 1024,
+						CPU:    aws.Int(1024),
+						Memory: aws.Int(1024),
 						Count:  aws.Int(1),
 						Secrets: map[string]string{
 							"API_TOKEN": "SUBS_API_TOKEN",


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR fixes #966 and all (hopefully) related issues concerning our manifest default value and override issues by

1. substitute all fields to pointer value in light of CloudFormation template. After this change all empty value (empty string, 0, false etc.) will be considered as valid value instead of `nil` value;
2. use [mergo](https://github.com/imdario/mergo) package for environment override and remove repetitive and error-prone `copyAndApply` and `deepcopy` methods.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
