### PR TITLE
chore(addons): merge cfn templates Transform section

### DIFF
--- a/internal/pkg/addons/testdata/merge/first.yaml
+++ b/internal/pkg/addons/testdata/merge/first.yaml
@@ -26,3 +26,5 @@ Mappings:
 
 Conditions:
     IsProd: !Equals [!Ref Env, prod]
+
+Transform: AWS::Serverless-2016-10-31

--- a/internal/pkg/addons/testdata/merge/second.yaml
+++ b/internal/pkg/addons/testdata/merge/second.yaml
@@ -56,3 +56,10 @@ Conditions:
   ExportOutputs: !Or
     - !Condition IsProd
     - !Condition IsTest
+
+Transform:
+  - Name: 'AWS::Include'
+    Parameters:
+      Location: 's3://MyAmazonS3BucketName/MyFileName.yaml'
+  - 'AWS::Serverless-2016-10-31'
+  - MyMacro

--- a/internal/pkg/addons/testdata/merge/wanted.yaml
+++ b/internal/pkg/addons/testdata/merge/wanted.yaml
@@ -43,3 +43,9 @@ Conditions:
     ExportOutputs: !Or
         - !Condition IsProd
         - !Condition IsTest
+Transform:
+    - AWS::Serverless-2016-10-31
+    - Name: 'AWS::Include'
+      Parameters:
+        Location: 's3://MyAmazonS3BucketName/MyFileName.yaml'
+    - MyMacro


### PR DESCRIPTION
Transform can be either a single element, or a list.
If any addon contains a Transform section, we make the merged template's
Transform field a list by default and start adding all the unique
macros.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
