### PR TITLE
chore(manifest): simplify load balanced/backend service struct

### DIFF
--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -48,7 +48,7 @@ func NewBackendService(mft *manifest.BackendService, env, app string, rc Runtime
 			name:   aws.StringValue(mft.Name),
 			env:    env,
 			app:    app,
-			tc:     envManifest.TaskConfig,
+			tc:     envManifest.BackendServiceConfig.TaskConfig,
 			rc:     rc,
 			parser: parser,
 			addons: addons,
@@ -66,10 +66,10 @@ func (s *BackendService) Template() (string, error) {
 		return "", err
 	}
 	content, err := s.parser.ParseBackendService(template.ServiceOpts{
-		Variables:   s.manifest.Variables,
-		Secrets:     s.manifest.Secrets,
+		Variables:   s.manifest.BackendServiceConfig.Variables,
+		Secrets:     s.manifest.BackendServiceConfig.Secrets,
 		NestedStack: outputs,
-		HealthCheck: s.manifest.Image.HealthCheckOpts(),
+		HealthCheck: s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)
@@ -82,7 +82,7 @@ func (s *BackendService) Parameters() []*cloudformation.Parameter {
 	return append(s.svc.Parameters(), []*cloudformation.Parameter{
 		{
 			ParameterKey:   aws.String(BackendServiceContainerPortParamKey),
-			ParameterValue: aws.String(strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.Image.Port)), 10)),
+			ParameterValue: aws.String(strconv.FormatUint(uint64(aws.Uint16Value(s.manifest.BackendServiceConfig.Image.Port)), 10)),
 		},
 	}...)
 }

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -133,7 +133,7 @@ func TestBackendService_Parameters(t *testing.T) {
 			name: aws.StringValue(testBackendSvcManifest.Name),
 			env:  testEnvName,
 			app:  testAppName,
-			tc:   testBackendSvcManifest.TaskConfig,
+			tc:   testBackendSvcManifest.BackendServiceConfig.TaskConfig,
 			rc: RuntimeConfig{
 				ImageRepoURL: testImageRepoURL,
 				ImageTag:     testImageTag,

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -19,23 +19,20 @@ const (
 // LoadBalancedWebService holds the configuration to build a container image with an exposed port that receives
 // requests through a load balancer with AWS Fargate as the compute engine.
 type LoadBalancedWebService struct {
-	Service      `yaml:",inline"`
-	Image        ServiceImageWithPort `yaml:",flow"`
-	RoutingRule  `yaml:"http,flow"`
-	TaskConfig   `yaml:",inline"`
-	LogConfig    `yaml:"logging,flow"`
-	Sidecar      `yaml:",inline"`
-	Environments map[string]loadBalancedWebServiceOverrideConfig `yaml:",flow"` // Fields to override per environment.
+	Service                      `yaml:",inline"`
+	LoadBalancedWebServiceConfig `yaml:",inline"`
+	Environments                 map[string]*LoadBalancedWebServiceConfig `yaml:",flow"` // Fields to override per environment.
 
 	parser template.Parser
 }
 
-type loadBalancedWebServiceOverrideConfig struct {
+// LoadBalancedWebServiceConfig holds the configuration for a load balanced web service.
+type LoadBalancedWebServiceConfig struct {
 	Image       ServiceImageWithPort `yaml:",flow"`
 	RoutingRule `yaml:"http,flow"`
 	TaskConfig  `yaml:",inline"`
 	LogConfig   `yaml:"logging,flow"`
-	Sidecar     `yaml:"sidecar,flow"`
+	Sidecar     `yaml:",inline"`
 }
 
 // RoutingRule holds the path to route requests to the service.
@@ -76,14 +73,16 @@ func NewLoadBalancedWebService(input *LoadBalancedWebServiceProps) *LoadBalanced
 func newDefaultLoadBalancedWebService() *LoadBalancedWebService {
 	return &LoadBalancedWebService{
 		Service: Service{},
-		Image:   ServiceImageWithPort{},
-		RoutingRule: RoutingRule{
-			HealthCheckPath: aws.String("/"),
-		},
-		TaskConfig: TaskConfig{
-			CPU:    aws.Int(256),
-			Memory: aws.Int(512),
-			Count:  aws.Int(1),
+		LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+			Image: ServiceImageWithPort{},
+			RoutingRule: RoutingRule{
+				HealthCheckPath: aws.String("/"),
+			},
+			TaskConfig: TaskConfig{
+				CPU:    aws.Int(256),
+				Memory: aws.Int(512),
+				Count:  aws.Int(1),
+			},
 		},
 	}
 }
@@ -111,11 +110,7 @@ func (s LoadBalancedWebService) ApplyEnv(envName string) (*LoadBalancedWebServic
 		return &s, nil
 	}
 	target := LoadBalancedWebService{
-		Image:       overrideConfig.Image,
-		RoutingRule: overrideConfig.RoutingRule,
-		TaskConfig:  overrideConfig.TaskConfig,
-		LogConfig:   overrideConfig.LogConfig,
-		Sidecar:     overrideConfig.Sidecar,
+		LoadBalancedWebServiceConfig: *overrideConfig,
 	}
 	if err := mergo.Merge(&s, target, mergo.WithOverride, mergo.WithOverwriteWithEmptyValue); err != nil {
 		return nil, err

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -74,20 +74,22 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					Name: aws.String("phonetool"),
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
-				Image: ServiceImageWithPort{
-					ServiceImage: ServiceImage{
-						Build: aws.String("./Dockerfile"),
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					Image: ServiceImageWithPort{
+						ServiceImage: ServiceImage{
+							Build: aws.String("./Dockerfile"),
+						},
+						Port: aws.Uint16(80),
 					},
-					Port: aws.Uint16(80),
-				},
-				RoutingRule: RoutingRule{
-					Path:            aws.String("/awards/*"),
-					HealthCheckPath: aws.String("/"),
-				},
-				TaskConfig: TaskConfig{
-					CPU:    aws.Int(1024),
-					Memory: aws.Int(1024),
-					Count:  aws.Int(1),
+					RoutingRule: RoutingRule{
+						Path:            aws.String("/awards/*"),
+						HealthCheckPath: aws.String("/"),
+					},
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(1024),
+						Memory: aws.Int(1024),
+						Count:  aws.Int(1),
+					},
 				},
 			},
 			envToApply: "prod-iad",
@@ -97,20 +99,22 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					Name: aws.String("phonetool"),
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
-				Image: ServiceImageWithPort{
-					ServiceImage: ServiceImage{
-						Build: aws.String("./Dockerfile"),
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					Image: ServiceImageWithPort{
+						ServiceImage: ServiceImage{
+							Build: aws.String("./Dockerfile"),
+						},
+						Port: aws.Uint16(80),
 					},
-					Port: aws.Uint16(80),
-				},
-				RoutingRule: RoutingRule{
-					Path:            aws.String("/awards/*"),
-					HealthCheckPath: aws.String("/"),
-				},
-				TaskConfig: TaskConfig{
-					CPU:    aws.Int(1024),
-					Memory: aws.Int(1024),
-					Count:  aws.Int(1),
+					RoutingRule: RoutingRule{
+						Path:            aws.String("/awards/*"),
+						HealthCheckPath: aws.String("/"),
+					},
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(1024),
+						Memory: aws.Int(1024),
+						Count:  aws.Int(1),
+					},
 				},
 			},
 		},
@@ -120,42 +124,44 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					Name: aws.String("phonetool"),
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
-				Image: ServiceImageWithPort{
-					ServiceImage: ServiceImage{
-						Build: aws.String("./Dockerfile"),
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					Image: ServiceImageWithPort{
+						ServiceImage: ServiceImage{
+							Build: aws.String("./Dockerfile"),
+						},
+						Port: aws.Uint16(80),
 					},
-					Port: aws.Uint16(80),
-				},
-				RoutingRule: RoutingRule{
-					Path:            aws.String("/awards/*"),
-					HealthCheckPath: aws.String("/"),
-				},
-				TaskConfig: TaskConfig{
-					CPU:    aws.Int(1024),
-					Memory: aws.Int(1024),
-					Count:  aws.Int(1),
-					Variables: map[string]string{
-						"LOG_LEVEL":      "DEBUG",
-						"DDB_TABLE_NAME": "awards",
+					RoutingRule: RoutingRule{
+						Path:            aws.String("/awards/*"),
+						HealthCheckPath: aws.String("/"),
 					},
-					Secrets: map[string]string{
-						"GITHUB_TOKEN": "1111",
-						"TWILIO_TOKEN": "1111",
-					},
-				},
-				Sidecar: Sidecar{
-					Sidecars: map[string]*SidecarConfig{
-						"xray": {
-							Port:      aws.String("2000"),
-							Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-							CredParam: aws.String("some arn"),
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(1024),
+						Memory: aws.Int(1024),
+						Count:  aws.Int(1),
+						Variables: map[string]string{
+							"LOG_LEVEL":      "DEBUG",
+							"DDB_TABLE_NAME": "awards",
+						},
+						Secrets: map[string]string{
+							"GITHUB_TOKEN": "1111",
+							"TWILIO_TOKEN": "1111",
 						},
 					},
+					Sidecar: Sidecar{
+						Sidecars: map[string]*SidecarConfig{
+							"xray": {
+								Port:      aws.String("2000"),
+								Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+								CredParam: aws.String("some arn"),
+							},
+						},
+					},
+					LogConfig: LogConfig{
+						ConfigFile: aws.String("mockConfigFile"),
+					},
 				},
-				LogConfig: LogConfig{
-					ConfigFile: aws.String("mockConfigFile"),
-				},
-				Environments: map[string]loadBalancedWebServiceOverrideConfig{
+				Environments: map[string]*LoadBalancedWebServiceConfig{
 					"prod-iad": {
 						Image: ServiceImageWithPort{
 							ServiceImage: ServiceImage{
@@ -195,43 +201,45 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 					Name: aws.String("phonetool"),
 					Type: aws.String(LoadBalancedWebServiceType),
 				},
-				Image: ServiceImageWithPort{
-					ServiceImage: ServiceImage{
-						Build: aws.String("./RealDockerfile"),
+				LoadBalancedWebServiceConfig: LoadBalancedWebServiceConfig{
+					Image: ServiceImageWithPort{
+						ServiceImage: ServiceImage{
+							Build: aws.String("./RealDockerfile"),
+						},
+						Port: aws.Uint16(5000),
 					},
-					Port: aws.Uint16(5000),
-				},
-				RoutingRule: RoutingRule{
-					Path:            aws.String("/awards/*"),
-					HealthCheckPath: aws.String("/"),
-					TargetContainer: aws.String("xray"),
-				},
-				TaskConfig: TaskConfig{
-					CPU:    aws.Int(2046),
-					Memory: aws.Int(1024),
-					Count:  aws.Int(0),
-					Variables: map[string]string{
-						"LOG_LEVEL":      "DEBUG",
-						"DDB_TABLE_NAME": "awards-prod",
+					RoutingRule: RoutingRule{
+						Path:            aws.String("/awards/*"),
+						HealthCheckPath: aws.String("/"),
+						TargetContainer: aws.String("xray"),
 					},
-					Secrets: map[string]string{
-						"GITHUB_TOKEN": "1111",
-						"TWILIO_TOKEN": "1111",
-					},
-				},
-				Sidecar: Sidecar{
-					Sidecars: map[string]*SidecarConfig{
-						"xray": {
-							Port:      aws.String("2000/udp"),
-							Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
-							CredParam: aws.String("some arn"),
+					TaskConfig: TaskConfig{
+						CPU:    aws.Int(2046),
+						Memory: aws.Int(1024),
+						Count:  aws.Int(0),
+						Variables: map[string]string{
+							"LOG_LEVEL":      "DEBUG",
+							"DDB_TABLE_NAME": "awards-prod",
+						},
+						Secrets: map[string]string{
+							"GITHUB_TOKEN": "1111",
+							"TWILIO_TOKEN": "1111",
 						},
 					},
-				},
-				LogConfig: LogConfig{
-					ConfigFile: aws.String("mockConfigFile"),
-					SecretOptions: map[string]string{
-						"FOO": "BAR",
+					Sidecar: Sidecar{
+						Sidecars: map[string]*SidecarConfig{
+							"xray": {
+								Port:      aws.String("2000/udp"),
+								Image:     aws.String("123456789012.dkr.ecr.us-east-2.amazonaws.com/xray-daemon"),
+								CredParam: aws.String("some arn"),
+							},
+						},
+					},
+					LogConfig: LogConfig{
+						ConfigFile: aws.String("mockConfigFile"),
+						SecretOptions: map[string]string{
+							"FOO": "BAR",
+						},
 					},
 				},
 			},

--- a/internal/pkg/manifest/svc.go
+++ b/internal/pkg/manifest/svc.go
@@ -106,9 +106,9 @@ func UnmarshalService(in []byte) (interface{}, error) {
 		if err := yaml.Unmarshal(in, m); err != nil {
 			return nil, fmt.Errorf("unmarshal to backend service: %w", err)
 		}
-		if m.Image.HealthCheck != nil {
+		if m.BackendServiceConfig.Image.HealthCheck != nil {
 			// Make sure that unset fields in the healthcheck gets a default value.
-			m.Image.HealthCheck.applyIfNotSet(newDefaultContainerHealthCheck())
+			m.BackendServiceConfig.Image.HealthCheck.applyIfNotSet(newDefaultContainerHealthCheck())
 		}
 		return m, nil
 	default:


### PR DESCRIPTION
<!-- Provide summary of changes -->
Simplify `BackendService` and `LoadbalancedWebService` by removing fields that are duplicated with the corresponding config struct. Addressing feedback https://github.com/aws/amazon-ecs-cli-v2/pull/970#pullrequestreview-419569244
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
