### PR TITLE
feat(env): associate FARGATE and FARGATE_SPOT cap providers with cluster

### DIFF
--- a/templates/environment/cf.yml
+++ b/templates/environment/cf.yml
@@ -160,6 +160,8 @@ Resources:
 
   Cluster:
     Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders: ['FARGATE', 'FARGATE_SPOT']
 
   PublicLoadBalancerSecurityGroup:
     Condition: CreatePublicLoadBalancer


### PR DESCRIPTION
The FARGATE and FARGATE_SPOT capacity providers are already
created and available to all accounts in Regions supported by AWS
Fargate. With this change we associate these cap providers with the
cluster, this way we can start running tasks on FARGATE_SPOT.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
