### PR TITLE
feat(storage): Add temporary execute method to storage init

### DIFF
--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -231,6 +231,10 @@ type wsAppManager interface {
 	Summary() (*workspace.Summary, error)
 }
 
+type wsAddonWriter interface {
+	WriteAddon(f encoding.BinaryMarshaler, svcName string, path string)
+}
+
 type artifactUploader interface {
 	PutArtifact(bucket, fileName string, data io.Reader) (string, error)
 }

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -232,7 +232,7 @@ type wsAppManager interface {
 }
 
 type wsAddonWriter interface {
-	WriteAddon(f encoding.BinaryMarshaler, svc, path string)
+	WriteAddon(f encoding.BinaryMarshaler, svc, path string) (string, error)
 }
 
 type artifactUploader interface {

--- a/internal/pkg/cli/interfaces.go
+++ b/internal/pkg/cli/interfaces.go
@@ -232,7 +232,7 @@ type wsAppManager interface {
 }
 
 type wsAddonWriter interface {
-	WriteAddon(f encoding.BinaryMarshaler, svcName string, path string)
+	WriteAddon(f encoding.BinaryMarshaler, svc, path string)
 }
 
 type artifactUploader interface {

--- a/internal/pkg/cli/mocks/mock_interfaces.go
+++ b/internal/pkg/cli/mocks/mock_interfaces.go
@@ -2173,6 +2173,44 @@ func (mr *MockwsAppManagerMockRecorder) Summary() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Summary", reflect.TypeOf((*MockwsAppManager)(nil).Summary))
 }
 
+// MockwsAddonWriter is a mock of wsAddonWriter interface
+type MockwsAddonWriter struct {
+	ctrl     *gomock.Controller
+	recorder *MockwsAddonWriterMockRecorder
+}
+
+// MockwsAddonWriterMockRecorder is the mock recorder for MockwsAddonWriter
+type MockwsAddonWriterMockRecorder struct {
+	mock *MockwsAddonWriter
+}
+
+// NewMockwsAddonWriter creates a new mock instance
+func NewMockwsAddonWriter(ctrl *gomock.Controller) *MockwsAddonWriter {
+	mock := &MockwsAddonWriter{ctrl: ctrl}
+	mock.recorder = &MockwsAddonWriterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockwsAddonWriter) EXPECT() *MockwsAddonWriterMockRecorder {
+	return m.recorder
+}
+
+// WriteAddon mocks base method
+func (m *MockwsAddonWriter) WriteAddon(f encoding.BinaryMarshaler, svc, path string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteAddon", f, svc, path)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteAddon indicates an expected call of WriteAddon
+func (mr *MockwsAddonWriterMockRecorder) WriteAddon(f, svc, path interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAddon", reflect.TypeOf((*MockwsAddonWriter)(nil).WriteAddon), f, svc, path)
+}
+
 // MockartifactUploader is a mock of artifactUploader interface
 type MockartifactUploader struct {
 	ctrl     *gomock.Controller

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -76,10 +76,10 @@ func newStorageInitOpts(vars initStorageVars) (*initStorageOpts, error) {
 	return &initStorageOpts{
 		initStorageVars: vars,
 
-		fs:            &afero.Afero{Fs: afero.NewOsFs()},
-		store:         store,
-		ws:            ws,
-		wsAddonWriter: ws,
+		fs:          &afero.Afero{Fs: afero.NewOsFs()},
+		store:       store,
+		ws:          ws,
+		addonWriter: ws,
 	}, nil
 }
 
@@ -275,11 +275,11 @@ Name:
 		Buffer: bytes.NewBufferString(cf),
 	}
 
-	wsAddonWriter.WriteAddons(paramsOut, o.StorageSvc, "params.yaml")
-	wsAddonWriter.WriteAddons(outputOut, o.StorageSvc, "outputs.yaml")
-	wsAddonWriter.WriteAddons(policyOut, o.StorageSvc, "policy.yaml")
-	wsAddonWriter.WriteAddons(cfOut, o.StorageSvc, "s3.yaml")
-
+	o.addonWriter.WriteAddon(paramsOut, o.StorageSvc, "params.yaml")
+	o.addonWriter.WriteAddon(outputOut, o.StorageSvc, "outputs.yaml")
+	o.addonWriter.WriteAddon(policyOut, o.StorageSvc, "policy.yaml")
+	o.addonWriter.WriteAddon(cfOut, o.StorageSvc, "s3.yaml")
+	return nil
 }
 
 // Strip non-alphanumeric characters from an input string

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -154,14 +154,17 @@ func (o *initStorageOpts) askStorageName() error {
 		return nil
 	}
 	var validator func(interface{}) error
+	var friendlyText string
 	switch o.StorageType {
 	case dynamoDBStorageType:
 		validator = dynamoTableNameValidation
+		friendlyText = "DynamoDB table"
 	case s3StorageType:
 		validator = s3BucketNameValidation
+		friendlyText = "S3 Bucket"
 	}
 	name, err := o.prompt.Get(fmt.Sprintf(fmtStorageInitNamePrompt,
-		color.HighlightUserInput(o.StorageType)),
+		color.HighlightUserInput(friendlyText)),
 		storageInitNameHelp,
 		validator)
 

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -246,8 +246,7 @@ Name:
           Effect: Allow
           Action: s3:ListBucket
           Resource: !Sub ${%[1]s.Arn}`
-	cf := `
-%[2]s:
+	cf := `%[2]s:
   Type: AWS::S3::Bucket
   DeletionPolicy: Retain
   Properties:
@@ -259,7 +258,7 @@ Name:
     BucketName: !Sub '${App}-${Env}-${Name}-%[1]s'
     PublicAccessBlockConfiguration: 
       BlockPublicAcls: true
-	  BlockPublicPolicy: true`
+      BlockPublicPolicy: true`
 	logicalIdName := logicalIdSafe(o.StorageName)
 	output = fmt.Sprintf(output, logicalIdName)
 	policy = fmt.Sprintf(policy, logicalIdName)

--- a/internal/pkg/cli/storage_init.go
+++ b/internal/pkg/cli/storage_init.go
@@ -4,9 +4,11 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/config"
+	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/template"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/color"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/term/log"
 	"github.com/aws/amazon-ecs-cli-v2/internal/pkg/workspace"
@@ -52,9 +54,10 @@ type initStorageVars struct {
 type initStorageOpts struct {
 	initStorageVars
 
-	fs    afero.Fs
-	ws    wsSvcReader
-	store store
+	fs          afero.Fs
+	ws          wsSvcReader
+	addonWriter wsAddonWriter
+	store       store
 
 	app *config.Application
 }
@@ -73,9 +76,10 @@ func newStorageInitOpts(vars initStorageVars) (*initStorageOpts, error) {
 	return &initStorageOpts{
 		initStorageVars: vars,
 
-		fs:    &afero.Afero{Fs: afero.NewOsFs()},
-		store: store,
-		ws:    ws,
+		fs:            &afero.Afero{Fs: afero.NewOsFs()},
+		store:         store,
+		ws:            ws,
+		wsAddonWriter: ws,
 	}, nil
 }
 
@@ -197,6 +201,104 @@ func (o *initStorageOpts) validateServiceName() error {
 	return fmt.Errorf("service %s not found in the workspace", o.StorageSvc)
 }
 
+func (o *initStorageOpts) Execute() error {
+	params := `
+App:
+  Type: String
+  Description: Your application's name.
+Env:
+  Type: String
+  Description: The environment name your service, job, or workflow is being deployed to.
+Name:
+  Type: String
+  Description: The name of the service, job, or workflow being deployed.`
+	output := `
+%[1]sBucketName:
+  Description: "The name of a user-defined bucket."
+  Value: !Ref %[1]s
+%[1]sAccessPolicy:
+  Description: "The IAM::ManagedPolicy to attach to the task role"
+  Value: !Ref %[1]sAccessPolicy`
+	policy := `
+%[1]sAccessPolicy:
+  Type: AWS::IAM::ManagedPolicy
+  Properties:
+    Description: !Sub
+      - Grants CRUD access to the S3 bucket ${Bucket}
+      - { Bucket: !Ref %[1]s }
+    PolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Sid: S3ObjectActions
+          Effect: Allow
+          Action:
+          - s3:GetObject
+          - s3:PutObject
+          - s3:PutObjectACL
+          - s3:PutObjectTagging
+          - s3:DeleteObject
+          - s3:RestoreObject
+          Resource: !Sub ${%[1]s.Arn}/*
+        - Sid: S3ListAction
+          Effect: Allow
+          Action: s3:ListBucket
+          Resource: !Sub ${%[1]s.Arn}`
+	cf := `
+%[2]s:
+  Type: AWS::S3::Bucket
+  DeletionPolicy: Retain
+  Properties:
+    AccessControl: Private
+    BucketEncryption: 
+      ServerSideEncryptionConfiguration:
+      - ServerSideEncryptionByDefault:
+          SSEAlgorithm: AES256
+    BucketName: !Sub '${App}-${Env}-${Name}-%[1]s'
+    PublicAccessBlockConfiguration: 
+      BlockPublicAcls: true
+	  BlockPublicPolicy: true`
+	logicalIdName := logicalIdSafe(o.StorageName)
+	output = fmt.Sprintf(output, logicalIdName)
+	policy = fmt.Sprintf(policy, logicalIdName)
+	cf = fmt.Sprintf(cf, o.StorageName, logicalIdName)
+
+	paramsOut := &template.Content{
+		Buffer: bytes.NewBufferString(params),
+	}
+	outputOut := &template.Content{
+		Buffer: bytes.NewBufferString(output),
+	}
+	policyOut := &template.Content{
+		Buffer: bytes.NewBufferString(policy),
+	}
+	cfOut := &template.Content{
+		Buffer: bytes.NewBufferString(cf),
+	}
+
+	wsAddonWriter.WriteAddons(paramsOut, o.StorageSvc, "params.yaml")
+	wsAddonWriter.WriteAddons(outputOut, o.StorageSvc, "outputs.yaml")
+	wsAddonWriter.WriteAddons(policyOut, o.StorageSvc, "policy.yaml")
+	wsAddonWriter.WriteAddons(cfOut, o.StorageSvc, "s3.yaml")
+
+}
+
+// Strip non-alphanumeric characters from an input string
+func logicalIdSafe(input string) string {
+	var output string
+	for _, c := range input {
+		if c >= 'a' && c <= 'z' {
+			output += string(c)
+		} else if c >= '0' && c <= '9' {
+			output += string(c)
+		} else if c >= 'A' && c <= 'Z' {
+			output += string(c)
+		} else {
+			continue
+		}
+	}
+	return output
+}
+
 func BuildStorageInitCmd() *cobra.Command {
 	vars := initStorageVars{
 		GlobalOpts: NewGlobalOpts(),
@@ -219,9 +321,9 @@ func BuildStorageInitCmd() *cobra.Command {
 			if err := opts.Ask(); err != nil {
 				return err
 			}
-			// if err := opts.Execute(); err != nil {
-			// 	return err
-			// }
+			if err := opts.Execute(); err != nil {
+				return err
+			}
 			log.Infoln("Recommended follow-up actions:")
 			// for _, followup := range opts.RecommendedActions() {
 			// 	log.Infof("- %s\n", followup)


### PR DESCRIPTION
Adds execute method which renders user inputs into cloudformation template in addons dir.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
addresses #769 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
