### PR TITLE
chore(copilot): Remove separate 'addons' group from help menu

### DIFF
--- a/cmd/copilot/template/template.go
+++ b/cmd/copilot/template/template.go
@@ -12,8 +12,8 @@ import (
 )
 
 // RootUsage is the text template for the root command.
-var RootUsage = fmt.Sprintf("{{h1 \"Commands\"}}{{ $cmds := .Commands }}{{$groups := mkSlice \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" }}{{range $group := $groups }} \n",
-	group.GettingStarted, group.Develop, group.Release, group.Addons, group.Settings) +
+var RootUsage = fmt.Sprintf("{{h1 \"Commands\"}}{{ $cmds := .Commands }}{{$groups := mkSlice \"%s\" \"%s\" \"%s\" \"%s\" }}{{range $group := $groups }} \n",
+	group.GettingStarted, group.Develop, group.Release, group.Settings) +
 	`  {{h2 $group}}{{$groupCmds := (filterCmdsByGroup $cmds $group)}}
 {{- range $j, $cmd := $groupCmds}}{{$lines := split $cmd.Short "\n"}}
 {{- range $i, $line := $lines}}


### PR DESCRIPTION
This command removes the orphaned "Addons" group from the `copilot -h` help menu. 
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
