### PR TITLE
feat(stack): add Firelens sidecar deployment support

### DIFF
--- a/e2e/addons/addons_test.go
+++ b/e2e/addons/addons_test.go
@@ -208,7 +208,7 @@ var _ = Describe("addons flow", func() {
 
 			for _, logLine := range svcLogs {
 				Expect(logLine.Message).NotTo(Equal(""))
-				Expect(logLine.TaskID).NotTo(Equal(""))
+				Expect(logLine.LogStreamName).NotTo(Equal(""))
 				Expect(logLine.Timestamp).NotTo(Equal(0))
 				Expect(logLine.IngestionTime).NotTo(Equal(0))
 			}

--- a/e2e/init/init_test.go
+++ b/e2e/init/init_test.go
@@ -127,7 +127,7 @@ var _ = Describe("init flow", func() {
 
 			for _, logLine := range svcLogs {
 				Expect(logLine.Message).NotTo(Equal(""))
-				Expect(logLine.TaskID).NotTo(Equal(""))
+				Expect(logLine.LogStreamName).NotTo(Equal(""))
 				Expect(logLine.Timestamp).NotTo(Equal(0))
 				Expect(logLine.IngestionTime).NotTo(Equal(0))
 			}

--- a/e2e/internal/client/outputs.go
+++ b/e2e/internal/client/outputs.go
@@ -60,7 +60,7 @@ func toSvcListOutput(jsonInput string) (*SvcListOutput, error) {
 }
 
 type SvcLogsOutput struct {
-	TaskID        string `json:"taskID"`
+	LogStreamName string `json:"logStreamName"`
 	IngestionTime int64  `json:"ingestionTime"`
 	Timestamp     int64  `json:"timestamp"`
 	Message       string `json:"message"`

--- a/e2e/multi-env-app/multi_env_test.go
+++ b/e2e/multi-env-app/multi_env_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Multiple Env App", func() {
 
 				for _, logLine := range svcLogs {
 					Expect(logLine.Message).NotTo(Equal(""))
-					Expect(logLine.TaskID).NotTo(Equal(""))
+					Expect(logLine.LogStreamName).NotTo(Equal(""))
 					Expect(logLine.Timestamp).NotTo(Equal(0))
 					Expect(logLine.IngestionTime).NotTo(Equal(0))
 				}

--- a/e2e/multi-svc-app/multi_svc_app_test.go
+++ b/e2e/multi-svc-app/multi_svc_app_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Multiple Service App", func() {
 			Expect("./copilot").Should(BeADirectory())
 		})
 
-		It("app ls includes new project", func() {
+		It("app ls includes new application", func() {
 			apps, err := cli.AppList()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(apps).To(ContainSubstring(appName))
@@ -235,7 +235,7 @@ var _ = Describe("Multiple Service App", func() {
 
 				for _, logLine := range svcLogs {
 					Expect(logLine.Message).NotTo(Equal(""))
-					Expect(logLine.TaskID).NotTo(Equal(""))
+					Expect(logLine.LogStreamName).NotTo(Equal(""))
 					Expect(logLine.Timestamp).NotTo(Equal(0))
 					Expect(logLine.IngestionTime).NotTo(Equal(0))
 				}

--- a/e2e/multi-svc-app/www/main.go
+++ b/e2e/multi-svc-app/www/main.go
@@ -14,8 +14,15 @@ func SimpleGet(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 	w.Write([]byte("www"))
 }
 
+func healthCheckHandler(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+	log.Println("Health Check Succeeded")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("www"))
+}
+
 func main() {
 	router := httprouter.New()
+	router.GET("/", healthCheckHandler)
 	router.GET("/www/", SimpleGet)
 	log.Fatal(http.ListenAndServe(":80", router))
 }

--- a/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/internal/pkg/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -43,11 +43,11 @@ func TestLogEvents(t *testing.T) {
 					OrderBy:      aws.String("LastEventTime"),
 				}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
 					LogStreams: []*cloudwatchlogs.LogStream{
-						&cloudwatchlogs.LogStream{
-							LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream1"),
+						{
+							LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream1"),
 						},
-						&cloudwatchlogs.LogStream{
-							LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream2"),
+						{
+							LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream2"),
 						},
 					},
 				}, nil)
@@ -57,10 +57,10 @@ func TestLogEvents(t *testing.T) {
 					EndTime:       aws.Int64(1234568),
 					Limit:         aws.Int64(10),
 					LogGroupName:  aws.String("mockLogGroup"),
-					LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream1"),
+					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream1"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
 					Events: []*cloudwatchlogs.OutputLogEvent{
-						&cloudwatchlogs.OutputLogEvent{
+						{
 							Message:   aws.String("some log"),
 							Timestamp: aws.Int64(1),
 						},
@@ -72,10 +72,10 @@ func TestLogEvents(t *testing.T) {
 					EndTime:       aws.Int64(1234568),
 					Limit:         aws.Int64(10),
 					LogGroupName:  aws.String("mockLogGroup"),
-					LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream2"),
+					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream2"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
 					Events: []*cloudwatchlogs.OutputLogEvent{
-						&cloudwatchlogs.OutputLogEvent{
+						{
 							Message:   aws.String("other log"),
 							Timestamp: aws.Int64(0),
 						},
@@ -84,20 +84,20 @@ func TestLogEvents(t *testing.T) {
 			},
 
 			wantLogEvents: []*Event{
-				&Event{
-					TaskID:    "mockLogStream2",
-					Message:   "other log",
-					Timestamp: 0,
+				{
+					LogStreamName: "mockLogGroup/mockLogStream2",
+					Message:       "other log",
+					Timestamp:     0,
 				},
-				&Event{
-					TaskID:    "mockLogStream1",
-					Message:   "some log",
-					Timestamp: 1,
+				{
+					LogStreamName: "mockLogGroup/mockLogStream1",
+					Message:       "some log",
+					Timestamp:     1,
 				},
 			},
 			wantLastEventTime: map[string]int64{
-				"ecs/mockLogGroup/mockLogStream1": 1,
-				"ecs/mockLogGroup/mockLogStream2": 0,
+				"copilot/mockLogGroup/mockLogStream1": 1,
+				"copilot/mockLogGroup/mockLogStream2": 0,
 			},
 			wantErr: nil,
 		},
@@ -107,7 +107,7 @@ func TestLogEvents(t *testing.T) {
 			endTime:      1234999,
 			limit:        10,
 			lastEventTime: map[string]int64{
-				"ecs/mockLogGroup/mockLogStream": 1234890,
+				"copilot/mockLogGroup/mockLogStream": 1234890,
 			},
 			mockcloudwatchlogsClient: func(m *mocks.Mockapi) {
 				m.EXPECT().DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
@@ -116,8 +116,8 @@ func TestLogEvents(t *testing.T) {
 					OrderBy:      aws.String("LastEventTime"),
 				}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
 					LogStreams: []*cloudwatchlogs.LogStream{
-						&cloudwatchlogs.LogStream{
-							LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream"),
+						{
+							LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
 						},
 					},
 				}, nil)
@@ -127,10 +127,10 @@ func TestLogEvents(t *testing.T) {
 					Limit:         aws.Int64(10),
 					EndTime:       aws.Int64(1234999),
 					LogGroupName:  aws.String("mockLogGroup"),
-					LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream"),
+					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
 					Events: []*cloudwatchlogs.OutputLogEvent{
-						&cloudwatchlogs.OutputLogEvent{
+						{
 							Message:   aws.String("some log"),
 							Timestamp: aws.Int64(1234892),
 						},
@@ -139,14 +139,14 @@ func TestLogEvents(t *testing.T) {
 			},
 
 			wantLogEvents: []*Event{
-				&Event{
-					TaskID:    "mockLogStream",
-					Message:   "some log",
-					Timestamp: 1234892,
+				{
+					LogStreamName: "mockLogGroup/mockLogStream",
+					Message:       "some log",
+					Timestamp:     1234892,
 				},
 			},
 			wantLastEventTime: map[string]int64{
-				"ecs/mockLogGroup/mockLogStream": 1234892,
+				"copilot/mockLogGroup/mockLogStream": 1234892,
 			},
 			wantErr: nil,
 		},
@@ -163,8 +163,8 @@ func TestLogEvents(t *testing.T) {
 					OrderBy:      aws.String("LastEventTime"),
 				}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
 					LogStreams: []*cloudwatchlogs.LogStream{
-						&cloudwatchlogs.LogStream{
-							LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream"),
+						{
+							LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
 						},
 					},
 				}, nil)
@@ -174,14 +174,14 @@ func TestLogEvents(t *testing.T) {
 					EndTime:       aws.Int64(1234568),
 					Limit:         aws.Int64(1),
 					LogGroupName:  aws.String("mockLogGroup"),
-					LogStreamName: aws.String("ecs/mockLogGroup/mockLogStream"),
+					LogStreamName: aws.String("copilot/mockLogGroup/mockLogStream"),
 				}).Return(&cloudwatchlogs.GetLogEventsOutput{
 					Events: []*cloudwatchlogs.OutputLogEvent{
-						&cloudwatchlogs.OutputLogEvent{
+						{
 							Message:   aws.String("some log"),
 							Timestamp: aws.Int64(0),
 						},
-						&cloudwatchlogs.OutputLogEvent{
+						{
 							Message:   aws.String("other log"),
 							Timestamp: aws.Int64(1),
 						},
@@ -190,14 +190,14 @@ func TestLogEvents(t *testing.T) {
 			},
 
 			wantLogEvents: []*Event{
-				&Event{
-					TaskID:    "mockLogStream",
-					Message:   "other log",
-					Timestamp: 1,
+				{
+					LogStreamName: "mockLogGroup/mockLogStream",
+					Message:       "other log",
+					Timestamp:     1,
 				},
 			},
 			wantLastEventTime: map[string]int64{
-				"ecs/mockLogGroup/mockLogStream": 1,
+				"copilot/mockLogGroup/mockLogStream": 1,
 			},
 			wantErr: nil,
 		},
@@ -250,7 +250,7 @@ func TestLogEvents(t *testing.T) {
 					OrderBy:      aws.String("LastEventTime"),
 				}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
 					LogStreams: []*cloudwatchlogs.LogStream{
-						&cloudwatchlogs.LogStream{
+						{
 							LogStreamName: aws.String("mockLogStream"),
 						},
 					},
@@ -311,7 +311,7 @@ func TestLogGroupExists(t *testing.T) {
 					LogGroupName: aws.String("mockLogGroup"),
 				}).Return(&cloudwatchlogs.DescribeLogStreamsOutput{
 					LogStreams: []*cloudwatchlogs.LogStream{
-						&cloudwatchlogs.LogStream{
+						{
 							LogStreamName: aws.String("mockLogStream"),
 						},
 					},

--- a/internal/pkg/aws/cloudwatchlogs/event.go
+++ b/internal/pkg/aws/cloudwatchlogs/event.go
@@ -13,12 +13,12 @@ import (
 )
 
 const (
-	shortTaskIDLength = 7
+	shortLogStreamNameLength = 25
 )
 
 // Event represents a log event.
 type Event struct {
-	TaskID        string `json:"taskID"`
+	LogStreamName string `json:"logStreamName"`
 	IngestionTime int64  `json:"ingestionTime"`
 	Message       string `json:"message"`
 	Timestamp     int64  `json:"timestamp"`
@@ -41,12 +41,12 @@ func (l *Event) HumanString() string {
 	for _, code := range warningCodes {
 		l.Message = strings.ReplaceAll(l.Message, code, color.Yellow.Sprint(code))
 	}
-	return fmt.Sprintf("%s %s\n", color.Grey.Sprint(l.shortTaskID()), l.Message)
+	return fmt.Sprintf("%s %s\n", color.Grey.Sprint(l.shortLogStreamName()), l.Message)
 }
 
-func (l *Event) shortTaskID() string {
-	if len(l.TaskID) < shortTaskIDLength {
-		return l.TaskID
+func (l *Event) shortLogStreamName() string {
+	if len(l.LogStreamName) < shortLogStreamNameLength {
+		return l.LogStreamName
 	}
-	return l.TaskID[0:shortTaskIDLength]
+	return l.LogStreamName[0:shortLogStreamNameLength]
 }

--- a/internal/pkg/cli/svc_logs_test.go
+++ b/internal/pkg/cli/svc_logs_test.go
@@ -573,29 +573,29 @@ func TestSvcLogs_Execute(t *testing.T) {
 	}
 	logEvents := []*cloudwatchlogs.Event{
 		{
-			TaskID:  "123456789",
-			Message: `10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -`,
+			LogStreamName: "firelens_log_router/fcfe4ab8043841c08162318e5ad805f1",
+			Message:       `10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -`,
 		},
 		{
-			TaskID:  "123456789",
-			Message: `10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -`,
+			LogStreamName: "firelens_log_router/fcfe4ab8043841c08162318e5ad805f1",
+			Message:       `10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -`,
 		},
 		{
-			TaskID:  "123456789",
-			Message: `10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -`,
+			LogStreamName: "firelens_log_router/fcfe4ab8043841c08162318e5ad805f1",
+			Message:       `10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -`,
 		},
 	}
 	moreLogEvents := []*cloudwatchlogs.Event{
 		{
-			TaskID:  "123456789",
-			Message: `10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -`,
+			LogStreamName: "firelens_log_router/fcfe4ab8043841c08162318e5ad805f1",
+			Message:       `10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -`,
 		},
 	}
-	logEventsHumanString := `1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -
-1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
-1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
+	logEventsHumanString := `firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
 `
-	logEventsJSONString := "{\"taskID\":\"123456789\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"GET / HTTP/1.1\\\" 200 -\",\"timestamp\":0}\n{\"taskID\":\"123456789\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"FATA some error\\\" - -\",\"timestamp\":0}\n{\"taskID\":\"123456789\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"WARN some warning\\\" - -\",\"timestamp\":0}\n"
+	logEventsJSONString := "{\"logStreamName\":\"firelens_log_router/fcfe4ab8043841c08162318e5ad805f1\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"GET / HTTP/1.1\\\" 200 -\",\"timestamp\":0}\n{\"logStreamName\":\"firelens_log_router/fcfe4ab8043841c08162318e5ad805f1\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"FATA some error\\\" - -\",\"timestamp\":0}\n{\"logStreamName\":\"firelens_log_router/fcfe4ab8043841c08162318e5ad805f1\",\"ingestionTime\":0,\"message\":\"10.0.0.00 - - [01/Jan/1970 01:01:01] \\\"WARN some warning\\\" - -\",\"timestamp\":0}\n"
 	testCases := map[string]struct {
 		inputApp     string
 		inputSvc     string
@@ -671,10 +671,10 @@ func TestSvcLogs_Execute(t *testing.T) {
 			},
 
 			wantedError: nil,
-			wantedContent: `1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -
-1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
-1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
-1234567 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -
+			wantedContent: `firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 200 -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "FATA some error" - -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "WARN some warning" - -
+firelens_log_router/fcfe4 10.0.0.00 - - [01/Jan/1970 01:01:01] "GET / HTTP/1.1" 404 -
 `,
 		},
 		"returns error if fail to get event logs": {

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc.go
@@ -67,7 +67,7 @@ func (s *BackendService) Template() (string, error) {
 	}
 	sidecars, err := s.manifest.Sidecar.SidecarsOpts()
 	if err != nil {
-		return "", fmt.Errorf("converts the sidecar configuration for service %s: %w", s.name, err)
+		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
 	}
 	content, err := s.parser.ParseBackendService(template.ServiceOpts{
 		Variables:   s.manifest.BackendServiceConfig.Variables,
@@ -75,6 +75,7 @@ func (s *BackendService) Template() (string, error) {
 		NestedStack: outputs,
 		Sidecars:    sidecars,
 		HealthCheck: s.manifest.BackendServiceConfig.Image.HealthCheckOpts(),
+		LogConfig:   s.manifest.LogConfigOpts(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("parse backend service template: %w", err)

--- a/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
+++ b/internal/pkg/deploy/cloudformation/stack/backend_svc_test.go
@@ -79,7 +79,7 @@ func TestBackendService_Template(t *testing.T) {
     Value: hello`,
 				}
 			},
-			wantedErr: fmt.Errorf("converts the sidecar configuration for service frontend: %w", errors.New("cannot parse port mapping from 80/80/80")),
+			wantedErr: fmt.Errorf("convert the sidecar configuration for service frontend: %w", errors.New("cannot parse port mapping from 80/80/80")),
 		},
 		"failed parsing svc template": {
 			manifest: testBackendSvcManifest,

--- a/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
+++ b/internal/pkg/deploy/cloudformation/stack/lb_web_svc.go
@@ -95,13 +95,14 @@ func (s *LoadBalancedWebService) Template() (string, error) {
 	}
 	sidecars, err := s.manifest.Sidecar.SidecarsOpts()
 	if err != nil {
-		return "", fmt.Errorf("converts the sidecar configuration for service %s: %w", s.name, err)
+		return "", fmt.Errorf("convert the sidecar configuration for service %s: %w", s.name, err)
 	}
 	content, err := s.parser.ParseLoadBalancedWebService(template.ServiceOpts{
 		Variables:          s.manifest.Variables,
 		Secrets:            s.manifest.Secrets,
 		NestedStack:        outputs,
 		Sidecars:           sidecars,
+		LogConfig:          s.manifest.LogConfigOpts(),
 		RulePriorityLambda: rulePriorityLambda.String(),
 	})
 	if err != nil {

--- a/internal/pkg/manifest/backend_svc.go
+++ b/internal/pkg/manifest/backend_svc.go
@@ -40,8 +40,16 @@ type BackendService struct {
 type BackendServiceConfig struct {
 	Image      imageWithPortAndHealthcheck `yaml:",flow"`
 	TaskConfig `yaml:",inline"`
-	LogConfig  `yaml:"logging,flow"`
+	*LogConfig `yaml:"logging,flow"`
 	Sidecar    `yaml:",inline"`
+}
+
+// LogConfigOpts converts the service's Firelens configuration into a format parsable by the templates pkg.
+func (bc *BackendServiceConfig) LogConfigOpts() *template.LogConfigOpts {
+	if bc.LogConfig == nil {
+		return nil
+	}
+	return bc.logConfigOpts()
 }
 
 type imageWithPortAndHealthcheck struct {

--- a/internal/pkg/manifest/backend_svc_test.go
+++ b/internal/pkg/manifest/backend_svc_test.go
@@ -240,10 +240,10 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 					},
 				},
 			},
-			LogConfig: LogConfig{
-				Destination: destinationConfig{
-					Name:           aws.String("datadog"),
-					ExcludePattern: aws.String("*"),
+			LogConfig: &LogConfig{
+				Destination: map[string]string{
+					"Name":            "datadog",
+					"exclude-pattern": "*",
 				},
 			},
 		},
@@ -263,10 +263,10 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 						},
 					},
 				},
-				LogConfig: LogConfig{
-					Destination: destinationConfig{
-						IncludePattern: aws.String("*"),
-						ExcludePattern: aws.String("fe/"),
+				LogConfig: &LogConfig{
+					Destination: map[string]string{
+						"include-pattern": "*",
+						"exclude-pattern": "fe/",
 					},
 				},
 			},
@@ -329,11 +329,11 @@ func TestBackendSvc_ApplyEnv(t *testing.T) {
 							},
 						},
 					},
-					LogConfig: LogConfig{
-						Destination: destinationConfig{
-							Name:           aws.String("datadog"),
-							IncludePattern: aws.String("*"),
-							ExcludePattern: aws.String("fe/"),
+					LogConfig: &LogConfig{
+						Destination: map[string]string{
+							"Name":            "datadog",
+							"include-pattern": "*",
+							"exclude-pattern": "fe/",
 						},
 					},
 				},

--- a/internal/pkg/manifest/lb_web_svc.go
+++ b/internal/pkg/manifest/lb_web_svc.go
@@ -32,8 +32,16 @@ type LoadBalancedWebServiceConfig struct {
 	Image       ServiceImageWithPort `yaml:",flow"`
 	RoutingRule `yaml:"http,flow"`
 	TaskConfig  `yaml:",inline"`
-	LogConfig   `yaml:"logging,flow"`
+	*LogConfig  `yaml:"logging,flow"`
 	Sidecar     `yaml:",inline"`
+}
+
+// LogConfigOpts converts the service's Firelens configuration into a format parsable by the templates pkg.
+func (lc *LoadBalancedWebServiceConfig) LogConfigOpts() *template.LogConfigOpts {
+	if lc.LogConfig == nil {
+		return nil
+	}
+	return lc.logConfigOpts()
 }
 
 // RoutingRule holds the path to route requests to the service.

--- a/internal/pkg/manifest/lb_web_svc_test.go
+++ b/internal/pkg/manifest/lb_web_svc_test.go
@@ -157,7 +157,7 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 							},
 						},
 					},
-					LogConfig: LogConfig{
+					LogConfig: &LogConfig{
 						ConfigFile: aws.String("mockConfigFile"),
 					},
 				},
@@ -186,7 +186,7 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 								},
 							},
 						},
-						LogConfig: LogConfig{
+						LogConfig: &LogConfig{
 							SecretOptions: map[string]string{
 								"FOO": "BAR",
 							},
@@ -235,7 +235,7 @@ func TestLoadBalancedWebSvc_ApplyEnv(t *testing.T) {
 							},
 						},
 					},
-					LogConfig: LogConfig{
+					LogConfig: &LogConfig{
 						ConfigFile: aws.String("mockConfigFile"),
 						SecretOptions: map[string]string{
 							"FOO": "BAR",

--- a/internal/pkg/manifest/svc_test.go
+++ b/internal/pkg/manifest/svc_test.go
@@ -43,14 +43,13 @@ sidecars:
     credentialsParameter: some arn
 logging:
   destination:
-    name: cloudwatch
-    includePattern: ^[a-z][aeiou].*$
-    excludePattern: ^.*[aeiou]$
+    Name: cloudwatch
+    include-pattern: ^[a-z][aeiou].*$
+    exclude-pattern: ^.*[aeiou]$
   enableMetadata: false
   secretOptions:
     LOG_TOKEN: LOG_TOKEN
-  configFile: ./extra.conf
-  permissionFile: ./permissions.json
+  configFilePath: /extra.conf
 environments:
   test:
     count: 3
@@ -87,15 +86,14 @@ environments:
 								},
 							},
 						},
-						LogConfig: LogConfig{
-							Destination: destinationConfig{
-								ExcludePattern: aws.String("^.*[aeiou]$"),
-								IncludePattern: aws.String("^[a-z][aeiou].*$"),
-								Name:           aws.String("cloudwatch"),
+						LogConfig: &LogConfig{
+							Destination: map[string]string{
+								"exclude-pattern": "^.*[aeiou]$",
+								"include-pattern": "^[a-z][aeiou].*$",
+								"Name":            "cloudwatch",
 							},
 							EnableMetadata: aws.Bool(false),
-							ConfigFile:     aws.String("./extra.conf"),
-							PermissionFile: aws.String("./permissions.json"),
+							ConfigFile:     aws.String("/extra.conf"),
 							SecretOptions: map[string]string{
 								"LOG_TOKEN": "LOG_TOKEN",
 							},

--- a/internal/pkg/template/service.go
+++ b/internal/pkg/template/service.go
@@ -38,6 +38,16 @@ type SidecarOpts struct {
 	CredsParam *string
 }
 
+// LogConfigOpts holds configuration that's needed if the service is configured with Firelens to route
+// its logs.
+type LogConfigOpts struct {
+	Image          *string
+	Destination    map[string]string
+	EnableMetadata *string
+	SecretOptions  map[string]string
+	ConfigFile     *string
+}
+
 // ServiceOpts holds optional data that can be provided to enable features in a service stack template.
 type ServiceOpts struct {
 	// Additional options that're common between **all** service templates.
@@ -45,6 +55,7 @@ type ServiceOpts struct {
 	Secrets     map[string]string
 	NestedStack *ServiceNestedStackOpts // Outputs from nested stacks such as the addons stack.
 	Sidecars    []*SidecarOpts
+	LogConfig   *LogConfigOpts
 
 	// Additional options that're not shared across all service templates.
 	HealthCheck        *ecs.HealthCheck

--- a/internal/pkg/template/service_test.go
+++ b/internal/pkg/template/service_test.go
@@ -38,6 +38,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
 				mockBox.AddString("services/common/cf/servicediscovery.yml", "servicediscovery")
 				mockBox.AddString("services/common/cf/addons.yml", "addons")
 				mockBox.AddString("services/common/cf/sidecars.yml", "sidecars")
+				mockBox.AddString("services/common/cf/logconfig.yml", "logconfig")
 
 				t.box = mockBox
 			},
@@ -50,6 +51,7 @@ func TestTemplate_ParseSvc(t *testing.T) {
   servicediscovery
   addons
   sidecars
+  logconfig
 `,
 		},
 	}

--- a/internal/pkg/template/template.go
+++ b/internal/pkg/template/template.go
@@ -32,6 +32,7 @@ var (
 		"servicediscovery",
 		"addons",
 		"sidecars",
+		"logconfig",
 	}
 )
 

--- a/templates/services/backend/cf.yml
+++ b/templates/services/backend/cf.yml
@@ -43,18 +43,15 @@ Resources:
           PortMappings:
             - ContainerPort: !Ref ContainerPort
 {{include "envvars" . | indent 10}}
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref AWS::Region
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: copilot{{if .HealthCheck}}
+{{include "logconfig" . | indent 10}}
+{{- if .HealthCheck}}
           HealthCheck:
             Command: {{quoteAll .HealthCheck.Command | stringifySlice}}
             Interval: {{.HealthCheck.Interval}}
             Retries: {{.HealthCheck.Retries}}
             StartPeriod: {{.HealthCheck.StartPeriod}}
-            Timeout: {{.HealthCheck.Timeout}}{{end}}
+            Timeout: {{.HealthCheck.Timeout}}
+{{- end}}
 {{include "sidecars" . | indent 8}}
 {{include "executionrole" . | indent 2}}
 

--- a/templates/services/common/cf/logconfig.yml
+++ b/templates/services/common/cf/logconfig.yml
@@ -1,0 +1,18 @@
+{{- if .LogConfig}}LogConfiguration:
+  LogDriver: awsfirelens
+{{- if .LogConfig.Destination}}
+  Options:{{range $name, $value := .LogConfig.Destination}}
+    {{$name}}: {{$value}}{{end}}
+{{- end}}
+{{- if .LogConfig.SecretOptions}}
+  SecretOptions:{{range $name, $valueFrom := .LogConfig.SecretOptions}}
+    - Name: {{$name}}
+      ValueFrom: {{$valueFrom}}{{end}}
+{{- end}}
+{{- else}}LogConfiguration:
+  LogDriver: awslogs
+  Options:
+    awslogs-region: !Ref AWS::Region
+    awslogs-group: !Ref LogGroup
+    awslogs-stream-prefix: copilot
+{{- end}}

--- a/templates/services/common/cf/sidecars.yml
+++ b/templates/services/common/cf/sidecars.yml
@@ -1,3 +1,17 @@
+{{if .LogConfig}}- Name: firelens_log_router
+  Image: {{ .LogConfig.Image }}
+  FirelensConfiguration:
+    Type: fluentbit
+    Options:
+      enable-ecs-log-metadata: {{.LogConfig.EnableMetadata}}{{if .LogConfig.ConfigFile}}
+      config-file-type: file
+      config-file-value: {{.LogConfig.ConfigFile}}{{end}}
+  LogConfiguration:
+    LogDriver: awslogs
+    Options:
+      awslogs-region: !Ref AWS::Region
+      awslogs-group: !Ref LogGroup
+      awslogs-stream-prefix: copilot{{end}}
 {{range $sidecar := .Sidecars}}- Name: {{$sidecar.Name}}
   Image: {{$sidecar.Image}}{{if $sidecar.Port}}
   PortMappings:

--- a/templates/services/lb-web/cf.yml
+++ b/templates/services/lb-web/cf.yml
@@ -60,12 +60,7 @@ Resources:
           PortMappings:
             - ContainerPort: !Ref ContainerPort
 {{include "envvars" . | indent 10}}
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-region: !Ref AWS::Region
-              awslogs-group: !Ref LogGroup
-              awslogs-stream-prefix: copilot
+{{include "logconfig" . | indent 10}}
 {{include "sidecars" . | indent 8}}
 {{include "executionrole" . | indent 2}}
 


### PR DESCRIPTION
<!-- Provide summary of changes -->
Partially address https://github.com/aws/amazon-ecs-cli-v2/issues/875. With this PR now we can deploy a Copilot service with Firelens as the log driver to deliver logs of the main container to destinations.

Users can config Firelens in two ways:

1. Set up configurations in the manifest (unable to sent to multiple destinations though).
2. Configure using fluentbit config file. Note that this requires users to build their own custom fluentbit image and specifying their config file path.

Additionally users might need to add permissions to task role if necessary. And they are able to add their own permissions by using Copilot addons feature. Any addons policy will be added to the task role.

This PR also adjusts `svc logs` to accommodate Firelens changes.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
