### PR TITLE
fix(cfn): change build project name for uniqueness 

### DIFF
--- a/templates/cicd/pipeline_cfn.yml
+++ b/templates/cicd/pipeline_cfn.yml
@@ -182,7 +182,7 @@ Resources:
   BuildTestCommands{{$stage.Name}}:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: BuildTestCommands-{{$stage.Name}}
+      Name: BuildTestCommands-{{$.AppName}}-{{$stage.Name}}
       EncryptionKey: !ImportValue {{$.AppName}}-ArtifactKey
       ServiceRole: !GetAtt BuildProjectRole.Arn
       Artifacts:


### PR DESCRIPTION
Added app name to the build project name so that pipelines within the same account don't end up with the same test command build project name.

Follow-up to https://github.com/aws/amazon-ecs-cli-v2/pull/1033.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
