### PR TITLE
feat(storage): Add dynamoDB Cloudformation templates

### DIFF
--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -1,7 +1,7 @@
 {{.TableResourceName}}:
   Type: AWS::DynamoDB::Table
   Properties:
-    TableName: !Sub ${Project}-${Env}-${App}-{{.TableName}}
+    TableName: !Sub ${App}-${Env}-${Name}-{{.TableName}}
     AttributeDefinitions:{{range .Attributes}}
       - AttributeName: {{.Name}}
         AttributeType: {{.DataType}}{{end}}

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -2,7 +2,7 @@
   Type: AWS::DynamoDB::Table
   Properties:
     TableName: !Sub ${App}-${Env}-${Name}-{{.TableName}}
-    AttributeDefinitions:{{range .Attributes}}
+    AttributeDefinitions:
       - AttributeName: {{.Name}}
         AttributeType: {{.DataType}}{{end}}
     ProvisionedThroughput: 
@@ -14,11 +14,11 @@
       - AttributeName: {{.SortKey}}
         KeyType: RANGE{{if .HasLSI}}
     LocalSecondaryIndexes{{range .LSIs}}
-      - IndexName: .Name
+      - IndexName: {{.Name}}
         KeySchema:
-          - AttributeName: .PartitionKey
+          - AttributeName: {{.PartitionKey}}
             KeyType: HASH
-          - AttributeName: .SortKey
+          - AttributeName: {{.SortKey}}
             KeyType: RANGE
         Projection:
           ProjectionType: ALL{{end}}{{end}}

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -5,14 +5,12 @@
     AttributeDefinitions:
       - AttributeName: {{.Name}}
         AttributeType: {{.DataType}}{{end}}
-    ProvisionedThroughput: 
-      ReadCapacityUnits: 2
-      WriteCapacityUnits: 2
+    BillingMode: PAY_PER_REQUEST
     KeySchema: 
       - AttributeName: {{.PartitionKey}}
-        KeyType: HASH
+        KeyType: HASH{{if .SortKey}}
       - AttributeName: {{.SortKey}}
-        KeyType: RANGE{{if .HasLSI}}
+        KeyType: RANGE{{end}}{{if .HasLSI}}
     LocalSecondaryIndexes:{{range .LSIs}}
       - IndexName: {{.Name}}
         KeySchema:

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -1,0 +1,24 @@
+{{.TableResourceName}}:
+  Type: AWS::DynamoDB::Table
+  Properties:
+    TableName: !Sub ${Project}-${Env}-${App}-{{.TableName}}
+    AttributeDefinitions:{{range .Attributes}}
+      - AttributeName: {{.Name}}
+        AttributeType: {{.DataType}}{{end}}
+    ProvisionedThroughput: 
+      ReadCapacityUnits: 2
+      WriteCapacityUnits: 2
+    KeySchema: 
+      - AttributeName: {{.PartitionKey}}
+        KeyType: HASH
+      - AttributeName: {{.SortKey}}
+        KeyType: RANGE{{if .HasLSI}}
+    LocalSecondaryIndexes{{range .LSIs}}
+      - IndexName: .Name
+        KeySchema:
+          - AttributeName: .PartitionKey
+            KeyType: HASH
+          - AttributeName: .SortKey
+            KeyType: RANGE
+        Projection:
+          ProjectionType: ALL{{end}}{{end}}

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -13,7 +13,7 @@
         KeyType: HASH
       - AttributeName: {{.SortKey}}
         KeyType: RANGE{{if .HasLSI}}
-    LocalSecondaryIndexes{{range .LSIs}}
+    LocalSecondaryIndexes:{{range .LSIs}}
       - IndexName: {{.Name}}
         KeySchema:
           - AttributeName: {{.PartitionKey}}

--- a/templates/addons/ddb/cf.yml
+++ b/templates/addons/ddb/cf.yml
@@ -1,14 +1,15 @@
 {{.TableResourceName}}:
   Type: AWS::DynamoDB::Table
+  DeletionPolicy: Retain
   Properties:
     TableName: !Sub ${App}-${Env}-${Name}-{{.TableName}}
     AttributeDefinitions:
       - AttributeName: {{.Name}}
-        AttributeType: {{.DataType}}{{end}}
+        AttributeType: "{{.DataType}}"{{end}}
     BillingMode: PAY_PER_REQUEST
     KeySchema: 
       - AttributeName: {{.PartitionKey}}
-        KeyType: HASH{{if .SortKey}}
+        KeyType: HASH{{ if .SortKey }}
       - AttributeName: {{.SortKey}}
         KeyType: RANGE{{end}}{{if .HasLSI}}
     LocalSecondaryIndexes:{{range .LSIs}}

--- a/templates/addons/ddb/outputs.yml
+++ b/templates/addons/ddb/outputs.yml
@@ -1,5 +1,5 @@
 {{.TableResourceName}}TableName:
-  Description: "The name of the DynamoDB table for this application."
+  Description: "The name of this DynamoDB."
   Value: !Ref {{.TableResourceName}}
 {{.TableResourceName}}AccessPolicy:
   Description: "The IAM::ManagedPolicy to attach to the task role."

--- a/templates/addons/ddb/outputs.yml
+++ b/templates/addons/ddb/outputs.yml
@@ -1,0 +1,6 @@
+{{.TableResourceName}}TableName:
+  Description: "The name of the DynamoDB table for this application."
+  Value: !Ref {{.TableResourceName}}
+{{.TableResourceName}}AccessPolicy:
+  Description: "The IAM::ManagedPolicy to attach to the task role."
+  Value: !Ref {{.TableResourceName}}AccessPolicy

--- a/templates/addons/ddb/policy.yml
+++ b/templates/addons/ddb/policy.yml
@@ -1,0 +1,30 @@
+{{.TableResourceName}}AccessPolicy:
+  Type: AWS::IAM::ManagedPolicy
+  Properties:
+  Description: !Sub
+      - Grants CRUD access to the Dynamo DB table ${Table}
+      - { Table: !Ref {{.TableResourceName}} }
+    PolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        - Sid: DDBActions
+          Effect: Allow
+          Action:
+          - dynamodb:BatchGet*
+          - dynamodb:DescribeStream
+          - dynamodb:DescribeTable
+          - dynamodb:Get*
+          - dynamodb:Query
+          - dynamodb:Scan
+          - dynamodb:BatchWrite*
+          - dynamodb:CreateTable
+          - dynamodb:Delete*
+          - dynamodb:Update*
+          - dynamodb:PutItem
+          Resource: !Sub ${ {{.TableResourceName}}.Arn}
+        - Sid: DDBLSIActions
+            Action: 
+              - dynamodb:Query
+              - dynamodb:Scan
+            Effect: Allow*
+            Resource: !Sub ${ {{.TableResourceName}}.Arn}/Index/*

--- a/templates/addons/ddb/policy.yml
+++ b/templates/addons/ddb/policy.yml
@@ -26,5 +26,5 @@
             Action: 
               - dynamodb:Query
               - dynamodb:Scan
-            Effect: Allow*
+            Effect: Allow
             Resource: !Sub ${ {{.TableResourceName}}.Arn}/Index/*

--- a/templates/addons/ddb/policy.yml
+++ b/templates/addons/ddb/policy.yml
@@ -17,14 +17,14 @@
           - dynamodb:Query
           - dynamodb:Scan
           - dynamodb:BatchWrite*
-          - dynamodb:CreateTable
+          - dynamodb:Create*
           - dynamodb:Delete*
           - dynamodb:Update*
           - dynamodb:PutItem
           Resource: !Sub ${ {{.TableResourceName}}.Arn}
         - Sid: DDBLSIActions
-            Action: 
-              - dynamodb:Query
-              - dynamodb:Scan
-            Effect: Allow
-            Resource: !Sub ${ {{.TableResourceName}}.Arn}/Index/*
+          Action:
+            - dynamodb:Query
+            - dynamodb:Scan
+          Effect: Allow
+          Resource: !Sub ${ {{.TableResourceName}}.Arn}/Index/*

--- a/templates/addons/ddb/policy.yml
+++ b/templates/addons/ddb/policy.yml
@@ -1,7 +1,7 @@
 {{.TableResourceName}}AccessPolicy:
   Type: AWS::IAM::ManagedPolicy
   Properties:
-  Description: !Sub
+    Description: !Sub
       - Grants CRUD access to the Dynamo DB table ${Table}
       - { Table: !Ref {{.TableResourceName}} }
     PolicyDocument:


### PR DESCRIPTION
<!-- Provide summary of changes -->
This PR adds the cloudformation template necessary to create DDB tables on behalf of customers in storage init. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses #769 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
