### PR TITLE
fix(docker): Fix failing end to end tests

### DIFF
--- a/e2e/addons/hello/addons/params.yml
+++ b/e2e/addons/hello/addons/params.yml
@@ -4,6 +4,6 @@ App:
 Env:
   Type: String
   Description: The environment name your service is being deployed to.
-Service:
+Name:
   Type: String
   Description: The name of the service being deployed.

--- a/internal/pkg/docker/docker.go
+++ b/internal/pkg/docker/docker.go
@@ -33,9 +33,8 @@ func New() Runner {
 func (r Runner) Build(uri, imageTag, path string) error {
 	imageName := imageName(uri, imageTag)
 	dfDir := filepath.Dir(path)
-	dfPath := filepath.Base(path)
 
-	err := r.Run("docker", []string{"build", "-t", imageName, dfDir, "-f", dfPath})
+	err := r.Run("docker", []string{"build", "-t", imageName, dfDir, "-f", path})
 
 	if err != nil {
 		return fmt.Errorf("building image: %w", err)

--- a/internal/pkg/docker/docker.go
+++ b/internal/pkg/docker/docker.go
@@ -29,12 +29,13 @@ func New() Runner {
 	}
 }
 
-// Build will run a `docker build` command with the input uri, tag, and Dockerfile image path.
+// Build will run a `docker build` command with the input uri, tag, and Dockerfile path.
 func (r Runner) Build(uri, imageTag, path string) error {
 	imageName := imageName(uri, imageTag)
-	dfPath, dfName := filepath.Split(path)
+	dfDir := filepath.Dir(path)
+	dfPath := filepath.Base(path)
 
-	err := r.Run("docker", []string{"build", "-t", imageName, dfPath, "-f", dfName})
+	err := r.Run("docker", []string{"build", "-t", imageName, dfDir, "-f", dfPath})
 
 	if err != nil {
 		return fmt.Errorf("building image: %w", err)

--- a/internal/pkg/docker/docker_test.go
+++ b/internal/pkg/docker/docker_test.go
@@ -17,7 +17,7 @@ func TestBuild(t *testing.T) {
 
 	mockURI := "mockURI"
 	mockImageTag := "mockImageTag"
-	mockPath := "mockPath/mockDockerfile"
+	mockPath := "mockPath/to/mockDockerfile"
 
 	var mockRunner *mocks.Mockrunner
 
@@ -32,7 +32,7 @@ func TestBuild(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockRunner = mocks.NewMockrunner(controller)
 
-				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath", "-f", "mockDockerfile"}).Return(mockError)
+				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath/to", "-f", "mockPath/to/mockDockerfile"}).Return(mockError)
 			},
 			want: fmt.Errorf("building image: %w", mockError),
 		},
@@ -41,7 +41,7 @@ func TestBuild(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockRunner = mocks.NewMockrunner(controller)
 
-				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath", "-f", "mockDockerfile"}).Return(nil)
+				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath/to", "-f", "mockPath/to/mockDockerfile"}).Return(nil)
 			},
 		},
 	}

--- a/internal/pkg/docker/docker_test.go
+++ b/internal/pkg/docker/docker_test.go
@@ -32,7 +32,7 @@ func TestBuild(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockRunner = mocks.NewMockrunner(controller)
 
-				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath/", "-f", "mockDockerfile"}).Return(mockError)
+				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath", "-f", "mockDockerfile"}).Return(mockError)
 			},
 			want: fmt.Errorf("building image: %w", mockError),
 		},
@@ -41,7 +41,7 @@ func TestBuild(t *testing.T) {
 			setupMocks: func(controller *gomock.Controller) {
 				mockRunner = mocks.NewMockrunner(controller)
 
-				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath/", "-f", "mockDockerfile"}).Return(nil)
+				mockRunner.EXPECT().Run("docker", []string{"build", "-t", imageName(mockURI, mockImageTag), "mockPath", "-f", "mockDockerfile"}).Return(nil)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Provide summary of changes -->
With #980, we fixed an issue which occurred when there were multiple dockerfiles present in the build directory. 

However, this may have broken our end to end tests, because the call to Docker was formatted as the following:

```sh
docker build -t <imageTag> path/to -f Dockerfile
```

This should be fine, but the end to end tests began to fail on Monday with the following output:
```bash
addons flow when deploying svc
  svc deploy should succeed
  /github.com/aws/amazon-ecs-cli-v2/e2e/addons/addons_test.go:145
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /github.com/aws/amazon-ecs-cli-v2/e2e/addons/Dockerfile: no such file or directory
Error: build Dockerfile at ./hello/Dockerfile with tag gallopinggurdey: building image: exit status 1
```
This indicates that although the Dockerfile path was set to `hello/Dockerfile`, Docker was looking for the file somewhere in the root directory of that path (.) and subsequently failing. 

This fix always sets the dockerfile path to be relative to the *root* of the docker build context, not the *leaf* of the build context. 

(previously we were parsing paths like `path/to/dockerfile` into `path/to` and `dockerfile`, assuming that the dockerfile would be searched for in `path/to`, not `path`. This was incorrect.)

The new behavior is to call:
```sh
docker build -t <imageTag> path/to -f path/to/dockerfile
```



<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
