### PR TITLE
style: reduce feedback noise for logs and prompts

### DIFF
--- a/internal/pkg/cli/app_init.go
+++ b/internal/pkg/cli/app_init.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	fmtAppInitStart    = "Creating the infrastructure to manage container repositories under application %s."
-	fmtAppInitComplete = "Created the infrastructure to manage container repositories under application %s."
-	fmtAppInitFailed   = "Failed to create the infrastructure to manage container repositories under application %s."
+	fmtAppInitStart    = "Creating the infrastructure to manage services under application %s."
+	fmtAppInitComplete = "Created the infrastructure to manage services under application %s.\n"
+	fmtAppInitFailed   = "Failed to create the infrastructure to manage services under application %s.\n"
 
 	appInitNameHelpPrompt = "Services in the same application share the same VPC and ECS Cluster and are discoverable via service discovery."
 )
@@ -95,8 +95,8 @@ func (o *initAppOpts) Ask() error {
 	if err == nil {
 		if o.AppName == "" {
 			log.Infoln(fmt.Sprintf(
-				"Looks like you are using a workspace that's registered to application %s.\nWe'll use that as your application.",
-				color.HighlightResource(summary.Application)))
+				"Your workspace is registered to application %s.",
+				color.HighlightUserInput(summary.Application)))
 			o.AppName = summary.Application
 			return nil
 		}
@@ -120,18 +120,15 @@ If you'd like to delete the application and all of its resources, run %s.
 
 	existingApps, _ := o.store.ListApplications()
 	if len(existingApps) == 0 {
-		log.Infoln("Looks like you don't have any existing applications. Let's create one!")
 		return o.askNewAppName()
 	}
 
-	log.Infoln("Looks like you have some applications already.")
 	useExistingApp, err := o.prompt.Confirm(
-		"Would you like to use one of your existing applications?", "", prompt.WithTrueDefault())
+		"Would you like to use one of your existing applications?", "", prompt.WithTrueDefault(), prompt.WithFinalMessage("Use existing application:"))
 	if err != nil {
 		return fmt.Errorf("prompt to confirm using existing application: %w", err)
 	}
 	if useExistingApp {
-		log.Infoln("Ok, here are your existing applications.")
 		return o.askSelectExistingAppName(existingApps)
 	}
 	log.Infoln("Ok, let's create a new application then.")
@@ -210,7 +207,8 @@ func (o *initAppOpts) askNewAppName() error {
 	appName, err := o.prompt.Get(
 		fmt.Sprintf("What would you like to %s your application?", color.Emphasize("name")),
 		appInitNameHelpPrompt,
-		validateAppName)
+		validateAppName,
+		prompt.WithFinalMessage("Application name:"))
 	if err != nil {
 		return fmt.Errorf("prompt get application name: %w", err)
 	}
@@ -226,7 +224,8 @@ func (o *initAppOpts) askSelectExistingAppName(existingApps []*config.Applicatio
 	name, err := o.prompt.SelectOne(
 		fmt.Sprintf("Which %s do you want to add a new service to?", color.Emphasize("existing application")),
 		appInitNameHelpPrompt,
-		names)
+		names,
+		prompt.WithFinalMessage("Application name:"))
 	if err != nil {
 		return fmt.Errorf("prompt select application name: %w", err)
 	}

--- a/internal/pkg/cli/app_init_test.go
+++ b/internal/pkg/cli/app_init_test.go
@@ -46,7 +46,7 @@ func TestInitAppOpts_Ask(t *testing.T) {
 			expect: func(opts *initAppOpts) {
 				opts.ws.(*mocks.MockwsAppManager).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
 				opts.store.(*mocks.Mockstore).EXPECT().ListApplications().Return([]*config.Application{}, nil)
-				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
+				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
 				opts.prompt.(*mocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
@@ -56,7 +56,7 @@ func TestInitAppOpts_Ask(t *testing.T) {
 			expect: func(opts *initAppOpts) {
 				opts.ws.(*mocks.MockwsAppManager).EXPECT().Summary().Return(nil, errors.New("no existing workspace"))
 				opts.store.(*mocks.Mockstore).EXPECT().ListApplications().Return([]*config.Application{}, nil)
-				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 			},
@@ -74,7 +74,7 @@ func TestInitAppOpts_Ask(t *testing.T) {
 					},
 				}, nil)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
+				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", errors.New("my error"))
 			},
 			wantedErr: "prompt select application name: my error",
 		},
@@ -90,7 +90,7 @@ func TestInitAppOpts_Ask(t *testing.T) {
 					},
 				}, nil)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
-				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
 			},
 			wantedAppName: "metrics",
 		},
@@ -107,7 +107,7 @@ func TestInitAppOpts_Ask(t *testing.T) {
 				}, nil)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().Confirm(gomock.Any(), gomock.Any(), gomock.Any()).Return(false, nil)
 				opts.prompt.(*mocks.Mockprompter).EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
-				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
+				opts.prompt.(*mocks.Mockprompter).EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("metrics", nil)
 			},
 			wantedAppName: "metrics",
 		},

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -41,7 +41,7 @@ const (
 	fmtStreamEnvComplete     = "Created the infrastructure for the %s environment.\n"
 	fmtAddEnvToAppStart      = "Linking account %s and region %s to application %s."
 	fmtAddEnvToAppFailed     = "Failed to link account %s and region %s to application %s.\n"
-	fmtAddEnvToAppComplete   = "Linked account %s and region %s application %s.\n"
+	fmtAddEnvToAppComplete   = "Linked account %s and region %s to application %s.\n"
 )
 
 var (

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -31,7 +31,7 @@ const (
 
 const (
 	fmtDeployEnvStart        = "Proposing infrastructure changes for the %s environment."
-	fmtDeployEnvComplete     = "CloudFormation stack for env %s already exists under application %s! Do nothing.\n"
+	fmtDeployEnvComplete     = "Environment %s already exists in application %s.\n"
 	fmtDeployEnvFailed       = "Failed to accept changes for the %s environment.\n"
 	fmtDNSDelegationStart    = "Sharing DNS permissions for this application to account %s."
 	fmtDNSDelegationFailed   = "Failed to grant DNS permissions to account %s.\n"

--- a/internal/pkg/cli/env_init.go
+++ b/internal/pkg/cli/env_init.go
@@ -31,16 +31,17 @@ const (
 
 const (
 	fmtDeployEnvStart        = "Proposing infrastructure changes for the %s environment."
-	fmtDeployEnvFailed       = "Failed to accept changes for the %s environment."
+	fmtDeployEnvComplete     = "CloudFormation stack for env %s already exists under application %s! Do nothing.\n"
+	fmtDeployEnvFailed       = "Failed to accept changes for the %s environment.\n"
 	fmtDNSDelegationStart    = "Sharing DNS permissions for this application to account %s."
-	fmtDNSDelegationFailed   = "Failed to grant DNS permissions to account %s."
-	fmtDNSDelegationComplete = "Shared DNS permissions for this application to account %s."
+	fmtDNSDelegationFailed   = "Failed to grant DNS permissions to account %s.\n"
+	fmtDNSDelegationComplete = "Shared DNS permissions for this application to account %s.\n"
 	fmtStreamEnvStart        = "Creating the infrastructure for the %s environment."
-	fmtStreamEnvFailed       = "Failed to create the infrastructure for the %s environment."
-	fmtStreamEnvComplete     = "Created the infrastructure for the %s environment."
+	fmtStreamEnvFailed       = "Failed to create the infrastructure for the %s environment.\n"
+	fmtStreamEnvComplete     = "Created the infrastructure for the %s environment.\n"
 	fmtAddEnvToAppStart      = "Linking account %s and region %s to application %s."
-	fmtAddEnvToAppFailed     = "Failed to link account %s and region %s to application %s."
-	fmtAddEnvToAppComplete   = "Linked account %s and region %s application %s."
+	fmtAddEnvToAppFailed     = "Failed to link account %s and region %s to application %s.\n"
+	fmtAddEnvToAppComplete   = "Linked account %s and region %s application %s.\n"
 )
 
 var (
@@ -167,7 +168,7 @@ func (o *initEnvOpts) Execute() error {
 		return fmt.Errorf("store environment: %w", err)
 	}
 	log.Successf("Created environment %s in region %s under application %s.\n",
-		color.HighlightUserInput(env.Name), color.HighlightResource(env.Region), color.HighlightResource(env.App))
+		color.HighlightUserInput(env.Name), color.Emphasize(env.Region), color.HighlightUserInput(env.App))
 	return nil
 }
 
@@ -191,9 +192,8 @@ func (o *initEnvOpts) deployEnv(app *config.Application) error {
 		var existsErr *cloudformation.ErrStackAlreadyExists
 		if errors.As(err, &existsErr) {
 			// Do nothing if the stack already exists.
-			o.prog.Stop("")
-			log.Successf("CloudFormation stack for env %s already exists under application %s! Do nothing.\n",
-				color.HighlightUserInput(o.EnvName), color.HighlightResource(o.AppName()))
+			o.prog.Stop(log.Ssuccessf(fmtDeployEnvComplete,
+				color.HighlightUserInput(o.EnvName), color.HighlightUserInput(o.AppName())))
 			return nil
 		}
 		o.prog.Stop(log.Serrorf(fmtDeployEnvFailed, color.HighlightUserInput(o.EnvName)))
@@ -217,12 +217,12 @@ func (o *initEnvOpts) deployEnv(app *config.Application) error {
 }
 
 func (o *initEnvOpts) addToStackset(app *config.Application, env *config.Environment) error {
-	o.prog.Start(fmt.Sprintf(fmtAddEnvToAppStart, color.HighlightResource(env.AccountID), color.HighlightResource(env.Region), color.HighlightUserInput(o.AppName())))
+	o.prog.Start(fmt.Sprintf(fmtAddEnvToAppStart, color.Emphasize(env.AccountID), color.Emphasize(env.Region), color.HighlightUserInput(o.AppName())))
 	if err := o.appDeployer.AddEnvToApp(app, env); err != nil {
-		o.prog.Stop(log.Serrorf(fmtAddEnvToAppFailed, color.HighlightResource(env.AccountID), color.HighlightResource(env.Region), color.HighlightUserInput(o.AppName())))
+		o.prog.Stop(log.Serrorf(fmtAddEnvToAppFailed, color.Emphasize(env.AccountID), color.Emphasize(env.Region), color.HighlightUserInput(o.AppName())))
 		return fmt.Errorf("deploy env %s to application %s: %w", env.Name, app.Name, err)
 	}
-	o.prog.Stop(log.Ssuccessf(fmtAddEnvToAppComplete, color.HighlightResource(env.AccountID), color.HighlightResource(env.Region), color.HighlightUserInput(o.AppName())))
+	o.prog.Stop(log.Ssuccessf(fmtAddEnvToAppComplete, color.Emphasize(env.AccountID), color.Emphasize(env.Region), color.HighlightUserInput(o.AppName())))
 
 	return nil
 }

--- a/internal/pkg/cli/env_init_test.go
+++ b/internal/pkg/cli/env_init_test.go
@@ -453,7 +453,7 @@ func TestInitEnvOpts_Execute(t *testing.T) {
 			},
 			expectProgress: func(m *mocks.Mockprogress) {
 				m.EXPECT().Start(fmt.Sprintf(fmtDeployEnvStart, "test"))
-				m.EXPECT().Stop("")
+				m.EXPECT().Stop(log.Ssuccessf(fmtDeployEnvComplete, "test", "phonetool"))
 				m.EXPECT().Start(fmt.Sprintf(fmtAddEnvToAppStart, "1234", "mars-1", "phonetool"))
 				m.EXPECT().Stop(log.Ssuccessf(fmtAddEnvToAppComplete, "1234", "mars-1", "phonetool"))
 			},

--- a/internal/pkg/cli/init.go
+++ b/internal/pkg/cli/init.go
@@ -175,9 +175,9 @@ func newInitOpts(vars initVars) (*initOpts, error) {
 // Run executes "app init", "env init", "svc init" and "svc deploy".
 func (o *initOpts) Run() error {
 	log.Warningln("It's best to run this command in the root of your Git repository.")
-	log.Infoln(`Welcome to the Copilot CLI! We're going to walk you through some questions
+	log.Infoln(color.Help(`Welcome to the Copilot CLI! We're going to walk you through some questions
 to help you get set up with an application on ECS. An application is a collection of
-containerized services that operate together.`)
+containerized services that operate together.`))
 	log.Infoln()
 
 	if err := o.loadApp(); err != nil {
@@ -189,7 +189,7 @@ containerized services that operate together.`)
 
 	log.Infof("Ok great, we'll set up a %s named %s in application %s listening on port %s.\n",
 		color.HighlightUserInput(*o.svcType), color.HighlightUserInput(*o.svcName), color.HighlightUserInput(*o.appName), color.HighlightUserInput(fmt.Sprintf("%d", *o.svcPort)))
-
+	log.Infoln()
 	if err := o.initAppCmd.Execute(); err != nil {
 		return fmt.Errorf("execute app init: %w", err)
 	}
@@ -236,6 +236,7 @@ func (o *initOpts) deployEnv() error {
 		return nil
 	}
 
+	log.Infoln()
 	return o.initEnvCmd.Execute()
 }
 
@@ -255,7 +256,7 @@ func (o *initOpts) deploySvc() error {
 }
 
 func (o *initOpts) askShouldDeploy() error {
-	v, err := o.prompt.Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt)
+	v, err := o.prompt.Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt, prompt.WithFinalMessage("Deploy:"))
 	if err != nil {
 		return fmt.Errorf("failed to confirm deployment: %w", err)
 	}

--- a/internal/pkg/cli/init_test.go
+++ b/internal/pkg/cli/init_test.go
@@ -83,7 +83,7 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 				opts.initSvcCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 
-				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt).
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt, gomock.Any()).
 					Return(true, nil)
 				opts.initEnvCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 				opts.deploySvcCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
@@ -101,7 +101,7 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 				opts.initSvcCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 
-				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt).
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt, gomock.Any()).
 					Return(true, nil)
 				opts.initEnvCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 				opts.deploySvcCmd.(*climocks.MockactionCommand).EXPECT().Ask().Return(nil)
@@ -119,7 +119,7 @@ func TestInitOpts_Run(t *testing.T) {
 				opts.initAppCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 				opts.initSvcCmd.(*climocks.MockactionCommand).EXPECT().Execute().Return(nil)
 
-				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt).
+				opts.prompt.(*climocks.Mockprompter).EXPECT().Confirm(initShouldDeployPrompt, initShouldDeployHelpPrompt, gomock.Any()).
 					Return(false, nil)
 			},
 		},

--- a/internal/pkg/cli/mocks/mock_prompter.go
+++ b/internal/pkg/cli/mocks/mock_prompter.go
@@ -34,10 +34,10 @@ func (m *Mockprompter) EXPECT() *MockprompterMockRecorder {
 }
 
 // Get mocks base method
-func (m *Mockprompter) Get(message, help string, validator prompt.ValidatorFunc, opts ...prompt.GetOption) (string, error) {
+func (m *Mockprompter) Get(message, help string, validator prompt.ValidatorFunc, promptOpts ...prompt.Option) (string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{message, help, validator}
-	for _, a := range opts {
+	for _, a := range promptOpts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Get", varargs...)
@@ -47,47 +47,57 @@ func (m *Mockprompter) Get(message, help string, validator prompt.ValidatorFunc,
 }
 
 // Get indicates an expected call of Get
-func (mr *MockprompterMockRecorder) Get(message, help, validator interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockprompterMockRecorder) Get(message, help, validator interface{}, promptOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{message, help, validator}, opts...)
+	varargs := append([]interface{}{message, help, validator}, promptOpts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*Mockprompter)(nil).Get), varargs...)
 }
 
 // GetSecret mocks base method
-func (m *Mockprompter) GetSecret(message, help string) (string, error) {
+func (m *Mockprompter) GetSecret(message, help string, promptOpts ...prompt.Option) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecret", message, help)
+	varargs := []interface{}{message, help}
+	for _, a := range promptOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSecret", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecret indicates an expected call of GetSecret
-func (mr *MockprompterMockRecorder) GetSecret(message, help interface{}) *gomock.Call {
+func (mr *MockprompterMockRecorder) GetSecret(message, help interface{}, promptOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*Mockprompter)(nil).GetSecret), message, help)
+	varargs := append([]interface{}{message, help}, promptOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*Mockprompter)(nil).GetSecret), varargs...)
 }
 
 // SelectOne mocks base method
-func (m *Mockprompter) SelectOne(message, help string, options []string) (string, error) {
+func (m *Mockprompter) SelectOne(message, help string, options []string, promptOpts ...prompt.Option) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectOne", message, help, options)
+	varargs := []interface{}{message, help, options}
+	for _, a := range promptOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SelectOne", varargs...)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SelectOne indicates an expected call of SelectOne
-func (mr *MockprompterMockRecorder) SelectOne(message, help, options interface{}) *gomock.Call {
+func (mr *MockprompterMockRecorder) SelectOne(message, help, options interface{}, promptOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*Mockprompter)(nil).SelectOne), message, help, options)
+	varargs := append([]interface{}{message, help, options}, promptOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*Mockprompter)(nil).SelectOne), varargs...)
 }
 
 // Confirm mocks base method
-func (m *Mockprompter) Confirm(message, help string, options ...prompt.ConfirmOption) (bool, error) {
+func (m *Mockprompter) Confirm(message, help string, promptOpts ...prompt.Option) (bool, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{message, help}
-	for _, a := range options {
+	for _, a := range promptOpts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Confirm", varargs...)
@@ -97,8 +107,8 @@ func (m *Mockprompter) Confirm(message, help string, options ...prompt.ConfirmOp
 }
 
 // Confirm indicates an expected call of Confirm
-func (mr *MockprompterMockRecorder) Confirm(message, help interface{}, options ...interface{}) *gomock.Call {
+func (mr *MockprompterMockRecorder) Confirm(message, help interface{}, promptOpts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{message, help}, options...)
+	varargs := append([]interface{}{message, help}, promptOpts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Confirm", reflect.TypeOf((*Mockprompter)(nil).Confirm), varargs...)
 }

--- a/internal/pkg/cli/prompter.go
+++ b/internal/pkg/cli/prompter.go
@@ -6,8 +6,8 @@ package cli
 import "github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/prompt"
 
 type prompter interface {
-	Get(message, help string, validator prompt.ValidatorFunc, opts ...prompt.GetOption) (string, error)
-	GetSecret(message, help string) (string, error)
-	SelectOne(message, help string, options []string) (string, error)
-	Confirm(message, help string, options ...prompt.ConfirmOption) (bool, error)
+	Get(message, help string, validator prompt.ValidatorFunc, promptOpts ...prompt.Option) (string, error)
+	GetSecret(message, help string, promptOpts ...prompt.Option) (string, error)
+	SelectOne(message, help string, options []string, promptOpts ...prompt.Option) (string, error)
+	Confirm(message, help string, promptOpts ...prompt.Option) (bool, error)
 }

--- a/internal/pkg/cli/selector/selector.go
+++ b/internal/pkg/cli/selector/selector.go
@@ -11,12 +11,13 @@ import (
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/prompt"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
 )
 
 // Prompter wraps the method for users to select an option from a list of options.
 type Prompter interface {
-	SelectOne(message, help string, options []string) (string, error)
+	SelectOne(message, help string, options []string, promptOpts ...prompt.Option) (string, error)
 }
 
 type appEnvLister interface {

--- a/internal/pkg/cli/svc_deploy.go
+++ b/internal/pkg/cli/svc_deploy.go
@@ -429,10 +429,10 @@ func (o *deploySvcOpts) deploySvc(addonsURL string) error {
 			color.HighlightUserInput(o.targetEnvironment.Name)))
 
 	if err := o.svcCFN.DeployService(conf, awscloudformation.WithRoleARN(o.targetEnvironment.ExecutionRoleARN)); err != nil {
-		o.spinner.Stop("Error!")
+		o.spinner.Stop(log.Serrorf("Failed to deploy service.\n"))
 		return fmt.Errorf("deploy service: %w", err)
 	}
-	o.spinner.Stop("")
+	o.spinner.Stop("\n")
 	return nil
 }
 

--- a/internal/pkg/cli/svc_init_test.go
+++ b/internal/pkg/cli/svc_init_test.go
@@ -116,7 +116,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq("Which type of infrastructure pattern best represents your service?"), gomock.Any(), gomock.Eq(manifest.ServiceTypes)).
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitSvcTypePrompt, "service type")), gomock.Any(), gomock.Eq(manifest.ServiceTypes), gomock.Any()).
 					Return(wantedSvcType, nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -130,7 +130,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Eq(manifest.ServiceTypes)).
+				m.EXPECT().SelectOne(gomock.Any(), gomock.Any(), gomock.Eq(manifest.ServiceTypes), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -144,7 +144,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(fmt.Sprintf("What do you want to name this %s?", wantedSvcType)), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf("What do you want to name this %s?", wantedSvcType)), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(wantedSvcName, nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -158,7 +158,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -179,12 +179,12 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitDockerfilePrompt, wantedSvcName)), svcInitDockerfileHelpPrompt, gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitDockerfilePrompt, "Dockerfile", wantedSvcName)), svcInitDockerfileHelpPrompt, gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",
 						"frontend/Dockerfile",
-					})).
+					}), gomock.Any()).
 					Return("frontend/Dockerfile", nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -217,12 +217,12 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 				afero.WriteFile(mockFS, "backend/Dockerfile", []byte("FROM nginx"), 0644)
 			},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitDockerfilePrompt, wantedSvcName)), gomock.Any(), gomock.Eq(
+				m.EXPECT().SelectOne(gomock.Eq(fmt.Sprintf(fmtSvcInitDockerfilePrompt, "Dockerfile", wantedSvcName)), gomock.Any(), gomock.Eq(
 					[]string{
 						"./Dockerfile",
 						"backend/Dockerfile",
 						"frontend/Dockerfile",
-					})).
+					}), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {},
@@ -236,7 +236,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(svcInitSvcPortPrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(svcInitSvcPortPrompt, "port")), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(defaultSvcPortString, nil)
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
@@ -252,7 +252,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(svcInitSvcPortPrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(svcInitSvcPortPrompt, "port")), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {
@@ -268,7 +268,7 @@ func TestSvcInitOpts_Ask(t *testing.T) {
 
 			mockFileSystem: func(mockFS afero.Fs) {},
 			mockPrompt: func(m *mocks.Mockprompter) {
-				m.EXPECT().Get(gomock.Eq(svcInitSvcPortPrompt), gomock.Any(), gomock.Any(), gomock.Any()).
+				m.EXPECT().Get(gomock.Eq(fmt.Sprintf(svcInitSvcPortPrompt, "port")), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return("100000", errors.New("some error"))
 			},
 			mockDockerfile: func(m *mocks.MockdockerfileParser) {

--- a/internal/pkg/term/color/color.go
+++ b/internal/pkg/term/color/color.go
@@ -20,10 +20,11 @@ var (
 	Red          = color.New(color.FgHiRed)
 	Green        = color.New(color.FgHiGreen)
 	Yellow       = color.New(color.FgHiYellow)
+	HiBlue       = color.New(color.FgHiBlue)
 	Cyan         = color.New(color.FgCyan)
 	HiCyan       = color.New(color.FgHiCyan)
 	Bold         = color.New(color.Bold)
-	BoldItalic   = color.New(color.Bold).Add(color.Italic)
+	Faint        = color.New(color.Faint)
 	BoldFgYellow = color.New(color.FgYellow).Add(color.Bold)
 )
 
@@ -53,19 +54,24 @@ func DisableColorBasedOnEnvVar() {
 	}
 }
 
+// Help colors the string to denote that it's auxiliary helpful information, and returns it.
+func Help(s string) string {
+	return Faint.Sprint(s)
+}
+
 // Emphasize colors the string to denote that it as important, and returns it.
 func Emphasize(s string) string {
-	return BoldItalic.Sprint(s)
+	return Bold.Sprint(s)
 }
 
 // HighlightUserInput colors the string to denote it as an input from standard input, and returns it.
 func HighlightUserInput(s string) string {
-	return Cyan.Sprint(s)
+	return Emphasize(s)
 }
 
 // HighlightResource colors the string to denote it as a resource created by the CLI, and returns it.
 func HighlightResource(s string) string {
-	return HiCyan.Sprint(s)
+	return HiBlue.Sprint(s)
 }
 
 // HighlightCode wraps the string with the ` character, colors it to denote it's a code block, and returns it.

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -8,53 +8,77 @@ package prompt
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 )
 
 func init() {
-	survey.ConfirmQuestionTemplate = `
-{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+	survey.ConfirmQuestionTemplate = `{{if not .Answer}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }}{{$lines := split .Help "\n"}}{{range $i, $line := $lines}}
+{{- if eq $i 0}}  {{ $line }}
+{{ else }}  {{ $line }}
+{{ end }}{{- end }}{{color "reset"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{if not .Answer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
 {{- color "default"}}{{ .Message }} {{color "reset"}}
 {{- if .Answer}}
-  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+  {{- color "default"}}{{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
-  {{- color "cyan"}}{{if .Default}}(Y/n) {{else}}(y/N) {{end}}{{color "reset"}}
+  {{- color "default"}}{{if .Default}}(Y/n) {{else}}(y/N) {{end}}{{color "reset"}}
 {{- end}}`
 
-	survey.SelectQuestionTemplate = `
-{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+	survey.SelectQuestionTemplate = `{{if not .Answer}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }}{{$lines := split .Help "\n"}}{{range $i, $line := $lines}}
+{{- if eq $i 0}}  {{ $line }}
+{{ else }}  {{ $line }}
+{{ end }}{{- end }}{{color "reset"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{if not .ShowAnswer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
 {{- color "default"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
-{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- if .ShowAnswer}}{{color "default"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
   {{- "  "}}{{- color "white"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
-    {{- if eq $ix $.SelectedIndex }}{{color "cyan+b" }}{{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}  {{end}}
+    {{- if eq $ix $.SelectedIndex }}{{color "default+b" }}  {{ $.Config.Icons.SelectFocus.Text }} {{else}}{{color "default"}}    {{end}}
     {{- $choice.Value}}
     {{- color "reset"}}{{"\n"}}
   {{- end}}
 {{- end}}`
 
-	survey.InputQuestionTemplate = `
-{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+	survey.InputQuestionTemplate = `{{if not .Answer}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }}{{$lines := split .Help "\n"}}{{range $i, $line := $lines}}
+{{- if eq $i 0}}  {{ $line }}
+{{ else }}  {{ $line }}
+{{ end }}{{- end }}{{color "reset"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{if not .ShowAnswer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
 {{- color "default"}}{{ .Message }} {{color "reset"}}
 {{- if .ShowAnswer}}
-  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+  {{- color "default"}}{{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
   {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ print .Config.HelpInput }} for help]{{color "reset"}} {{end}}
-  {{- if .Default}}{{color "cyan"}}({{.Default}}) {{color "reset"}}{{end}}
+  {{- if .Default}}{{color "default"}}({{.Default}}) {{color "reset"}}{{end}}
 {{- end}}`
 
-	survey.PasswordQuestionTemplate = `
-{{ if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
+	survey.PasswordQuestionTemplate = `{{if not .Answer}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }}{{$lines := split .Help "\n"}}{{range $i, $line := $lines}}
+{{- if eq $i 0}}  {{ $line }}
+{{ else }}  {{ $line }}
+{{ end }}{{- end }}{{color "reset"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{if not .ShowAnswer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
 {{- color "default"}}{{ .Message }} {{color "reset"}}
 {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}`
+
+	core.TemplateFuncs["split"] = func(s string, sep string) []string {
+		return strings.Split(s, sep)
+	}
 }
 
 // ErrEmptyOptions indicates the input options list was empty.
@@ -66,18 +90,57 @@ type Prompt func(survey.Prompt, interface{}, ...survey.AskOpt) error
 // ValidatorFunc defines the function signature for validating inputs.
 type ValidatorFunc func(interface{}) error
 
-// New returns an Prompt with default configuration.
+// New returns a Prompt with default configuration.
 func New() Prompt {
 	return survey.AskOne
 }
 
-// Get prompts the user for free-form text input.
-func (p Prompt) Get(message, help string, validator ValidatorFunc, opts ...GetOption) (string, error) {
-	prompt := &survey.Input{
-		Message: message,
-		Help:    help,
+type prompter interface {
+	Prompt(config *survey.PromptConfig) (interface{}, error)
+	Cleanup(*survey.PromptConfig, interface{}) error
+	Error(*survey.PromptConfig, error) error
+	WithStdio(terminal.Stdio)
+}
+
+type prompt struct {
+	prompter
+	FinalMessage string // Text to display after the user selects an answer.
+}
+
+// Cleanup does a final render with the user's chosen value.
+// This method overrides survey.Select's Cleanup method by assigning the prompt's message to be the final message.
+func (p *prompt) Cleanup(config *survey.PromptConfig, val interface{}) error {
+	if p.FinalMessage == "" {
+		return p.prompter.Cleanup(config, val) // Delegate to the parent Cleanup.
 	}
-	for _, opt := range opts {
+
+	// Update the message of the underlying struct.
+	switch typedPrompt := p.prompter.(type) {
+	case *survey.Select:
+		typedPrompt.Message = p.FinalMessage
+	case *survey.Input:
+		typedPrompt.Message = p.FinalMessage
+	case *survey.Password:
+		typedPrompt.Message = p.FinalMessage
+	case *survey.Confirm:
+		typedPrompt.Message = p.FinalMessage
+	}
+	return p.prompter.Cleanup(config, val)
+}
+
+// Get prompts the user for free-form text input.
+func (p Prompt) Get(message, help string, validator ValidatorFunc, promptOpts ...Option) (string, error) {
+	input := &survey.Input{
+		Message: message,
+	}
+	if help != "" {
+		input.Help = color.Help(help)
+	}
+
+	prompt := &prompt{
+		prompter: input,
+	}
+	for _, opt := range promptOpts {
 		opt(prompt)
 	}
 
@@ -86,73 +149,101 @@ func (p Prompt) Get(message, help string, validator ValidatorFunc, opts ...GetOp
 	return result, err
 }
 
-// GetOption is a functional option to modify the Get prompt.
-type GetOption func(*survey.Input)
-
-// WithDefaultInput sets a default message for the input.
-func WithDefaultInput(s string) GetOption {
-	return func(input *survey.Input) {
-		input.Default = s
-	}
-}
-
 // GetSecret prompts the user for sensitive input. Wraps survey.Password
-func (p Prompt) GetSecret(message, help string) (string, error) {
-	prompt := &survey.Password{
+func (p Prompt) GetSecret(message, help string, promptOpts ...Option) (string, error) {
+	passwd := &survey.Password{
 		Message: message,
-		Help:    help,
+	}
+	if help != "" {
+		passwd.Help = color.Help(help)
+	}
+
+	prompt := &prompt{
+		prompter: passwd,
+	}
+	for _, opt := range promptOpts {
+		opt(prompt)
 	}
 
 	var result string
-
 	err := p(prompt, &result, stdio(), icons())
-
 	return result, err
 }
 
 // SelectOne prompts the user with a list of options to choose from with the arrow keys.
-func (p Prompt) SelectOne(message, help string, options []string) (string, error) {
+func (p Prompt) SelectOne(message, help string, options []string, promptOpts ...Option) (string, error) {
 	if len(options) <= 0 {
 		return "", ErrEmptyOptions
 	}
 
-	prompt := &survey.Select{
+	sel := &survey.Select{
 		Message: message,
-		Help:    help,
 		Options: options,
 		// TODO: we can expose this if we want to enable consumers to set an explicit default.
 		Default: options[0],
 	}
+	if help != "" {
+		sel.Help = color.Help(help)
+	}
+
+	prompt := &prompt{
+		prompter: sel,
+	}
+	for _, opt := range promptOpts {
+		opt(prompt)
+	}
 
 	var result string
-
 	err := p(prompt, &result, stdio(), icons())
-
 	return result, err
 }
 
-type ConfirmOption func(*survey.Confirm)
-
 // Confirm prompts the user with a yes/no option.
-func (p Prompt) Confirm(message, help string, opts ...ConfirmOption) (bool, error) {
-	prompt := &survey.Confirm{
+func (p Prompt) Confirm(message, help string, promptOpts ...Option) (bool, error) {
+	confirm := &survey.Confirm{
 		Message: message,
-		Help:    help,
 	}
-	for _, option := range opts {
+	if help != "" {
+		confirm.Help = color.Help(help)
+	}
+
+	prompt := &prompt{
+		prompter: confirm,
+	}
+	for _, option := range promptOpts {
 		option(prompt)
 	}
 
 	var result bool
-
 	err := p(prompt, &result, stdio(), icons())
-
 	return result, err
 }
 
-func WithTrueDefault() ConfirmOption {
-	return func(confirm *survey.Confirm) {
-		confirm.Default = true
+// Option is a functional option to configure the prompt.
+type Option func(*prompt)
+
+// WithDefaultInput sets a default message for an input prompt.
+func WithDefaultInput(s string) Option {
+	return func(p *prompt) {
+		if get, ok := p.prompter.(*survey.Input); ok {
+			get.Default = s
+		}
+	}
+}
+
+// WithFinalMessage sets a final message that replaces the question prompt once the user enters an answer.
+func WithFinalMessage(msg string) Option {
+	return func(p *prompt) {
+		p.FinalMessage = color.Emphasize(msg)
+	}
+}
+
+// WithTrueDefault sets the default for a confirm prompt to true.
+func WithTrueDefault() Option {
+	return func(p *prompt) {
+		if confirm, ok := p.prompter.(*survey.Confirm); ok {
+			confirm.Default = true
+		}
 	}
 }
 
@@ -162,11 +253,14 @@ func stdio() survey.AskOpt {
 
 func icons() survey.AskOpt {
 	return survey.WithIcons(func(icons *survey.IconSet) {
-		// The question mark "?" icon to denote a prompt will be colored in bold cyan.
-		icons.Question.Format = "cyan+b"
-		// Help text shown when user presses "?" will have the inverse color "i" and be surrounded by a background box ":default" of default text color.
-		// For example, if your terminal background is white with black text, the help text will have a black background with white text.
-		icons.Help.Format = "default+i:default"
+		// The question mark "?" icon to denote a prompt will be colored in bold.
+		icons.Question.Text = ""
+		icons.Question.Format = "default+b"
+
+		// Survey uses https://github.com/mgutz/ansi to set colors which unfortunately doesn't support the "Faint" style.
+		// We are setting the help text to be fainted in the individual prompt methods instead.
+		icons.Help.Text = ""
+		icons.Help.Format = "default"
 	})
 }
 

--- a/internal/pkg/term/prompt/prompt_test.go
+++ b/internal/pkg/term/prompt/prompt_test.go
@@ -11,26 +11,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGet(t *testing.T) {
+func TestPrompt_Get(t *testing.T) {
 	mockError := fmt.Errorf("error")
 	mockInput := "yes"
+	mockDefaultInput := "yes"
 	mockMessage := "mockMessage"
 	mockHelpMessage := "mockHelpMessage"
+	mockFinalMessage := "mockFinalMessage"
 
 	testCases := map[string]struct {
-		mockPrompter      Prompt
-		mockValidatorFunc ValidatorFunc
+		inValidator ValidatorFunc
+		inPrompt    Prompt
 
 		wantValue string
 		wantError error
 	}{
 		"should return users input": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
-				internalPrompt, ok := p.(*survey.Input)
-
-				require.True(t, ok, "input prompt should be type *survey.Input")
-				require.Equal(t, mockMessage, internalPrompt.Message)
-				require.Equal(t, mockHelpMessage, internalPrompt.Help)
+			inValidator: func(ans interface{}) error {
+				return nil
+			},
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				internalPrompt, ok := p.(*prompt)
+				require.True(t, ok, "input prompt should be type *prompt")
+				require.Equal(t, mockFinalMessage, internalPrompt.FinalMessage)
+				input, ok := internalPrompt.prompter.(*survey.Input)
+				require.True(t, ok, "internal prompt should be type *survey.Input")
+				require.Equal(t, mockMessage, input.Message)
+				require.Equal(t, mockHelpMessage, input.Help)
+				require.Equal(t, mockDefaultInput, input.Default)
 
 				result, ok := out.(*string)
 
@@ -42,14 +50,11 @@ func TestGet(t *testing.T) {
 
 				return nil
 			},
-			mockValidatorFunc: func(ans interface{}) error {
-				return nil
-			},
 			wantValue: mockInput,
 			wantError: nil,
 		},
 		"should echo error": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
 				return mockError
 			},
 			wantError: mockError,
@@ -58,7 +63,8 @@ func TestGet(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotValue, gotError := tc.mockPrompter.Get(mockMessage, mockHelpMessage, nil)
+			gotValue, gotError := tc.inPrompt.Get(mockMessage, mockHelpMessage, tc.inValidator,
+				WithDefaultInput(mockDefaultInput), WithFinalMessage(mockFinalMessage))
 
 			require.Equal(t, tc.wantValue, gotValue)
 			require.Equal(t, tc.wantError, gotError)
@@ -66,57 +72,52 @@ func TestGet(t *testing.T) {
 	}
 }
 
-func TestSelectOne(t *testing.T) {
+func TestPrompt_GetSecret(t *testing.T) {
 	mockError := fmt.Errorf("error")
-	mockMessage := "Which droid is best droid?"
-	mockHelpMessage := "All the droids."
+	mockMessage := "What's your super secret password?"
+	mockSecret := "password"
 
 	testCases := map[string]struct {
-		mockPrompter Prompt
-		mockOptions  []string
+		inPrompt Prompt
 
 		wantValue string
 		wantError error
 	}{
-		"should return users input": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
-				internalPrompt, ok := p.(*survey.Select)
+		"should return true": {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				internalPrompt, ok := p.(*prompt)
+				require.True(t, ok, "input prompt should be type *prompt")
+				require.Empty(t, internalPrompt.FinalMessage)
 
-				require.True(t, ok, "input prompt should be type *survey.Select")
-				require.Equal(t, mockMessage, internalPrompt.Message)
-				require.Equal(t, mockHelpMessage, internalPrompt.Help)
-				require.NotEmpty(t, internalPrompt.Options)
+				passwd, ok := internalPrompt.prompter.(*survey.Password)
+				require.True(t, ok, "internal prompt should be type *survey.Password")
+				require.Equal(t, mockMessage, passwd.Message)
+				require.Empty(t, passwd.Help)
 
 				result, ok := out.(*string)
 
 				require.True(t, ok, "type to write user input to should be a string")
 
-				*result = internalPrompt.Options[0]
+				*result = mockSecret
 
 				require.Equal(t, 2, len(opts))
 
 				return nil
 			},
-			mockOptions: []string{"r2d2", "c3po", "bb8"},
-			wantValue:   "r2d2",
-			wantError:   nil,
+			wantValue: mockSecret,
+			wantError: nil,
 		},
 		"should echo error": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
 				return mockError
 			},
-			mockOptions: []string{"apple", "orange", "banana"},
-			wantError:   mockError,
-		},
-		"should return error if input options list is empty": {
-			mockOptions: []string{},
-			wantError:   ErrEmptyOptions,
+			wantError: mockError,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotValue, gotError := tc.mockPrompter.SelectOne(mockMessage, mockHelpMessage, tc.mockOptions)
+			gotValue, gotError := tc.inPrompt.GetSecret(mockMessage, "")
 
 			require.Equal(t, tc.wantValue, gotValue)
 			require.Equal(t, tc.wantError, gotError)
@@ -124,24 +125,89 @@ func TestSelectOne(t *testing.T) {
 	}
 }
 
-func TestConfirm(t *testing.T) {
+func TestPrompt_SelectOne(t *testing.T) {
+	mockError := fmt.Errorf("error")
+	mockMessage := "Which droid is best droid?"
+
+	testCases := map[string]struct {
+		inPrompt Prompt
+		inOpts   []string
+
+		wantValue string
+		wantError error
+	}{
+		"should return users input": {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				internalPrompt, ok := p.(*prompt)
+				require.True(t, ok, "input prompt should be type *prompt")
+				require.Empty(t, internalPrompt.FinalMessage)
+
+				sel, ok := internalPrompt.prompter.(*survey.Select)
+				require.True(t, ok, "internal prompt should be type *survey.Select")
+				require.Equal(t, mockMessage, sel.Message)
+				require.Empty(t, sel.Help)
+				require.NotEmpty(t, sel.Options)
+
+				result, ok := out.(*string)
+
+				require.True(t, ok, "type to write user input to should be a string")
+
+				*result = sel.Options[0]
+
+				require.Equal(t, 2, len(opts))
+
+				return nil
+			},
+			inOpts:    []string{"r2d2", "c3po", "bb8"},
+			wantValue: "r2d2",
+			wantError: nil,
+		},
+		"should echo error": {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				return mockError
+			},
+			inOpts:    []string{"apple", "orange", "banana"},
+			wantError: mockError,
+		},
+		"should return error if input options list is empty": {
+			inOpts:    []string{},
+			wantError: ErrEmptyOptions,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotValue, gotError := tc.inPrompt.SelectOne(mockMessage, "", tc.inOpts)
+
+			require.Equal(t, tc.wantValue, gotValue)
+			require.Equal(t, tc.wantError, gotError)
+		})
+	}
+}
+
+func TestPrompt_Confirm(t *testing.T) {
 	mockError := fmt.Errorf("error")
 	mockMessage := "Is devx awesome?"
 	mockHelpMessage := "Yes."
+	mockFinalMessage := "Awesome"
 
 	testCases := map[string]struct {
-		mockPrompter Prompt
+		inPrompt Prompt
 
 		wantValue bool
 		wantError error
 	}{
 		"should return true": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
-				internalPrompt, ok := p.(*survey.Confirm)
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				internalPrompt, ok := p.(*prompt)
+				require.True(t, ok, "input prompt should be type *prompt")
+				require.Equal(t, mockFinalMessage, internalPrompt.FinalMessage)
 
-				require.True(t, ok, "input prompt should be type *survey.Confirm")
-				require.Equal(t, mockMessage, internalPrompt.Message)
-				require.Equal(t, mockHelpMessage, internalPrompt.Help)
+				confirm, ok := internalPrompt.prompter.(*survey.Confirm)
+				require.True(t, ok, "internal prompt should be type *survey.Confirm")
+				require.Equal(t, mockMessage, confirm.Message)
+				require.Equal(t, mockHelpMessage, confirm.Help)
+				require.True(t, confirm.Default)
 
 				result, ok := out.(*bool)
 
@@ -157,7 +223,7 @@ func TestConfirm(t *testing.T) {
 			wantError: nil,
 		},
 		"should echo error": {
-			mockPrompter: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
 				return mockError
 			},
 			wantError: mockError,
@@ -166,7 +232,8 @@ func TestConfirm(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotValue, gotError := tc.mockPrompter.Confirm(mockMessage, mockHelpMessage)
+			gotValue, gotError := tc.inPrompt.Confirm(mockMessage, mockHelpMessage,
+				WithTrueDefault(), WithFinalMessage(mockFinalMessage))
 
 			require.Equal(t, tc.wantValue, gotValue)
 			require.Equal(t, tc.wantError, gotError)


### PR DESCRIPTION
1. We introduce a new WithFinalMessage() option in the "prompt" package to
collapse our long prompt messages to a short final message once the user
answers the prompt.
2. Prompts are now indented to signal that we're asking a user
question.
3. Combined a lot of our logs as they made it hard to read what was
actually created.
4. Changed our colorscheme to be monochrome except when we create a
resource or print code.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
