### PR TITLE
fix(cli): fix svc show log output when no svc found

### DIFF
--- a/internal/pkg/cli/svc_show.go
+++ b/internal/pkg/cli/svc_show.go
@@ -172,7 +172,7 @@ func (o *showSvcOpts) askSvcName() error {
 	}
 
 	if len(svcNames) == 0 {
-		log.Infof("No services found in application %s\n.", color.HighlightUserInput(o.AppName()))
+		log.Infof("No services found in application %s.\n", color.HighlightUserInput(o.AppName()))
 		return nil
 	}
 	if len(svcNames) == 1 {


### PR DESCRIPTION
<!-- Provide summary of changes -->
Quick fix to get rid of the unexpected period at the end of the log output when there's no service found in the app.
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
