### PR TITLE
feat(prompt): Add multiselect prompter option 

### DIFF
--- a/internal/pkg/cli/mocks/mock_prompter.go
+++ b/internal/pkg/cli/mocks/mock_prompter.go
@@ -93,6 +93,26 @@ func (mr *MockprompterMockRecorder) SelectOne(message, help, options interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectOne", reflect.TypeOf((*Mockprompter)(nil).SelectOne), varargs...)
 }
 
+// MultiSelect mocks base method
+func (m *Mockprompter) MultiSelect(message, help string, options []string, promptOpts ...prompt.Option) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{message, help, options}
+	for _, a := range promptOpts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MultiSelect", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MultiSelect indicates an expected call of MultiSelect
+func (mr *MockprompterMockRecorder) MultiSelect(message, help, options interface{}, promptOpts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{message, help, options}, promptOpts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultiSelect", reflect.TypeOf((*Mockprompter)(nil).MultiSelect), varargs...)
+}
+
 // Confirm mocks base method
 func (m *Mockprompter) Confirm(message, help string, promptOpts ...prompt.Option) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/cli/prompter.go
+++ b/internal/pkg/cli/prompter.go
@@ -9,5 +9,6 @@ type prompter interface {
 	Get(message, help string, validator prompt.ValidatorFunc, promptOpts ...prompt.Option) (string, error)
 	GetSecret(message, help string, promptOpts ...prompt.Option) (string, error)
 	SelectOne(message, help string, options []string, promptOpts ...prompt.Option) (string, error)
+	MultiSelect(message, help string, options []string, promptOpts ...prompt.Option) ([]string, error)
 	Confirm(message, help string, promptOpts ...prompt.Option) (bool, error)
 }

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -75,6 +75,26 @@ func init() {
 {{- color "default"}}{{ .Message }} {{color "reset"}}
 {{- if and .Help (not .ShowHelp)}}{{color "white"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}`
 
+	survey.MultiSelectQuestionTemplate = `{{if not .Answer}}
+{{end}}
+{{- if .ShowHelp }}{{- color .Config.Icons.Help.Format }}{{ .Config.Icons.Help.Text }}{{$lines := split .Help "\n"}}{{range $i, $line := $lines}}
+{{- if eq $i 0}}  {{ $line }}
+{{ else }}  {{ $line }}
+{{ end }}{{- end }}{{color "reset"}}{{end}}
+{{- color .Config.Icons.Question.Format }}{{if not .ShowAnswer}}  {{ .Config.Icons.Question.Text }}{{else}}{{ .Config.Icons.Question.Text }}{{end}}{{color "reset"}}
+{{- color "default"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "default"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+	{{- "  "}}{{- color "white"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ .Config.HelpInput }} for more help{{end}}]{{color "reset"}}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- if eq $ix $.SelectedIndex }}{{color "default+b" }}  {{ $.Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}
+    {{- if index $.Checked $option.Index }}{{color "default+b" }} {{ $.Config.Icons.MarkedOption.Text }} {{else}}{{color "default" }} {{ $.Config.Icons.UnmarkedOption.Text }} {{end}}
+    {{- color "reset"}}
+    {{- " "}}{{$option.Value}}{{"\n"}}
+  {{- end}}
+{{- end}}`
+
 	core.TemplateFuncs["split"] = func(s string, sep string) []string {
 		return strings.Split(s, sep)
 	}

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -242,7 +242,7 @@ func (p Prompt) SelectOne(message, help string, options []string, promptOpts ...
 	return result, err
 }
 
-// Multiselect prompts the user with a list of options to choose from with the arrow keys and enter key.
+// MultiSelect prompts the user with a list of options to choose from with the arrow keys and enter key.
 func (p Prompt) MultiSelect(message, help string, options []string, promptOpts ...Option) ([]string, error) {
 	var result []string
 	if len(options) <= 0 {

--- a/internal/pkg/term/prompt/prompt.go
+++ b/internal/pkg/term/prompt/prompt.go
@@ -222,6 +222,33 @@ func (p Prompt) SelectOne(message, help string, options []string, promptOpts ...
 	return result, err
 }
 
+// Multiselect prompts the user with a list of options to choose from with the arrow keys and enter key.
+func (p Prompt) MultiSelect(message, help string, options []string, promptOpts ...Option) ([]string, error) {
+	var result []string
+	if len(options) <= 0 {
+		// returns nil slice if error
+		return result, ErrEmptyOptions
+	}
+	multiselect := &survey.MultiSelect{
+		Message: message,
+		Options: options,
+		Default: options[0],
+	}
+	if help != "" {
+		multiselect.Help = color.Help(help)
+	}
+
+	prompt := &prompt{
+		prompter: multiselect,
+	}
+	for _, option := range promptOpts {
+		option(prompt)
+	}
+
+	err := p(prompt, &result, stdio(), icons())
+	return result, err
+}
+
 // Confirm prompts the user with a yes/no option.
 func (p Prompt) Confirm(message, help string, promptOpts ...Option) (bool, error) {
 	confirm := &survey.Confirm{

--- a/internal/pkg/term/prompt/prompt_test.go
+++ b/internal/pkg/term/prompt/prompt_test.go
@@ -185,6 +185,65 @@ func TestPrompt_SelectOne(t *testing.T) {
 	}
 }
 
+func TestPrompt_MultiSelect(t *testing.T) {
+	mockError := fmt.Errorf("error")
+	mockMessage := "Which dogs are best?"
+
+	testCases := map[string]struct {
+		inPrompt Prompt
+		inOpts   []string
+
+		wantValue []string
+		wantError error
+	}{
+		"should return users input": {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				internalPrompt, ok := p.(*prompt)
+				require.True(t, ok, "input prompt should be type *prompt")
+				require.Empty(t, internalPrompt.FinalMessage)
+
+				sel, ok := internalPrompt.prompter.(*survey.MultiSelect)
+				require.True(t, ok, "internal prompt should be type *survey.MultiSelect")
+				require.Equal(t, mockMessage, sel.Message)
+				require.Empty(t, sel.Help)
+				require.NotEmpty(t, sel.Options)
+
+				result, ok := out.(*[]string)
+
+				require.True(t, ok, "type to write user input to should be a string")
+
+				*result = sel.Options
+
+				require.Equal(t, 2, len(opts))
+
+				return nil
+			},
+			inOpts:    []string{"bowie", "clyde", "keno", "cava", "meow"},
+			wantValue: []string{"bowie", "clyde", "keno", "cava", "meow"},
+			wantError: nil,
+		},
+		"should echo error": {
+			inPrompt: func(p survey.Prompt, out interface{}, opts ...survey.AskOpt) error {
+				return mockError
+			},
+			inOpts:    []string{"apple", "orange", "banana"},
+			wantError: mockError,
+		},
+		"should return error if input options list is empty": {
+			inOpts:    []string{},
+			wantError: ErrEmptyOptions,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotValue, gotError := tc.inPrompt.MultiSelect(mockMessage, "", tc.inOpts)
+
+			require.Equal(t, tc.wantValue, gotValue)
+			require.Equal(t, tc.wantError, gotError)
+		})
+	}
+}
 func TestPrompt_Confirm(t *testing.T) {
 	mockError := fmt.Errorf("error")
 	mockMessage := "Is devx awesome?"


### PR DESCRIPTION
<!-- Provide summary of changes -->
Adds a multiselect based on survey.MultiSelect to the list of prompter methods. This will be used when selecting which attributes to use for extra LSI sort keys on a DDB table. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
